### PR TITLE
release: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.0"
+version = "0.2.1"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+# programmer v0.2.1
+
+v0.2.1 makes the Auto-mode classifier compatible with providers that impose a
+smaller `top_logprobs` limit than OpenAI.
+
+## Fixes
+
+- Added the persisted `classifier_top_logprobs` setting with validation for the
+  Responses API range of 0–20.
+- Added `/classifier logprobs <0-20>` to inspect and change the setting without
+  editing `config.toml` manually.
+- Passed the configured value through TUI, headless, child-agent, and MCP
+  classifier paths.
+- Documented that Qwen endpoints accept at most 5 top logprobs.
+
+**Full changelog:** https://github.com/huangdihd/programmer/compare/v0.1.1...v0.2.1
+
+---
+
 # programmer v0.2.0
 
 v0.2.0 is the largest Programmer release so far. It turns the original coding


### PR DESCRIPTION
## Summary

- bump the crate and lockfile version from 0.2.0 to 0.2.1
- add v0.2.1 release notes for the configurable classifier `top_logprobs` fix

## Validation

- `cargo metadata --no-deps --format-version 1` reports `programmer 0.2.1`
- `cargo fmt --all -- --check`
- `git diff --check`

This PR contains the release metadata commit that was pushed just after #17 was merged. It must land on `main` before the v0.2.1 release workflow is dispatched.