### PR TITLE
fix: make classifier top logprobs configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ default_provider = "openai"
 # Falls back to the chat model when absent. Must be a non-reasoning model.
 classifier_model = "openai/gpt-4o-mini"
 
+# Alternative-token count for the classifier's fast logprob probe. OpenAI
+# accepts up to 20; some compatible providers have a lower limit (Qwen: 5).
+classifier_top_logprobs = 20
+
 # Gate YOLO mode behind this flag so it can't be entered by accident.
 allow_yolo = true
 
@@ -178,6 +182,7 @@ api_key = "sk-your-key-here"
 |---|---|---|
 | `default_provider` | `"openai"` | Active provider at startup. |
 | `classifier_model` | (chat model) | `provider/model` for the Auto-mode classifier. Must be a **non-reasoning** model (see [Auto mode](#work-modes)). |
+| `classifier_top_logprobs` | `20` | Alternative-token count for the fast classifier probe (`0`–`20`). Lower this for providers with a smaller limit; Qwen accepts at most `5`. |
 | `allow_yolo` | `false` | Whether `/mode yolo` and `Ctrl+T` can reach YOLO mode. |
 | `auto_update_check` | `true` | Check GitHub Releases at startup and show a non-blocking update notice. |
 | `git_coauthor` | `programmer <noreply@programmer.local>` | `Co-Authored-By:` trailer added to the agent's git commits. Use a GitHub-linked email for an avatar; `""` disables. |
@@ -268,6 +273,19 @@ or in config:
 classifier_model = "openai/gpt-4o-mini"
 ```
 
+Some OpenAI-compatible providers limit how many alternatives may be requested.
+For example, Qwen accepts at most 5. Adjust it at runtime:
+
+```
+/classifier logprobs 5
+```
+
+or in config:
+
+```toml
+classifier_top_logprobs = 5
+```
+
 If the classifier model turns out to be a thinking model, all Auto-mode
 calls will be denied with a clear error message. Switch it to a
 non-reasoning model to fix.
@@ -297,7 +315,8 @@ programmer
 | `/mode <manual\|auto\|plan>` | Set work mode (or cycle with `Ctrl+T`) |
 | `/mode yolo` | Enter YOLO mode (requires `allow_yolo = true`) |
 | `/plan <approve\|cancel>` | Approve or cancel the current Plan-mode proposal |
-| `/classifier [provider/model]` | Set/show the Auto-mode classifier model |
+| `/classifier [provider/model]` | Set/show the Auto-mode classifier settings |
+| `/classifier logprobs <0-20>` | Set the fast-probe alternative-token count |
 | `/classifier clear` | Reset classifier to the chat model |
 | `/init` | Create or refresh `PROGRAMMER.md` and project diagnostics |
 | `/thinking [level]` | Set/show reasoning effort for chat and compaction |

--- a/src/app/command_handlers/settings.rs
+++ b/src/app/command_handlers/settings.rs
@@ -484,8 +484,9 @@ fn mode(app: &mut App<'_>, arg: &str) -> CommandOutcome {
 }
 
 fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
-    match arg.trim() {
-        "" => {
+    let parts = arg.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        [] => {
             let current = app
                 .config
                 .classifier_model
@@ -493,19 +494,36 @@ fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
                 .unwrap_or_else(|| format!("{} (chat model)", app.current_model));
             app.conversation_panel.add_info_string(format!(
                 "classifier model: {current}\n\
-                 usage: /classifier <provider/model> to set, \
-                 /classifier clear to reset to the chat model"
+                 classifier top logprobs: {}\n\
+                 usage: /classifier <provider/model> to set the model, \
+                 /classifier logprobs <0-20> to set the fast-probe alternatives, \
+                 /classifier clear to reset to the chat model",
+                app.config.classifier_top_logprobs
             ));
         }
-        "clear" | "default" | "reset" => {
+        ["clear" | "default" | "reset"] => {
             app.config.classifier_model = None;
             app.conversation_panel
                 .add_info_string("classifier model reset — Auto mode now uses the chat model");
             session::persist_config(app);
         }
-        model => match app.provider_manager.resolve(model) {
+        ["logprobs" | "top-logprobs" | "top_logprobs", value] => {
+            match parse_classifier_top_logprobs(value) {
+                Ok(top_logprobs) => {
+                    app.config.classifier_top_logprobs = top_logprobs;
+                    app.conversation_panel
+                        .add_info_string(format!("classifier top logprobs set to: {top_logprobs}"));
+                    session::persist_config(app);
+                }
+                Err(error) => app.conversation_panel.add_error_string(error),
+            }
+        }
+        ["logprobs" | "top-logprobs" | "top_logprobs"] => app
+            .conversation_panel
+            .add_error_string("usage: /classifier logprobs <0-20>".to_string()),
+        [model] => match app.provider_manager.resolve(model) {
             Some(_) => {
-                app.config.classifier_model = Some(model.to_string());
+                app.config.classifier_model = Some((*model).to_string());
                 app.conversation_panel
                     .add_info_string(format!("classifier model set to: {model}"));
                 session::persist_config(app);
@@ -516,8 +534,24 @@ fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
                 ));
             }
         },
+        _ => app.conversation_panel.add_error_string(
+            "usage: /classifier [provider/model | clear | logprobs <0-20>]".to_string(),
+        ),
     }
     CommandOutcome::handled(true)
+}
+
+fn parse_classifier_top_logprobs(value: &str) -> Result<u8, String> {
+    let value = value
+        .parse::<u8>()
+        .map_err(|_| format!("invalid top logprobs '{value}': expected an integer from 0 to 20"))?;
+    if value > crate::consts::MAX_CLASSIFIER_TOP_LOGPROBS {
+        return Err(format!(
+            "invalid top logprobs '{value}': expected an integer from 0 to {}",
+            crate::consts::MAX_CLASSIFIER_TOP_LOGPROBS
+        ));
+    }
+    Ok(value)
 }
 
 fn thinking(app: &mut App<'_>, arg: &str) -> CommandOutcome {
@@ -551,6 +585,15 @@ fn thinking(app: &mut App<'_>, arg: &str) -> CommandOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classifier_top_logprobs_parser_enforces_api_range() {
+        assert_eq!(parse_classifier_top_logprobs("0"), Ok(0));
+        assert_eq!(parse_classifier_top_logprobs("5"), Ok(5));
+        assert_eq!(parse_classifier_top_logprobs("20"), Ok(20));
+        assert!(parse_classifier_top_logprobs("21").is_err());
+        assert!(parse_classifier_top_logprobs("five").is_err());
+    }
 
     #[test]
     fn selection_mode_toggles_and_accepts_explicit_states() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -564,11 +564,13 @@ impl App<'_> {
                     RunnerPolicy::Llm(Box::new(LlmPolicy {
                         client: c_client.clone(),
                         model_name: c_model_name.clone(),
+                        top_logprobs: self.config.classifier_top_logprobs,
                         no_logprobs: self.classifier_no_logprobs.clone(),
                     })),
                     crate::agents::AgentPolicyFactory::Llm(Box::new(LlmPolicy {
                         client: c_client.clone(),
                         model_name: c_model_name,
+                        top_logprobs: self.config.classifier_top_logprobs,
                         no_logprobs: self.classifier_no_logprobs.clone(),
                     })),
                 )

--- a/src/classifier/llm.rs
+++ b/src/classifier/llm.rs
@@ -82,9 +82,19 @@ pub async fn classify_tool_call(
     light_context: &str,
     full_context: &str,
     try_logprobs: bool,
+    top_logprobs: u8,
 ) -> ClassifyOutcome {
     if try_logprobs {
-        match classify_fast(client, model, tool_name, arguments, light_context).await {
+        match classify_fast(
+            client,
+            model,
+            tool_name,
+            arguments,
+            light_context,
+            top_logprobs,
+        )
+        .await
+        {
             Ok(FastResult::Approved) => {
                 return ClassifyOutcome {
                     verdict: Verdict::Allow,
@@ -156,6 +166,14 @@ fn base_request(model: &str, prompt: String) -> CreateResponse {
     }
 }
 
+fn fast_request(model: &str, prompt: String, top_logprobs: u8) -> CreateResponse {
+    let mut request = base_request(model, prompt);
+    request.max_output_tokens = Some(CLASSIFIER_MAX_TOKENS);
+    request.top_logprobs = Some(top_logprobs);
+    request.include = Some(vec![IncludeEnum::MessageOutputTextLogprobs]);
+    request
+}
+
 /// Pull the first assistant text out of a response, with its logprobs.
 fn first_text(
     response: &async_openai::types::responses::Response,
@@ -203,6 +221,7 @@ async fn classify_fast(
     tool_name: &str,
     arguments: &str,
     context: &str,
+    top_logprobs: u8,
 ) -> Result<FastResult, String> {
     let prompt = format!(
         "{}\n\nShould this tool call be auto-approved? \
@@ -210,10 +229,7 @@ async fn classify_fast(
          direction. Answer with exactly one word: yes or no.",
         call_block(context, tool_name, arguments)
     );
-    let mut req = base_request(model, prompt);
-    req.max_output_tokens = Some(CLASSIFIER_MAX_TOKENS);
-    req.top_logprobs = Some(20);
-    req.include = Some(vec![IncludeEnum::MessageOutputTextLogprobs]);
+    let req = fast_request(model, prompt, top_logprobs);
 
     let response = match create_with_retries(client, &req).await {
         Ok(r) => r,
@@ -345,6 +361,14 @@ mod tests {
         let value = serde_json::to_value(request).expect("classifier request should serialize");
 
         assert_eq!(value["reasoning"]["effort"], "none");
+    }
+
+    #[test]
+    fn fast_request_uses_configured_top_logprobs() {
+        let request = fast_request("test-model", "test prompt".to_string(), 5);
+        let value = serde_json::to_value(request).expect("fast request should serialize");
+
+        assert_eq!(value["top_logprobs"], 5);
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,9 +34,9 @@ pub enum Command {
     Providers(String),
     /// `/mode <manual|auto|plan|yolo>` — cycle/set work mode.
     Mode(String),
-    /// `/classifier [provider/model]` — set or show the Auto-mode classifier
-    /// model. Empty argument shows the current setting; "clear"/"default"
-    /// resets it to the chat model.
+    /// `/classifier [provider/model | logprobs <0-20>]` — set or show the
+    /// Auto-mode classifier settings. Empty argument shows the current
+    /// settings; "clear"/"default" resets the model to the chat model.
     Classifier(String),
     /// `/init` — have the agent explore the project, write `PROGRAMMER.md`, and
     /// configure the diagnostics profile.
@@ -99,6 +99,7 @@ enum CommandKind {
 enum CompletionKind {
     None,
     Model,
+    Classifier,
     Fixed(&'static [&'static str]),
     Providers,
     Skill,
@@ -257,11 +258,11 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         kind: CommandKind::Classifier,
         name: "classifier",
         aliases: &[],
-        completion: CompletionKind::Model,
+        completion: CompletionKind::Classifier,
         help: &[HelpEntry {
             order: 2,
-            usage: "/classifier [provider/model]",
-            description: "Set/show the Auto-mode classifier model",
+            usage: "/classifier [provider/model | logprobs <0-20>]",
+            description: "Set/show the Auto-mode classifier settings",
         }],
     },
     CommandSpec {
@@ -615,6 +616,7 @@ impl CompletionEngine {
         match spec.completion {
             CompletionKind::None => None,
             CompletionKind::Model => Self::complete_model(text, cmd, pm),
+            CompletionKind::Classifier => Self::complete_classifier(text, cmd, pm),
             CompletionKind::Fixed(values) => Self::complete_subcommand(text, cmd, values),
             CompletionKind::Providers => Self::complete_providers(text, cmd, pm),
             CompletionKind::Skill => Self::complete_skill(text, cmd, skill_registry),
@@ -871,6 +873,28 @@ impl CompletionEngine {
             .map(|p| format!("{}/", p))
             .collect();
         CompletionState::new(prefix, providers)
+    }
+
+    fn complete_classifier(text: &str, cmd: &str, pm: &ProviderManager) -> Option<CompletionState> {
+        let after_cmd = text[cmd.len()..].trim_start();
+        if after_cmd.split_whitespace().count() > 1 || after_cmd.ends_with(char::is_whitespace) {
+            return None;
+        }
+
+        let mut candidates = ["clear", "logprobs"]
+            .into_iter()
+            .filter(|candidate| candidate.starts_with(after_cmd))
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if let Some(state) = Self::complete_model(text, cmd, pm) {
+            candidates.extend(
+                state
+                    .candidates
+                    .into_iter()
+                    .map(|candidate| candidate.value),
+            );
+        }
+        CompletionState::new(format!("/{cmd} "), candidates)
     }
 
     fn complete_skill(
@@ -1581,8 +1605,8 @@ mod tests {
                 "Set work mode (or cycle with Ctrl+T)",
             ),
             (
-                "/classifier [provider/model]",
-                "Set/show the Auto-mode classifier model",
+                "/classifier [provider/model | logprobs <0-20>]",
+                "Set/show the Auto-mode classifier settings",
             ),
             (
                 "/init",
@@ -1719,6 +1743,19 @@ mod tests {
         let state = CompletionEngine::complete_subcommand("mode p", "mode", values)
             .expect("mode plan completion");
         assert_eq!(state.candidates[0].value, "plan");
+
+        let classifier = COMMAND_SPECS
+            .iter()
+            .find(|spec| spec.name == "classifier")
+            .expect("classifier spec");
+        assert!(matches!(classifier.completion, CompletionKind::Classifier));
+        let state = CompletionEngine::complete_classifier(
+            "classifier log",
+            "classifier",
+            &provider_manager,
+        )
+        .expect("classifier logprobs completion");
+        assert_eq!(state.candidates[0].value, "logprobs");
 
         let plan = COMMAND_SPECS
             .iter()

--- a/src/config/programmer_config.rs
+++ b/src/config/programmer_config.rs
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 pub(crate) const DEFAULT_SECURITY_PROFILE: &str = "default";
@@ -42,6 +43,14 @@ pub struct ProgrammerConfig {
     /// `provider/model` string. When absent, the current chat model is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub classifier_model: Option<String>,
+    /// Number of alternative tokens requested by the Auto-mode classifier's
+    /// fast logprob probe. Some compatible providers accept fewer than the
+    /// OpenAI maximum of 20.
+    #[serde(
+        default = "default_classifier_top_logprobs",
+        deserialize_with = "deserialize_classifier_top_logprobs"
+    )]
+    pub classifier_top_logprobs: u8,
     /// YOLO mode (run every tool call unchecked) is gated behind this flag so
     /// it can't be reached by the normal Ctrl+T cycle or a bare `/mode yolo`.
     #[serde(default)]
@@ -118,6 +127,25 @@ fn default_true() -> bool {
     true
 }
 
+fn default_classifier_top_logprobs() -> u8 {
+    crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS
+}
+
+fn deserialize_classifier_top_logprobs<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = u8::deserialize(deserializer)?;
+    if value <= crate::consts::MAX_CLASSIFIER_TOP_LOGPROBS {
+        Ok(value)
+    } else {
+        Err(D::Error::custom(format!(
+            "classifier_top_logprobs must be between 0 and {}",
+            crate::consts::MAX_CLASSIFIER_TOP_LOGPROBS
+        )))
+    }
+}
+
 impl Default for ProgrammerConfig {
     fn default() -> Self {
         let mut providers = HashMap::new();
@@ -136,6 +164,7 @@ impl Default for ProgrammerConfig {
             default_provider: "openai".to_string(),
             providers,
             classifier_model: None,
+            classifier_top_logprobs: default_classifier_top_logprobs(),
             allow_yolo: false,
             security,
             // Kept empty until normalization so deserialization can distinguish
@@ -287,6 +316,23 @@ mod tests {
         let config = ProgrammerConfig::default();
         let serialized = toml::to_string(&config).expect("serialize");
         assert!(!serialized.contains("mcp_servers"));
+    }
+
+    #[test]
+    fn classifier_top_logprobs_defaults_and_validates() {
+        let defaulted: ProgrammerConfig = toml::from_str("").expect("deserialize defaults");
+        assert_eq!(
+            defaulted.classifier_top_logprobs,
+            crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS
+        );
+
+        let configured: ProgrammerConfig =
+            toml::from_str("classifier_top_logprobs = 5").expect("deserialize configured value");
+        assert_eq!(configured.classifier_top_logprobs, 5);
+
+        let error = toml::from_str::<ProgrammerConfig>("classifier_top_logprobs = 21")
+            .expect_err("reject value above the Responses API maximum");
+        assert!(error.to_string().contains("must be between 0 and 20"));
     }
 
     #[test]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -23,6 +23,14 @@ pub(crate) const MAX_OUTPUT_LENGTH: usize = 8000;
 /// Maximum number of Auto-mode classifier LLM requests in flight at once.
 pub(crate) const MAX_CONCURRENT_CLASSIFICATIONS: usize = 4;
 
+/// Default number of alternative tokens requested for the classifier's
+/// fast-path logprob probe.
+pub(crate) const DEFAULT_CLASSIFIER_TOP_LOGPROBS: u8 = 20;
+
+/// Maximum accepted by the OpenAI Responses API. Compatible providers may
+/// impose a lower limit, which can be selected in the user configuration.
+pub(crate) const MAX_CLASSIFIER_TOP_LOGPROBS: u8 = 20;
+
 /// Maximum number of read-only tool calls executed concurrently within a batch.
 /// Writes are never run concurrently; see `spawn_run`.
 pub(crate) const MAX_CONCURRENT_READ_TOOLS: usize = 8;

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -207,11 +207,13 @@ impl HeadlessAgent {
                     RunnerPolicy::Llm(Box::new(LlmPolicy {
                         client: classifier_client.clone(),
                         model_name: classifier_name.clone(),
+                        top_logprobs: config.classifier_top_logprobs,
                         no_logprobs: no_logprobs.clone(),
                     })),
                     crate::agents::AgentPolicyFactory::Llm(Box::new(LlmPolicy {
                         client: classifier_client,
                         model_name: classifier_name,
+                        top_logprobs: config.classifier_top_logprobs,
                         no_logprobs,
                     })),
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,14 @@ mod tools;
 mod ui;
 mod upgrade;
 
-/// Build the `(client, model)` the MCP server's `auto` mode uses to classify
-/// tool calls: the configured classifier model, else the default model. Returns
-/// `None` when no provider resolves (auto mode then refuses dangerous tools).
+/// Build the `(client, model, top_logprobs)` the MCP server's `auto` mode uses
+/// to classify tool calls: the configured classifier model, else the default
+/// model. Returns `None` when no provider resolves (auto mode then refuses
+/// dangerous tools).
 async fn build_mcp_classifier() -> Option<(
     async_openai::Client<async_openai::config::OpenAIConfig>,
     String,
+    u8,
 )> {
     let (config, _) = load_config().ok()?;
     let pm = crate::providers::ProviderManager::new(&config).await;
@@ -61,7 +63,7 @@ async fn build_mcp_classifier() -> Option<(
         .clone()
         .unwrap_or_else(|| pm.default_classifier_model());
     pm.resolve(&model)
-        .map(|(client, name)| (client.clone(), name))
+        .map(|(client, name)| (client.clone(), name, config.classifier_top_logprobs))
 }
 
 /// Resolved session data ready for the application.

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -77,7 +77,7 @@ pub(crate) struct ServerState {
     /// Current work mode; the console mutates it on Ctrl+T.
     pub(crate) mode: Arc<Mutex<WorkMode>>,
     /// Classifier client for `auto` mode (None → auto refuses dangerous tools).
-    classifier: Option<(Client<OpenAIConfig>, String)>,
+    classifier: Option<(Client<OpenAIConfig>, String, u8)>,
     event_tx: mpsc::UnboundedSender<ConsoleEvent>,
     next_call_id: AtomicU64,
     security: Arc<crate::security::SecurityManager>,
@@ -87,7 +87,7 @@ pub(crate) struct ServerState {
 /// the operator quits the console.
 pub async fn serve(
     mode: WorkMode,
-    classifier: Option<(Client<OpenAIConfig>, String)>,
+    classifier: Option<(Client<OpenAIConfig>, String, u8)>,
     addr: SocketAddr,
     allow_yolo: bool,
     security: Arc<crate::security::SecurityManager>,
@@ -218,11 +218,20 @@ impl ServerState {
     }
 
     async fn llm_approve(&self, name: &str, args: &str) -> Result<(), String> {
-        let Some((client, model)) = &self.classifier else {
+        let Some((client, model, top_logprobs)) = &self.classifier else {
             return Err("auto mode has no classifier model configured; refusing".to_string());
         };
-        let outcome =
-            crate::classifier::classify_tool_call(client, model, name, args, "", "", true).await;
+        let outcome = crate::classifier::classify_tool_call(
+            client,
+            model,
+            name,
+            args,
+            "",
+            "",
+            true,
+            *top_logprobs,
+        )
+        .await;
         match outcome.verdict {
             Verdict::Allow => Ok(()),
             Verdict::Deny { reason } | Verdict::Ask { reason } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -46,7 +46,7 @@ const DEFAULT_PROTOCOL_VERSION: &str = "2024-11-05";
 /// and a counter for server-initiated request ids.
 pub struct McpServer {
     mode: WorkMode,
-    classifier: Option<(Client<OpenAIConfig>, String)>,
+    classifier: Option<(Client<OpenAIConfig>, String, u8)>,
     client_elicitation: bool,
     next_request_id: u64,
     security: std::sync::Arc<crate::security::SecurityManager>,
@@ -66,7 +66,7 @@ enum Gate {
 
 impl McpServer {
     #[cfg(test)]
-    pub fn new(mode: WorkMode, classifier: Option<(Client<OpenAIConfig>, String)>) -> Self {
+    pub fn new(mode: WorkMode, classifier: Option<(Client<OpenAIConfig>, String, u8)>) -> Self {
         let security = crate::security::SecurityManager::for_current_dir(Default::default())
             .expect("the current directory should support the default security policy");
         Self::with_security(mode, classifier, std::sync::Arc::new(security))
@@ -74,7 +74,7 @@ impl McpServer {
 
     pub(crate) fn with_security(
         mode: WorkMode,
-        classifier: Option<(Client<OpenAIConfig>, String)>,
+        classifier: Option<(Client<OpenAIConfig>, String, u8)>,
         security: std::sync::Arc<crate::security::SecurityManager>,
     ) -> Self {
         McpServer {
@@ -238,15 +238,24 @@ impl McpServer {
     /// Auto mode: let the LLM classifier decide. Empty context — the server has
     /// no conversation, so the call is judged on its own merits.
     async fn llm_approve(&self, name: &str, args: &str) -> Result<(), String> {
-        let Some((client, model)) = &self.classifier else {
+        let Some((client, model, top_logprobs)) = &self.classifier else {
             return Err(
                 "auto mode has no classifier model configured (set classifier_model or a \
                  default model); refusing"
                     .to_string(),
             );
         };
-        let outcome =
-            crate::classifier::classify_tool_call(client, model, name, args, "", "", true).await;
+        let outcome = crate::classifier::classify_tool_call(
+            client,
+            model,
+            name,
+            args,
+            "",
+            "",
+            true,
+            *top_logprobs,
+        )
+        .await;
         match outcome.verdict {
             Verdict::Allow => Ok(()),
             Verdict::Deny { reason } | Verdict::Ask { reason } => {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -347,6 +347,7 @@ mod tests {
             default_provider: "offline".to_string(),
             providers,
             classifier_model: None,
+            classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),

--- a/src/runner/classify.rs
+++ b/src/runner/classify.rs
@@ -117,6 +117,7 @@ pub(crate) fn classify_sync(
 pub(crate) async fn classify_llm(
     client: &Client<OpenAIConfig>,
     model_name: &str,
+    top_logprobs: u8,
     no_logprobs: &Arc<Mutex<HashSet<String>>>,
     light_context: &str,
     full_context: &str,
@@ -142,6 +143,7 @@ pub(crate) async fn classify_llm(
                 light_context,
                 full_context,
                 try_logprobs,
+                top_logprobs,
             )
             .await;
             if outcome.logprobs_missing {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -52,6 +52,7 @@ use std::sync::{Arc, Mutex};
 pub(crate) struct LlmPolicy {
     pub client: Client<OpenAIConfig>,
     pub model_name: String,
+    pub top_logprobs: u8,
     pub no_logprobs: Arc<Mutex<HashSet<String>>>,
 }
 
@@ -475,6 +476,7 @@ impl TurnRunner {
                 classify::classify_llm(
                     &p.client,
                     &p.model_name,
+                    p.top_logprobs,
                     &p.no_logprobs,
                     &light,
                     &full,

--- a/src/ui/components/provider_panel/mod.rs
+++ b/src/ui/components/provider_panel/mod.rs
@@ -903,6 +903,7 @@ mod tests {
             default_provider: names.first().unwrap_or(&"").to_string(),
             providers,
             classifier_model: None,
+            classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),


### PR DESCRIPTION
## Summary

- add a persisted `classifier_top_logprobs` setting with a default of 20 and validation for the Responses API range (0–20)
- add `/classifier logprobs <0-20>` plus command completion and status output
- pass the configured value through TUI, headless, child-agent, and MCP classifier paths
- document the Qwen maximum of 5

## Root cause

The fast classifier probe always sent `top_logprobs: 20`. Qwen-compatible endpoints reject values above 5, so Auto mode failed with a 400 response before classification could run.

## Impact

Users can keep the higher default for providers that support it or set `classifier_top_logprobs = 5` (or run `/classifier logprobs 5`) for Qwen.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --bin programmer` (449 passed)
- targeted configuration, request serialization, and command completion tests
- `git diff --check`

The existing Windows-only `cli_diagnostics` integration fixture still fails because it invokes the Unix `printf` command; this is unrelated to the classifier changes.

Fixes #14