### PR TITLE
release: programmer v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.1"
+version = "0.2.2"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/PROGRAMMER.md
+++ b/PROGRAMMER.md
@@ -13,6 +13,8 @@ The binary is a single crate at the repo root.
 Key features beyond the chat loop:
 - **Multi-provider**: add/edit/delete/switch API backends at runtime.
 - **Multi-session**: UUID-keyed JSON persistence in `~/.config/programmer/sessions/`.
+- **Rewind checkpoints**: prompt-level conversation checkpoints plus content-addressed snapshots for built-in file edits.
+- **Context compaction**: manual and provider-usage-triggered background summaries with session overrides.
 - **Auto-mode classifier**: per-mode LLM classifier that approves/denies/defers tool calls.
 - **MCP (Model Context Protocol)**: connect to external MCP servers (stdio + HTTP);
   their tools are advertised to the model as `mcp__<server>__<tool>`.
@@ -92,6 +94,7 @@ src/
 │   ├── stream.rs             #   API stream management + retry
 │   └── tools.rs              #   Tool-call routing (execute + approval queue)
 │
+├── checkpoint.rs             # Per-session rewind manifests, blobs, conflict-safe restore
 ├── classifier/               # Auto-mode tool-call classification
 │   ├── mod.rs                #   WorkMode enum, Verdict, Classifier trait
 │   └── llm.rs                #   Light (logprob probe) + Full (reasoned) classifier calls

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ classifier_model = "openai/gpt-4o-mini"
 # accepts up to 20; some compatible providers have a lower limit (Qwen: 5).
 classifier_top_logprobs = 20
 
+# Model used for manual and automatic context compaction. Falls back to the
+# current chat model when absent.
+compact_model = "openai/gpt-4o-mini"
+
+# Automatically compact after a response reports at least this many input
+# tokens. This uses provider-reported usage (not an estimate); 0 disables it.
+auto_compact_tokens = 100000
+
+# Keep this many recent complete turns verbatim after compaction.
+compact_keep_recent_turns = 2
+
 # Gate YOLO mode behind this flag so it can't be entered by accident.
 allow_yolo = true
 
@@ -183,6 +194,9 @@ api_key = "sk-your-key-here"
 | `default_provider` | `"openai"` | Active provider at startup. |
 | `classifier_model` | (chat model) | `provider/model` for the Auto-mode classifier. Must be a **non-reasoning** model (see [Auto mode](#work-modes)). |
 | `classifier_top_logprobs` | `20` | Alternative-token count for the fast classifier probe (`0`–`20`). Lower this for providers with a smaller limit; Qwen accepts at most `5`. |
+| `compact_model` | (chat model) | `provider/model` used for manual and automatic context compaction. |
+| `auto_compact_tokens` | `100000` | Provider-reported input-token threshold for seamless background compaction. `0` disables it. Providers that do not report usage do not trigger it. |
+| `compact_keep_recent_turns` | `2` | Number of recent complete turns kept verbatim when context is compacted. |
 | `allow_yolo` | `false` | Whether `/mode yolo` and `Ctrl+T` can reach YOLO mode. |
 | `auto_update_check` | `true` | Check GitHub Releases at startup and show a non-blocking update notice. |
 | `git_coauthor` | `programmer <noreply@programmer.local>` | `Co-Authored-By:` trailer added to the agent's git commits. Use a GitHub-linked email for an avatar; `""` disables. |
@@ -301,6 +315,7 @@ programmer
 | Key | Action |
 |---|---|
 | `Enter` | Send message |
+| `Esc` | Cancel the active request; before any model output, restore the original draft to the input |
 | `Ctrl+T` | Cycle work mode (Manual → Auto → Plan → optional YOLO) |
 | `Ctrl+C` / `Ctrl+Q` twice | Quit |
 | `Ctrl+V` | Paste an image from the clipboard |
@@ -315,12 +330,21 @@ programmer
 | `/mode <manual\|auto\|plan>` | Set work mode (or cycle with `Ctrl+T`) |
 | `/mode yolo` | Enter YOLO mode (requires `allow_yolo = true`) |
 | `/plan <approve\|cancel>` | Approve or cancel the current Plan-mode proposal |
-| `/classifier [provider/model]` | Set/show the Auto-mode classifier settings |
-| `/classifier logprobs <0-20>` | Set the fast-probe alternative-token count |
-| `/classifier clear` | Reset classifier to the chat model |
+| `/classifier [show]` | Show the effective Auto-mode classifier settings and their source |
+| `/classifier <provider/model>` | Override the classifier model for this session |
+| `/classifier current` | Force this session to follow the current chat model |
+| `/classifier default` | Clear the session override and inherit the global setting |
+| `/classifier logprobs <0-20\|default>` | Override or inherit the fast-probe alternative-token count for this session |
 | `/init` | Create or refresh `PROGRAMMER.md` and project diagnostics |
+| `/diagnostics manage` | Open the project diagnostics checker management panel |
+| `/diagnostics update` | Re-run configured checkers and refresh the sidebar diagnostics |
 | `/thinking [level]` | Set/show reasoning effort for chat and compaction |
-| `/compact [provider/model]` | Summarize older history to reduce context usage |
+| `/compact` | Manually compact older complete turns with the effective compact model |
+| `/compact show` | Show compact model, threshold, latest reported usage, and background status |
+| `/compact set model <provider/model\|current\|default>` | Set the compact model for this session |
+| `/compact set tokens <number\|off\|default>` | Set, disable, or inherit automatic compaction for this session |
+| `/compact set keep <number\|default>` | Set or inherit recent-turn retention for this session |
+| `/rewind` | Restore conversation and/or built-in `write_file`/`edit_file` changes to a previous user prompt |
 | `/vision <on\|off>` | Enable/disable `@image` attachments for this session |
 | `/select [on\|off]` | Toggle native terminal text selection and copying |
 | `/permission` `/sandbox` | Show sandbox, file protection, and permission status |
@@ -353,7 +377,29 @@ Open with `/providers manage` or the `--providers` flag.
 | `e` | Edit selected provider |
 | `d` | Delete selected provider (confirm with `y`) |
 | `m` | Browse model list of selected provider |
+| `Enter` (model list) | Choose the model's global chat/classifier/compact role |
+| `g` | Edit global classifier logprobs and automatic-compaction settings |
 | `q` / `Esc` | Close panel |
+
+Slash commands change only the current session. Changes made in this panel are
+global and persisted to `config.toml`. Effective model precedence is session
+override → global role → current chat model.
+
+### Rewind and automatic compaction
+
+`/rewind` creates a checkpoint for every user prompt that actually starts. It
+can restore the conversation, built-in file edits, or both. File rewind tracks
+only successful `write_file` and `edit_file` calls (including sub-agents); shell
+commands, MCP tools, IDE edits, and remote side effects are outside its scope.
+If a tracked file no longer has the content Programmer last wrote, restore
+stops before changing any file. Before changing files, Programmer creates a
+recovery checkpoint so its file changes can be undone from the same panel.
+
+Automatic compaction observes the real `input_tokens` returned after every API
+response. For tool-using responses it waits until all call outputs are recorded,
+then summarizes a stable prefix in the background. Input stays usable and new
+messages remain outside that prefix. A stale summary is discarded after
+`/clear`, `/new`, or `/rewind`.
 
 **In model browser (`m`):**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+# programmer v0.2.2
+
+v0.2.2 adds recoverable conversation navigation, automatic context management,
+and in-app diagnostics configuration.
+
+## Highlights
+
+- Added `/rewind` checkpoints with independent code/conversation restore modes
+  and conversation forking that preserves the source session.
+- Restored an unsent prompt to the input editor when a request is cancelled
+  before the model begins responding.
+- Added manual and automatic context compaction with configurable global and
+  session-level models, token thresholds, and recent-turn retention.
+- Added `/diagnostics manage` and `/diagnostics update` for editing and
+  refreshing diagnostics without leaving the TUI.
+- Added global classifier and compaction model controls to provider management,
+  plus model search and modal keyboard-routing fixes.
+- Made `classifier_top_logprobs` a single global setting; `/classifier
+  logprobs` now updates and persists that value directly.
+
+## Fixes
+
+- Fixed Escape in management panels cancelling the active conversation.
+- Fixed provider model filtering swallowing characters used by Vim-style
+  navigation and improved model-list colors and refresh feedback.
+
+**Full changelog:** https://github.com/huangdihd/programmer/compare/v0.2.1...v0.2.2
+
+---
+
 # programmer v0.2.1
 
 v0.2.1 makes the Auto-mode classifier compatible with providers that impose a

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -372,6 +372,7 @@ pub(crate) struct AgentRuntime {
     pub(crate) skill_registry: crate::skills::SkillRegistry,
     pub(crate) skill_prompt: Option<String>,
     pub(crate) approval_label: String,
+    pub(crate) checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
 }
 
 impl AgentRuntime {
@@ -408,11 +409,14 @@ impl AgentRuntime {
         };
 
         let mut providers: Vec<Arc<dyn ToolProvider>> = vec![
-            Arc::new(LocalToolProvider::new_scoped(
-                self.todos.clone(),
-                self.security.clone(),
-                file_scope,
-            )),
+            Arc::new(
+                LocalToolProvider::new_scoped(
+                    self.todos.clone(),
+                    self.security.clone(),
+                    file_scope,
+                )
+                .with_checkpoint(self.checkpoint.clone()),
+            ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];
         if let Some(mcp) = &self.mcp_manager {

--- a/src/app/command_handlers/integrations.rs
+++ b/src/app/command_handlers/integrations.rs
@@ -8,6 +8,7 @@
 use super::CommandOutcome;
 use crate::app::App;
 use crate::commands::Command;
+use crate::ui::components::diagnostics_panel::DiagnosticsPanel;
 use crate::ui::components::mcp_panel::McpPanel;
 use crate::ui::components::provider_panel::ProviderPanel;
 use crate::ui::components::skills_panel::SkillsPanel;
@@ -19,9 +20,26 @@ pub(in crate::app) fn execute(app: &mut App<'_>, command: Command) -> CommandOut
         Command::Providers(arg) => providers(app, &arg),
         Command::Skill(arg) => skill(app, &arg),
         Command::Mcp(arg) => mcp(app, &arg),
+        Command::Diagnostics(arg) => diagnostics(app, &arg),
         _ => unreachable!("integrations handler received a command from another domain"),
     }
     CommandOutcome::handled(true)
+}
+
+fn diagnostics(app: &mut App<'_>, arg: &str) {
+    match arg.trim() {
+        "manage" => match DiagnosticsPanel::load() {
+            Ok(panel) => app.diagnostics_panel = Some(panel),
+            Err(error) => app
+                .conversation_panel
+                .add_error_string(format!("could not open diagnostics profile: {error}")),
+        },
+        "update" | "refresh" => crate::app::diagnostics::start_update(app, true),
+        _ => app.conversation_panel.add_info_string(
+            "usage: /diagnostics manage — edit .programmer/diagnostics.toml\n\
+             \u{20}      /diagnostics update — re-run checkers and refresh current findings",
+        ),
+    }
 }
 
 fn providers(app: &mut App<'_>, arg: &str) {

--- a/src/app/command_handlers/session.rs
+++ b/src/app/command_handlers/session.rs
@@ -153,7 +153,6 @@ fn new(app: &mut App<'_>) -> CommandOutcome {
     app.sync_todos_to_store();
     app.vision_enabled = false;
     app.session.classifier_model_override = crate::session::ModelOverride::Inherit;
-    app.session.classifier_top_logprobs_override = None;
     app.session.compact_model_override = crate::session::ModelOverride::Inherit;
     app.session.auto_compact_override = crate::session::AutoCompactOverride::Inherit;
     app.session.compact_keep_recent_turns_override = None;

--- a/src/app/command_handlers/session.rs
+++ b/src/app/command_handlers/session.rs
@@ -21,6 +21,7 @@ pub(in crate::app) fn execute(app: &mut App<'_>, command: Command) -> CommandOut
         Command::New => new(app),
         Command::Session => show_session(app),
         Command::Usage => usage(app),
+        Command::Rewind => rewind(app),
         Command::Todo => {
             app.sync_todos_from_store();
             app.todo_panel = Some(TodoPanel::new(app.todo_list.clone()));
@@ -33,6 +34,28 @@ pub(in crate::app) fn execute(app: &mut App<'_>, command: Command) -> CommandOut
         Command::Help => help(app),
         _ => unreachable!("session handler received a command from another domain"),
     }
+}
+
+fn rewind(app: &mut App<'_>) -> CommandOutcome {
+    if app.cancel.active_id.is_some() {
+        app.conversation_panel
+            .add_warning_string("cannot rewind while a turn is in flight");
+        return CommandOutcome::handled(false);
+    }
+    let Some(store) = &app.checkpoint_store else {
+        app.conversation_panel
+            .add_warning_string("rewind checkpoints are unavailable");
+        return CommandOutcome::handled(false);
+    };
+    let panel =
+        crate::ui::components::rewind_panel::RewindPanel::new(store.lock().unwrap().checkpoints());
+    if panel.is_empty() {
+        app.conversation_panel
+            .add_info_string("no user prompt checkpoints to rewind to");
+    } else {
+        app.rewind_panel = Some(panel);
+    }
+    CommandOutcome::handled(false)
 }
 
 fn show_session(app: &mut App<'_>) -> CommandOutcome {
@@ -98,6 +121,7 @@ fn format_usage(summary: crate::conversation::UsageSummary) -> String {
 }
 
 fn clear(app: &mut App<'_>) -> CommandOutcome {
+    commands::invalidate_auto_compaction(app);
     app.conversation_panel.clear_messages();
     diagnostics::reset_diagnostics_state(app);
     app.pending_images.clear();
@@ -108,6 +132,7 @@ fn clear(app: &mut App<'_>) -> CommandOutcome {
 }
 
 fn new(app: &mut App<'_>) -> CommandOutcome {
+    commands::invalidate_auto_compaction(app);
     session::save_session(app);
     app.conversation_panel.clear_messages();
     diagnostics::reset_diagnostics_state(app);
@@ -121,9 +146,17 @@ fn new(app: &mut App<'_>) -> CommandOutcome {
         let new_session = manager.create();
         app.session.uuid = new_session.uuid;
     }
+    app.checkpoint_store = crate::checkpoint::CheckpointStore::for_session(&app.session.uuid)
+        .map(|store| std::sync::Arc::new(std::sync::Mutex::new(store)));
+    app.current_checkpoint_id = None;
     app.todo_list = crate::todos::TodoList::default();
     app.sync_todos_to_store();
     app.vision_enabled = false;
+    app.session.classifier_model_override = crate::session::ModelOverride::Inherit;
+    app.session.classifier_top_logprobs_override = None;
+    app.session.compact_model_override = crate::session::ModelOverride::Inherit;
+    app.session.auto_compact_override = crate::session::AutoCompactOverride::Inherit;
+    app.session.compact_keep_recent_turns_override = None;
 
     let mut message = "Started a new session. Previous session saved.".to_string();
     if killed > 0 {

--- a/src/app/command_handlers/settings.rs
+++ b/src/app/command_handlers/settings.rs
@@ -486,56 +486,73 @@ fn mode(app: &mut App<'_>, arg: &str) -> CommandOutcome {
 fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
     let parts = arg.split_whitespace().collect::<Vec<_>>();
     match parts.as_slice() {
-        [] => {
-            let current = app
-                .config
-                .classifier_model
-                .clone()
-                .unwrap_or_else(|| format!("{} (chat model)", app.current_model));
+        [] | ["show"] => {
+            let source = match &app.session.classifier_model_override {
+                crate::session::ModelOverride::Inherit => "global",
+                crate::session::ModelOverride::Current => "session: current chat model",
+                crate::session::ModelOverride::Model(_) => "session",
+            };
+            let logprobs_source = if app.session.classifier_top_logprobs_override.is_some() {
+                "session"
+            } else {
+                "global"
+            };
             app.conversation_panel.add_info_string(format!(
-                "classifier model: {current}\n\
-                 classifier top logprobs: {}\n\
-                 usage: /classifier <provider/model> to set the model, \
-                 /classifier logprobs <0-20> to set the fast-probe alternatives, \
-                 /classifier clear to reset to the chat model",
-                app.config.classifier_top_logprobs
+                "classifier model: {} ({source})\n\
+                 classifier top logprobs: {} ({logprobs_source})\n\
+                 usage: /classifier <provider/model|current|default>, \
+                 /classifier logprobs <0-20|default>",
+                app.effective_classifier_model(),
+                app.effective_classifier_top_logprobs()
             ));
         }
         ["clear" | "default" | "reset"] => {
-            app.config.classifier_model = None;
+            app.session.classifier_model_override = crate::session::ModelOverride::Inherit;
             app.conversation_panel
-                .add_info_string("classifier model reset — Auto mode now uses the chat model");
-            session::persist_config(app);
+                .add_info_string("classifier model now inherits the global setting");
+            session::mark_dirty(app);
+        }
+        ["current"] => {
+            app.session.classifier_model_override = crate::session::ModelOverride::Current;
+            app.conversation_panel
+                .add_info_string("classifier model set to the current chat model for this session");
+            session::mark_dirty(app);
+        }
+        ["logprobs" | "top-logprobs" | "top_logprobs", "default"] => {
+            app.session.classifier_top_logprobs_override = None;
+            app.conversation_panel
+                .add_info_string("classifier top logprobs now inherits the global setting");
+            session::mark_dirty(app);
         }
         ["logprobs" | "top-logprobs" | "top_logprobs", value] => {
             match parse_classifier_top_logprobs(value) {
                 Ok(top_logprobs) => {
-                    app.config.classifier_top_logprobs = top_logprobs;
-                    app.conversation_panel
-                        .add_info_string(format!("classifier top logprobs set to: {top_logprobs}"));
-                    session::persist_config(app);
+                    app.session.classifier_top_logprobs_override = Some(top_logprobs);
+                    app.conversation_panel.add_info_string(format!(
+                        "classifier top logprobs set to {top_logprobs} for this session"
+                    ));
+                    session::mark_dirty(app);
                 }
                 Err(error) => app.conversation_panel.add_error_string(error),
             }
         }
         ["logprobs" | "top-logprobs" | "top_logprobs"] => app
             .conversation_panel
-            .add_error_string("usage: /classifier logprobs <0-20>".to_string()),
+            .add_error_string("usage: /classifier logprobs <0-20|default>".to_string()),
         [model] => match app.provider_manager.resolve(model) {
             Some(_) => {
-                app.config.classifier_model = Some((*model).to_string());
+                app.session.classifier_model_override =
+                    crate::session::ModelOverride::Model((*model).to_string());
                 app.conversation_panel
-                    .add_info_string(format!("classifier model set to: {model}"));
-                session::persist_config(app);
+                    .add_info_string(format!("classifier model set to {model} for this session"));
+                session::mark_dirty(app);
             }
-            None => {
-                app.conversation_panel.add_error_string(format!(
-                    "unknown provider/model: {model} — use /providers to list available"
-                ));
-            }
+            None => app.conversation_panel.add_error_string(format!(
+                "unknown provider/model: {model} — use /providers to list available"
+            )),
         },
         _ => app.conversation_panel.add_error_string(
-            "usage: /classifier [provider/model | clear | logprobs <0-20>]".to_string(),
+            "usage: /classifier [show | provider/model | current | default | logprobs <0-20|default>]",
         ),
     }
     CommandOutcome::handled(true)

--- a/src/app/command_handlers/settings.rs
+++ b/src/app/command_handlers/settings.rs
@@ -492,18 +492,13 @@ fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
                 crate::session::ModelOverride::Current => "session: current chat model",
                 crate::session::ModelOverride::Model(_) => "session",
             };
-            let logprobs_source = if app.session.classifier_top_logprobs_override.is_some() {
-                "session"
-            } else {
-                "global"
-            };
             app.conversation_panel.add_info_string(format!(
                 "classifier model: {} ({source})\n\
-                 classifier top logprobs: {} ({logprobs_source})\n\
+                 classifier top logprobs: {} (global)\n\
                  usage: /classifier <provider/model|current|default>, \
                  /classifier logprobs <0-20|default>",
                 app.effective_classifier_model(),
-                app.effective_classifier_top_logprobs()
+                app.config.classifier_top_logprobs
             ));
         }
         ["clear" | "default" | "reset"] => {
@@ -519,19 +514,24 @@ fn classifier(app: &mut App<'_>, arg: &str) -> CommandOutcome {
             session::mark_dirty(app);
         }
         ["logprobs" | "top-logprobs" | "top_logprobs", "default"] => {
-            app.session.classifier_top_logprobs_override = None;
-            app.conversation_panel
-                .add_info_string("classifier top logprobs now inherits the global setting");
-            session::mark_dirty(app);
+            app.config.classifier_top_logprobs =
+                crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS;
+            app.classifier_no_logprobs.lock().unwrap().clear();
+            session::persist_config(app);
+            app.conversation_panel.add_info_string(format!(
+                "global classifier top logprobs reset to {}",
+                app.config.classifier_top_logprobs
+            ));
         }
         ["logprobs" | "top-logprobs" | "top_logprobs", value] => {
             match parse_classifier_top_logprobs(value) {
                 Ok(top_logprobs) => {
-                    app.session.classifier_top_logprobs_override = Some(top_logprobs);
+                    app.config.classifier_top_logprobs = top_logprobs;
+                    app.classifier_no_logprobs.lock().unwrap().clear();
+                    session::persist_config(app);
                     app.conversation_panel.add_info_string(format!(
-                        "classifier top logprobs set to {top_logprobs} for this session"
+                        "global classifier top logprobs set to {top_logprobs}"
                     ));
-                    session::mark_dirty(app);
                 }
                 Err(error) => app.conversation_panel.add_error_string(error),
             }

--- a/src/app/command_handlers/workflow.rs
+++ b/src/app/command_handlers/workflow.rs
@@ -50,9 +50,115 @@ fn init(app: &mut App<'_>) -> CommandOutcome {
 }
 
 fn compact(app: &mut App<'_>, arg: &str) -> CommandOutcome {
-    // Completion may append a display name; only the first token is the model.
-    let model = arg.split_whitespace().next().unwrap_or("");
-    commands::start_compact(app, model);
+    let parts = arg.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        [] => commands::start_compact(app),
+        ["show"] => {
+            let model_source = match &app.session.compact_model_override {
+                crate::session::ModelOverride::Inherit => "global",
+                crate::session::ModelOverride::Current => "session: current chat model",
+                crate::session::ModelOverride::Model(_) => "session",
+            };
+            let tokens = app
+                .effective_auto_compact_tokens()
+                .map_or_else(|| "off".to_string(), |value| value.to_string());
+            let tokens_source = match app.session.auto_compact_override {
+                crate::session::AutoCompactOverride::Inherit => "global",
+                _ => "session",
+            };
+            let keep_source = if app.session.compact_keep_recent_turns_override.is_some() {
+                "session"
+            } else {
+                "global"
+            };
+            let reported = app.auto_compact.last_input_tokens.map_or_else(
+                || "unavailable (provider has not reported usage)".to_string(),
+                |tokens| tokens.to_string(),
+            );
+            let status = if app.auto_compact.active_id.is_some() {
+                "running in background"
+            } else {
+                "idle"
+            };
+            app.conversation_panel.add_info_string(format!(
+                "compact model: {} ({model_source})\n\
+                 auto compact input tokens: {tokens} ({tokens_source})\n\
+                 recent turns kept: {} ({keep_source})\n\
+                 last reported input tokens: {reported}\n\
+                 auto compact status: {status}",
+                app.effective_compact_model(),
+                app.effective_compact_keep_recent_turns()
+            ));
+        }
+        ["set", "model", "default"] => {
+            app.session.compact_model_override = crate::session::ModelOverride::Inherit;
+            app.conversation_panel
+                .add_info_string("compact model now inherits the global setting");
+            session::mark_dirty(app);
+        }
+        ["set", "model", "current"] => {
+            app.session.compact_model_override = crate::session::ModelOverride::Current;
+            app.conversation_panel
+                .add_info_string("compact model set to the current chat model for this session");
+            session::mark_dirty(app);
+        }
+        ["set", "model", model] if app.provider_manager.resolve(model).is_some() => {
+            app.session.compact_model_override =
+                crate::session::ModelOverride::Model((*model).to_string());
+            app.conversation_panel
+                .add_info_string(format!("compact model set to {model} for this session"));
+            session::mark_dirty(app);
+        }
+        ["set", "model", model] => app
+            .conversation_panel
+            .add_error_string(format!("unknown provider/model: {model}")),
+        ["set", "tokens", "default"] => {
+            app.session.auto_compact_override = crate::session::AutoCompactOverride::Inherit;
+            app.conversation_panel
+                .add_info_string("auto compact threshold now inherits the global setting");
+            session::mark_dirty(app);
+        }
+        ["set", "tokens", "off"] => {
+            app.session.auto_compact_override = crate::session::AutoCompactOverride::Disabled;
+            app.conversation_panel
+                .add_info_string("automatic context compaction disabled for this session");
+            session::mark_dirty(app);
+        }
+        ["set", "tokens", value] => match value.parse::<u32>() {
+            Ok(tokens) if tokens > 0 => {
+                app.session.auto_compact_override =
+                    crate::session::AutoCompactOverride::Tokens(tokens);
+                app.conversation_panel.add_info_string(format!(
+                    "automatic context compaction threshold set to {tokens} input tokens for this session"
+                ));
+                session::mark_dirty(app);
+            }
+            _ => app
+                .conversation_panel
+                .add_error_string("compact token threshold must be a positive integer"),
+        },
+        ["set", "keep", "default"] => {
+            app.session.compact_keep_recent_turns_override = None;
+            app.conversation_panel
+                .add_info_string("recent-turn retention now inherits the global setting");
+            session::mark_dirty(app);
+        }
+        ["set", "keep", value] => match value.parse::<usize>() {
+            Ok(keep) => {
+                app.session.compact_keep_recent_turns_override = Some(keep);
+                app.conversation_panel.add_info_string(format!(
+                    "compaction will keep {keep} recent complete turn(s) for this session"
+                ));
+                session::mark_dirty(app);
+            }
+            Err(_) => app
+                .conversation_panel
+                .add_error_string("compact keep value must be a non-negative integer"),
+        },
+        _ => app.conversation_panel.add_error_string(
+            "usage: /compact [show | set model <provider/model|current|default> | set tokens <positive integer|off|default> | set keep <non-negative integer|default>]",
+        ),
+    }
     CommandOutcome::handled(false)
 }
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -56,6 +56,8 @@ pub(crate) async fn send_message(app: &mut App<'_>) {
     if typed.is_empty() {
         return;
     }
+    let draft = app.input_panel.draft_snapshot();
+    let history_text = typed.clone();
     let pasted_images = app.input_panel.take_images();
     // History keeps the compact `@path` form; the model receives a path-only
     // reference for regular files or a stored image for image paths. The
@@ -80,7 +82,14 @@ pub(crate) async fn send_message(app: &mut App<'_>) {
             "omitted {omitted} image(s): attachment count or total size exceeds the per-message limit"
         ));
     }
-    start_request_with_images(app, expanded.text, images).await;
+    start_request_as_with_images(
+        app,
+        expanded.text,
+        InputRole::User,
+        images,
+        Some((draft, history_text)),
+    )
+    .await;
 }
 
 pub(crate) async fn start_request_with_images(
@@ -88,13 +97,13 @@ pub(crate) async fn start_request_with_images(
     text: String,
     images: Vec<async_openai::types::responses::InputImageContent>,
 ) {
-    start_request_as_with_images(app, text, InputRole::User, images).await;
+    start_request_as_with_images(app, text, InputRole::User, images, None).await;
 }
 
 /// Start a turn from a message with the given role. `User` is a normal user
 /// message; `Developer` carries a hidden instruction (like `/init`).
 pub(crate) async fn start_request_as(app: &mut App<'_>, text: String, role: InputRole) {
-    start_request_as_with_images(app, text, role, Vec::new()).await;
+    start_request_as_with_images(app, text, role, Vec::new(), None).await;
 }
 
 async fn start_request_as_with_images(
@@ -102,6 +111,10 @@ async fn start_request_as_with_images(
     text: String,
     role: InputRole,
     images: Vec<async_openai::types::responses::InputImageContent>,
+    original_draft: Option<(
+        crate::ui::components::input_panel::input_panel::InputDraft,
+        String,
+    )>,
 ) {
     // active_id is the lifecycle authority. UI phases are presentation state
     // and can briefly lag the runner; they must never decide whether two turns
@@ -116,7 +129,7 @@ async fn start_request_as_with_images(
         return;
     }
 
-    start_ready_request(app, vec![(text, role, images)]).await;
+    start_ready_request(app, vec![(text, role, images)], original_draft).await;
 }
 
 /// Start one turn containing any completed task/sub-agent updates and an
@@ -149,7 +162,7 @@ pub(crate) async fn start_runtime_update_request(
     if let Some((text, images)) = pending_user {
         inputs.push((text, InputRole::User, images));
     }
-    start_ready_request(app, inputs).await;
+    start_ready_request(app, inputs, None).await;
 }
 
 fn format_agent_updates(agents: &[crate::agents::AgentSnapshot]) -> String {
@@ -187,8 +200,31 @@ fn format_agent_updates(agents: &[crate::agents::AgentSnapshot]) -> String {
 async fn start_ready_request(
     app: &mut App<'_>,
     inputs: Vec<(String, InputRole, Vec<InputImageContent>)>,
+    original_draft: Option<(
+        crate::ui::components::input_panel::input_panel::InputDraft,
+        String,
+    )>,
 ) {
     debug_assert!(app.cancel.active_id.is_none());
+    let conversation_cutoff = app.conversation_panel.items_snapshot().len();
+    let user_prompt = inputs
+        .iter()
+        .find(|(_, role, _)| matches!(role, InputRole::User))
+        .map(|(text, _, _)| text.clone());
+    app.current_checkpoint_id = None;
+    if let (Some(prompt), Some(store)) = (user_prompt, app.checkpoint_store.as_ref()) {
+        let cutoff = app.conversation_panel.items_snapshot().len();
+        match store
+            .lock()
+            .unwrap()
+            .begin(prompt, cutoff, app.todo_list.todos.clone())
+        {
+            Ok(id) => app.current_checkpoint_id = Some(id),
+            Err(error) => app
+                .conversation_panel
+                .add_warning_string(format!("could not create rewind checkpoint: {error}")),
+        }
+    }
     for (text, role, images) in inputs {
         let content = ordered_message_content(text, images);
         app.conversation_panel
@@ -208,9 +244,19 @@ async fn start_ready_request(
     app.cancel.next_id = app.cancel.next_id.wrapping_add(1);
     let operation_id = app.cancel.next_id;
     app.cancel.active_id = Some(operation_id);
+    app.cancel.turn_conversation_cutoff = Some(conversation_cutoff);
+    app.cancel.response_started = false;
+    app.cancel.active_user_request =
+        original_draft.map(|(draft, history_text)| super::ActiveUserRequest {
+            draft,
+            conversation_cutoff,
+            history_text,
+        });
 
     let Some(runner) = app.build_runner() else {
         app.cancel.active_id = None;
+        app.cancel.turn_conversation_cutoff = None;
+        app.cancel.active_user_request = None;
         app.conversation_panel
             .add_error_string(format!("unknown provider/model: {}", app.current_model));
         return;
@@ -409,12 +455,7 @@ pub(crate) fn run_bang_command(app: &mut App<'_>, input: &str) {
     }
 }
 
-/// `/compact [provider/model]`: ask the model for a continuation summary of the
-/// conversation so far, then (in [`super::events`]'s `CompactFinished` handler)
-/// install it as a context boundary — the model afterwards sees the summary
-/// instead of the summarized history, while the UI keeps everything visible.
-/// An argument picks a different model for the summarization request only; the
-/// chat model is unchanged.
+/// Build the no-tools request shared by foreground and background compaction.
 fn build_compact_request(
     input_items: Vec<async_openai::types::responses::InputItem>,
     model_name: String,
@@ -428,50 +469,11 @@ fn build_compact_request(
     }
 }
 
-pub(crate) fn start_compact(app: &mut App<'_>, model_arg: &str) {
-    use crate::ui::components::conversation_panel::conversation_panel::ActivePhase;
-    use crate::ui::event::Event;
-    use async_openai::types::responses::{
-        InputItem, InputParam, Item, OutputItem, OutputMessageContent,
-    };
-
-    if app.cancel.active_id.is_some() {
-        app.conversation_panel
-            .add_warning_string("cannot compact while a turn is in flight");
-        return;
-    }
-    if !app.conversation_panel.has_compactable_history() {
-        app.conversation_panel
-            .add_info_string("nothing to compact yet".to_string());
-        return;
-    }
-    let target_model = if model_arg.is_empty() {
-        app.current_model.clone()
-    } else {
-        model_arg.to_string()
-    };
-    let (client, model_name) = match app.provider_manager.resolve(&target_model) {
-        Some((c, m)) => (c.clone(), m),
-        None => {
-            app.conversation_panel
-                .add_error_string(format!("unknown provider/model: {target_model}"));
-            return;
-        }
-    };
-    if !model_arg.is_empty() {
-        app.conversation_panel
-            .add_info_string(format!("compacting with {target_model}"));
-    }
-
-    // The full current context plus the summarization instruction. No tools:
-    // the model must answer with the summary text, not act.
-    let mut input_items = match app.conversation_panel.get_input_param(
-        &target_model,
-        None,
-        None,
-        None,
-        app.vision_enabled,
-    ) {
+fn compact_input_items(
+    input: async_openai::types::responses::InputParam,
+) -> Vec<async_openai::types::responses::InputItem> {
+    use async_openai::types::responses::{InputItem, InputParam, Item};
+    let mut items = match input {
         InputParam::Items(items) => items,
         InputParam::Text(text) => vec![InputItem::from(Item::Message(ApiMessageItem::Input(
             InputMessage {
@@ -481,7 +483,7 @@ pub(crate) fn start_compact(app: &mut App<'_>, model_arg: &str) {
             },
         )))],
     };
-    input_items.push(InputItem::from(Item::Message(ApiMessageItem::Input(
+    items.push(InputItem::from(Item::Message(ApiMessageItem::Input(
         InputMessage {
             content: vec![InputContent::InputText(InputTextContent {
                 text: crate::prompts::COMPACT_PROMPT.to_string(),
@@ -490,6 +492,72 @@ pub(crate) fn start_compact(app: &mut App<'_>, model_arg: &str) {
             status: Some(OutputStatus::Completed),
         },
     ))));
+    items
+}
+
+fn compact_response_text(
+    response: async_openai::types::responses::Response,
+) -> Result<String, String> {
+    use async_openai::types::responses::{OutputItem, OutputMessageContent};
+    let text = response
+        .output
+        .iter()
+        .filter_map(|item| match item {
+            OutputItem::Message(message) => {
+                Some(message.content.iter().filter_map(|content| match content {
+                    OutputMessageContent::OutputText(text) => Some(text.text.as_str()),
+                    _ => None,
+                }))
+            }
+            _ => None,
+        })
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.trim().is_empty() {
+        Err("the model returned an empty summary".to_string())
+    } else {
+        Ok(text)
+    }
+}
+
+pub(crate) fn start_compact(app: &mut App<'_>) {
+    use crate::ui::components::conversation_panel::conversation_panel::ActivePhase;
+    use crate::ui::event::Event;
+
+    if app.cancel.active_id.is_some() {
+        app.conversation_panel
+            .add_warning_string("cannot compact while a turn is in flight");
+        return;
+    }
+    invalidate_auto_compaction(app);
+    let Some(cutoff) = app
+        .conversation_panel
+        .compaction_cutoff(app.effective_compact_keep_recent_turns())
+    else {
+        app.conversation_panel
+            .add_info_string("nothing old enough to compact yet".to_string());
+        return;
+    };
+    let target_model = app.effective_compact_model();
+    let (client, model_name) = match app.provider_manager.resolve(&target_model) {
+        Some((c, m)) => (c.clone(), m),
+        None => {
+            app.conversation_panel
+                .add_error_string(format!("unknown provider/model: {target_model}"));
+            return;
+        }
+    };
+    app.conversation_panel
+        .add_info_string(format!("compacting with {target_model}"));
+
+    // The full current context plus the summarization instruction. No tools:
+    // the model must answer with the summary text, not act.
+    let input_items = compact_input_items(app.conversation_panel.input_param_for_prefix(
+        cutoff,
+        &target_model,
+        app.vision_enabled,
+    ));
 
     app.conversation_panel.phase = ActivePhase::Compacting;
     app.cancel.active = crate::cancel::CancellationToken::new();
@@ -507,28 +575,7 @@ pub(crate) fn start_compact(app: &mut App<'_>, model_arg: &str) {
             .wait_or(client.responses().create(request))
             .await
         {
-            Some(Ok(response)) => {
-                let text = response
-                    .output
-                    .iter()
-                    .filter_map(|item| match item {
-                        OutputItem::Message(msg) => {
-                            Some(msg.content.iter().filter_map(|c| match c {
-                                OutputMessageContent::OutputText(t) => Some(t.text.as_str()),
-                                _ => None,
-                            }))
-                        }
-                        _ => None,
-                    })
-                    .flatten()
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                if text.trim().is_empty() {
-                    Err("the model returned an empty summary".to_string())
-                } else {
-                    Ok(text)
-                }
-            }
+            Some(Ok(response)) => compact_response_text(response),
             Some(Err(e)) => Err(e.to_string()),
             None => Err("cancelled".to_string()),
         };
@@ -536,10 +583,79 @@ pub(crate) fn start_compact(app: &mut App<'_>, model_arg: &str) {
         // handle_compact_finished can clear active_id and reset the phase.
         let _ = sender.send(Event::App(crate::ui::event::AppEvent::CompactFinished(
             operation_id,
+            cutoff,
             result,
             cancel_token,
         )));
     });
+}
+
+/// Observe a provider-reported input-token count and, when the session's
+/// threshold is crossed, snapshot a complete historical prefix for seamless
+/// background compaction. The foreground turn and input remain interactive.
+pub(crate) fn maybe_start_auto_compact(app: &mut App<'_>, input_tokens: u32) {
+    app.auto_compact.last_input_tokens = Some(input_tokens);
+    let Some(threshold) = app.effective_auto_compact_tokens() else {
+        return;
+    };
+    if input_tokens < threshold || app.auto_compact.active_id.is_some() {
+        return;
+    }
+    let stable_end = app
+        .cancel
+        .turn_conversation_cutoff
+        .unwrap_or_else(|| app.conversation_panel.items_snapshot().len());
+    let Some(cutoff) = app
+        .conversation_panel
+        .compaction_cutoff_before(app.effective_compact_keep_recent_turns(), stable_end)
+    else {
+        return;
+    };
+    if app.auto_compact.last_cutoff == Some(cutoff) {
+        return;
+    }
+    let target_model = app.effective_compact_model();
+    let Some((client, model_name)) = app.provider_manager.resolve(&target_model) else {
+        app.conversation_panel.add_warning_string(format!(
+            "automatic context compaction skipped: unknown provider/model {target_model}"
+        ));
+        app.auto_compact.last_cutoff = Some(cutoff);
+        return;
+    };
+    let client = client.clone();
+    let input_items = compact_input_items(app.conversation_panel.input_param_for_prefix(
+        cutoff,
+        &target_model,
+        app.vision_enabled,
+    ));
+    app.auto_compact.next_id = app.auto_compact.next_id.wrapping_add(1);
+    let job_id = app.auto_compact.next_id;
+    let history_epoch = app.auto_compact.history_epoch;
+    app.auto_compact.active_id = Some(job_id);
+    app.auto_compact.last_cutoff = Some(cutoff);
+    let thinking_level = app.thinking_level;
+    let sender = app.events.sender.clone();
+    tokio::spawn(async move {
+        let request = build_compact_request(input_items, model_name, thinking_level);
+        let result = client
+            .responses()
+            .create(request)
+            .await
+            .map_err(|error| error.to_string())
+            .and_then(compact_response_text);
+        let _ = sender.send(Event::App(AppEvent::AutoCompactFinished {
+            job_id,
+            history_epoch,
+            cutoff,
+            result,
+        }));
+    });
+}
+
+pub(crate) fn invalidate_auto_compaction(app: &mut App<'_>) {
+    app.auto_compact.history_epoch = app.auto_compact.history_epoch.wrapping_add(1);
+    app.auto_compact.active_id = None;
+    app.auto_compact.last_cutoff = None;
 }
 
 /// Open the full-screen task panel. Interactive tasks can grab input; pipe
@@ -618,6 +734,7 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
         | Command::New
         | Command::Session
         | Command::Usage
+        | Command::Rewind
         | Command::Todo
         | Command::Terminal(_)
         | Command::Help) => command_handlers::session::execute(app, command),
@@ -628,9 +745,10 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
         | Command::Classifier(_)
         | Command::Thinking(_)
         | Command::Permission(_)) => command_handlers::settings::execute(app, command),
-        command @ (Command::Providers(_) | Command::Skill(_) | Command::Mcp(_)) => {
-            command_handlers::integrations::execute(app, command)
-        }
+        command @ (Command::Providers(_)
+        | Command::Skill(_)
+        | Command::Mcp(_)
+        | Command::Diagnostics(_)) => command_handlers::integrations::execute(app, command),
         command @ (Command::Init | Command::Compact(_) | Command::Plan(_)) => {
             command_handlers::workflow::execute(app, command).await
         }
@@ -663,6 +781,7 @@ mod tests {
         ProviderPanel,
         SkillsPanel,
         McpPanel,
+        DiagnosticsPanel,
         SecurityPanel,
         TodoPanel,
         Quit,
@@ -701,6 +820,7 @@ mod tests {
                 ExpectedCommandEffect::AppendedMessage,
             ),
             ("usage", "/usage", ExpectedCommandEffect::AppendedMessage),
+            ("rewind", "/rewind", ExpectedCommandEffect::AppendedMessage),
             ("mode", "/mode auto", ExpectedCommandEffect::AppendedMessage),
             (
                 "classifier",
@@ -711,6 +831,11 @@ mod tests {
             ("todo", "/todo", ExpectedCommandEffect::TodoPanel),
             ("skill", "/skill manage", ExpectedCommandEffect::SkillsPanel),
             ("mcp", "/mcp manage", ExpectedCommandEffect::McpPanel),
+            (
+                "diagnostics",
+                "/diagnostics manage",
+                ExpectedCommandEffect::DiagnosticsPanel,
+            ),
             ("plan", "/plan", ExpectedCommandEffect::AppendedMessage),
             (
                 "terminal",
@@ -771,6 +896,9 @@ mod tests {
                 ExpectedCommandEffect::ProviderPanel => assert!(app.provider_panel.is_some()),
                 ExpectedCommandEffect::SkillsPanel => assert!(app.skills_panel.is_some()),
                 ExpectedCommandEffect::McpPanel => assert!(app.mcp_panel.is_some()),
+                ExpectedCommandEffect::DiagnosticsPanel => {
+                    assert!(app.diagnostics_panel.is_some())
+                }
                 ExpectedCommandEffect::SecurityPanel => assert!(app.security_panel.is_some()),
                 ExpectedCommandEffect::TodoPanel => assert!(app.todo_panel.is_some()),
                 ExpectedCommandEffect::Quit => assert!(!app.running),

--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -19,6 +19,52 @@
 
 use super::App;
 
+/// Persist the profile edited by `/diagnostics manage`. An empty profile means
+/// diagnostics are disabled and removes the project file entirely.
+pub(crate) fn save_profile(profile: &crate::diagnostics::DiagnosticsProfile) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+    let path = crate::diagnostics::DiagnosticsProfile::path_in(&cwd);
+    if profile.checkers.is_empty() {
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .map_err(|error| format!("remove {}: {error}", path.display()))?;
+        }
+        return Ok(());
+    }
+    profile.validate()?;
+    let text = profile.to_toml()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| "diagnostics profile has no parent directory".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    std::fs::write(&path, text).map_err(|error| format!("write {}: {error}", path.display()))
+}
+
+/// Re-run the configured checkers without blocking the TUI and update the
+/// shared sidebar snapshot when the matching result arrives.
+pub(crate) fn start_update(app: &mut App<'_>, notify_started: bool) {
+    app.diagnostics_update_generation = app.diagnostics_update_generation.wrapping_add(1);
+    let generation = app.diagnostics_update_generation;
+    if notify_started {
+        app.conversation_panel
+            .add_info_string("Updating diagnostics in the background…");
+    }
+    let sender = app.events.sender.clone();
+    tokio::spawn(async move {
+        let cwd =
+            std::env::current_dir().unwrap_or_else(|_| std::path::Path::new(".").to_path_buf());
+        let snapshot =
+            crate::diagnostics::collect(&cwd, &crate::cancel::CancellationToken::new()).await;
+        let _ = sender.send(crate::ui::event::Event::App(
+            crate::ui::event::AppEvent::DiagnosticsUpdated {
+                generation,
+                snapshot,
+            },
+        ));
+    });
+}
+
 /// On the first turn of a session with a diagnostics profile, run the
 /// checkers once in the background to establish a baseline in the shared
 /// [`crate::runner::DiagnosticsState`] (accessible to both the runner and the UI).

--- a/src/app/events/keys.rs
+++ b/src/app/events/keys.rs
@@ -29,9 +29,13 @@ pub(crate) async fn handle_key_events(
     app: &mut App<'_>,
     key_event: KeyEvent,
 ) -> color_eyre::Result<()> {
-    // ---- Esc while a turn is active: cancel before ANY panel grabs it ----
-    // (including the terminal panel and approval/question modals)
-    if key_event.code == KeyCode::Esc && app.cancel.active_id.is_some() {
+    // ---- Esc while a turn is active: cancel unless an independent overlay
+    // owns the key. Approval/question prompts belong to the active turn and
+    // intentionally are not listed here, so Esc still cancels that turn.
+    if key_event.code == KeyCode::Esc
+        && app.cancel.active_id.is_some()
+        && !independent_overlay_owns_escape(app)
+    {
         app.events.send(AppEvent::Cancel);
         return Ok(());
     }
@@ -52,6 +56,23 @@ pub(crate) async fn handle_key_events(
     if let Some(panel) = app.agent_panel.as_mut() {
         if panel.handle_key(key_event) {
             app.agent_panel = None;
+        }
+        return Ok(());
+    }
+
+    if let Some(panel) = app.rewind_panel.as_mut() {
+        use crate::ui::components::rewind_panel::PanelAction as RewindAction;
+        let action = panel.handle_key(key_event);
+        match action {
+            RewindAction::Close => app.rewind_panel = None,
+            RewindAction::Restore {
+                checkpoint_id,
+                mode,
+            } => {
+                app.rewind_panel = None;
+                apply_rewind(app, checkpoint_id, mode);
+            }
+            RewindAction::None => {}
         }
         return Ok(());
     }
@@ -182,6 +203,28 @@ pub(crate) async fn handle_key_events(
                 app.events.send(AppEvent::McpChanged);
             }
             McpAction::None => {}
+        }
+        return Ok(());
+    }
+
+    // ---- diagnostics management panel (modal) ----
+    if let Some(panel) = app.diagnostics_panel.as_mut() {
+        use crate::ui::components::diagnostics_panel::PanelAction as DiagnosticsAction;
+        match panel.handle_key(key_event) {
+            DiagnosticsAction::Close => app.diagnostics_panel = None,
+            DiagnosticsAction::Saved(profile) => {
+                match crate::app::diagnostics::save_profile(&profile) {
+                    Ok(()) => {
+                        crate::app::diagnostics::reset_diagnostics_state(app);
+                        app.diag.lsp_configured = crate::app::helpers::lsp_checker_configured();
+                        crate::app::diagnostics::start_update(app, false);
+                    }
+                    Err(error) => app
+                        .conversation_panel
+                        .add_error_string(format!("could not save diagnostics profile: {error}")),
+                }
+            }
+            DiagnosticsAction::None => {}
         }
         return Ok(());
     }
@@ -368,6 +411,167 @@ pub(crate) async fn handle_key_events(
     Ok(())
 }
 
+/// Independent UI surfaces must get the first chance to close or leave their
+/// local mode before Esc is interpreted as cancelling the active model turn.
+fn independent_overlay_owns_escape(app: &App<'_>) -> bool {
+    app.terminal_pane.is_some()
+        || app.agent_panel.is_some()
+        || app.rewind_panel.is_some()
+        || app.todo_panel.is_some()
+        || app.provider_panel.is_some()
+        || app.skills_panel.is_some()
+        || app.mcp_panel.is_some()
+        || app.diagnostics_panel.is_some()
+        || app.security_panel.is_some()
+        || app
+            .sidebar
+            .as_ref()
+            .is_some_and(|sidebar| sidebar.has_focus)
+        || app
+            .input_panel
+            .completion
+            .as_ref()
+            .is_some_and(|completion| completion.visible)
+}
+
+fn apply_rewind(
+    app: &mut App<'_>,
+    checkpoint_id: u64,
+    mode: crate::ui::components::rewind_panel::RestoreMode,
+) {
+    use crate::ui::components::rewind_panel::RestoreMode;
+
+    let restore_code = matches!(
+        mode,
+        RestoreMode::CodeAndConversation | RestoreMode::CodeOnly
+    );
+    let restore_conversation = matches!(
+        mode,
+        RestoreMode::CodeAndConversation | RestoreMode::ConversationOnly
+    );
+    if restore_code
+        && (crate::tasks::snapshot_all()
+            .iter()
+            .any(|task| task.status == crate::tasks::TaskStatus::Running)
+            || app
+                .agents
+                .snapshot_all()
+                .iter()
+                .any(|agent| !agent.status.is_terminal()))
+    {
+        app.conversation_panel.add_warning_string(
+            "cannot restore files while a background task or sub-agent is running",
+        );
+        return;
+    }
+
+    let Some(store) = app.checkpoint_store.as_ref().cloned() else {
+        app.conversation_panel
+            .add_error_string("rewind checkpoints are unavailable");
+        return;
+    };
+    let checkpoint = {
+        let store = store.lock().unwrap();
+        store.checkpoint(checkpoint_id).cloned()
+    };
+    let Some(checkpoint) = checkpoint else {
+        app.conversation_panel
+            .add_error_string("the selected rewind checkpoint no longer exists");
+        return;
+    };
+
+    let mut restored_files = 0;
+    let mut recovery_id = None;
+    if restore_code {
+        let has_file_changes = store
+            .lock()
+            .unwrap()
+            .has_file_changes_for_restore(checkpoint_id);
+        if has_file_changes {
+            let conversation_cutoff = app.conversation_panel.items_snapshot().len();
+            let begin_recovery = store.lock().unwrap().begin_recovery(
+                checkpoint_id,
+                conversation_cutoff,
+                app.todo_list.todos.clone(),
+            );
+            match begin_recovery {
+                Ok(id) => recovery_id = Some(id),
+                Err(error) => {
+                    app.conversation_panel.add_error_string(format!(
+                        "could not create rewind recovery point: {error}"
+                    ));
+                    return;
+                }
+            }
+        }
+        let restore_result = store.lock().unwrap().restore_files(checkpoint_id);
+        match restore_result {
+            Ok(report) if report.conflicts.is_empty() => restored_files = report.restored,
+            Ok(report) => {
+                if let Some(recovery_id) = recovery_id {
+                    let _ = store.lock().unwrap().discard_checkpoint(recovery_id);
+                }
+                let paths = report
+                    .conflicts
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                app.conversation_panel.add_warning_string(format!(
+                    "rewind stopped: files changed outside Programmer: {paths}"
+                ));
+                return;
+            }
+            Err(error) => {
+                if let Some(recovery_id) = recovery_id {
+                    let _ = store.lock().unwrap().discard_checkpoint(recovery_id);
+                }
+                app.conversation_panel
+                    .add_error_string(format!("rewind failed: {error}"));
+                return;
+            }
+        }
+        if let Some(recovery_id) = recovery_id
+            && let Err(error) = store.lock().unwrap().finalize_recovery(recovery_id)
+        {
+            app.conversation_panel.add_warning_string(format!(
+                "files were restored, but the recovery point could not be finalized: {error}"
+            ));
+        }
+    }
+
+    if restore_conversation {
+        commands::invalidate_auto_compaction(app);
+        app.conversation_panel
+            .truncate(checkpoint.conversation_cutoff);
+        app.input_panel.set_content(&checkpoint.prompt);
+        app.todo_list = crate::todos::TodoList {
+            todos: checkpoint.todos,
+        };
+        app.sync_todos_to_store();
+        app.pending_images.clear();
+    }
+    if let Err(error) = store
+        .lock()
+        .unwrap()
+        .truncate_after(checkpoint_id, recovery_id)
+    {
+        app.conversation_panel
+            .add_warning_string(format!("could not prune rewind history: {error}"));
+    }
+    app.current_checkpoint_id = None;
+    session::mark_dirty(app);
+    app.conversation_panel.add_info_string(format!(
+        "Rewound to prompt #{checkpoint_id}: {} file(s) restored{}",
+        restored_files,
+        if restore_conversation {
+            "; prompt returned to the input"
+        } else {
+            ""
+        }
+    ));
+}
+
 fn is_promote_shortcut(key: KeyEvent) -> bool {
     key.code == KeyCode::Char('z') && key.modifiers == KeyModifiers::CONTROL
 }
@@ -527,6 +731,9 @@ pub(crate) fn handle_paste(app: &mut App<'_>, data: String) {
         return;
     }
     let data = data.replace("\r\n", "\n").replace('\r', "\n");
+    if app.rewind_panel.is_some() {
+        return;
+    }
     if let Some(panel) = app.question_panel.as_mut() {
         panel.handle_paste(&data);
         return;
@@ -536,6 +743,10 @@ pub(crate) fn handle_paste(app: &mut App<'_>, data: String) {
         return;
     }
     if let Some(panel) = app.mcp_panel.as_mut() {
+        panel.handle_paste(&data);
+        return;
+    }
+    if let Some(panel) = app.diagnostics_panel.as_mut() {
         panel.handle_paste(&data);
         return;
     }
@@ -734,5 +945,33 @@ mod tests {
             KeyCode::Char('v'),
             KeyModifiers::NONE
         )));
+    }
+
+    #[tokio::test]
+    async fn esc_closes_mcp_panel_without_cancelling_the_active_turn() {
+        let mut config = crate::config::programmer_config::ProgrammerConfig::default();
+        config.providers.clear();
+        let mut app = crate::app::App::new(
+            config,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            "mcp-escape-routing-test".to_string(),
+            None,
+            Vec::new(),
+            false,
+            "test".to_string(),
+        )
+        .await;
+        app.cancel.active_id = Some(42);
+        app.mcp_panel = Some(crate::ui::components::mcp_panel::McpPanel::new());
+
+        handle_key_events(&mut app, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .await
+            .unwrap();
+
+        assert!(app.mcp_panel.is_none());
+        assert_eq!(app.cancel.active_id, Some(42));
+        assert!(!app.cancel.active.is_cancelled());
     }
 }

--- a/src/app/events/keys.rs
+++ b/src/app/events/keys.rs
@@ -65,6 +65,10 @@ pub(crate) async fn handle_key_events(
         let action = panel.handle_key(key_event);
         match action {
             RewindAction::Close => app.rewind_panel = None,
+            RewindAction::Fork { checkpoint_id } => {
+                app.rewind_panel = None;
+                apply_rewind_fork(app, checkpoint_id);
+            }
             RewindAction::Restore {
                 checkpoint_id,
                 mode,
@@ -570,6 +574,73 @@ fn apply_rewind(
             ""
         }
     ));
+}
+
+fn apply_rewind_fork(app: &mut App<'_>, checkpoint_id: u64) {
+    let Some(source_store) = app.checkpoint_store.as_ref().cloned() else {
+        app.conversation_panel
+            .add_error_string("rewind checkpoints are unavailable");
+        return;
+    };
+    let checkpoint = {
+        let store = source_store.lock().unwrap();
+        store.checkpoint(checkpoint_id).cloned()
+    };
+    let Some(checkpoint) = checkpoint.filter(|checkpoint| !checkpoint.recovery) else {
+        app.conversation_panel
+            .add_error_string("the selected rewind checkpoint cannot be forked");
+        return;
+    };
+    if app.session.mgr.is_none() {
+        app.conversation_panel
+            .add_error_string("cannot fork without session persistence");
+        return;
+    }
+    if let Err(error) = session::save_session_checked(app) {
+        app.conversation_panel.add_error_string(format!(
+            "could not save the source session before forking: {error}"
+        ));
+        return;
+    }
+    let manager = app
+        .session
+        .mgr
+        .as_ref()
+        .expect("session manager checked above");
+    let source_uuid = app.session.uuid.clone();
+    let fork_uuid = manager.create().uuid;
+    let Some(mut fork_store) = crate::checkpoint::CheckpointStore::for_session(&fork_uuid) else {
+        app.conversation_panel
+            .add_error_string("could not create rewind history for the fork");
+        return;
+    };
+    if let Err(error) =
+        fork_store.copy_conversation_history_before(&source_store.lock().unwrap(), checkpoint_id)
+    {
+        app.conversation_panel.add_error_string(format!(
+            "could not create rewind history for the fork: {error}"
+        ));
+        return;
+    }
+
+    commands::invalidate_auto_compaction(app);
+    app.session.uuid = fork_uuid.clone();
+    app.session.did_save = false;
+    app.conversation_panel
+        .truncate(checkpoint.conversation_cutoff);
+    app.input_panel.set_content(&checkpoint.prompt);
+    app.todo_list = crate::todos::TodoList {
+        todos: checkpoint.todos,
+    };
+    app.sync_todos_to_store();
+    app.pending_images.clear();
+    app.checkpoint_store = Some(std::sync::Arc::new(std::sync::Mutex::new(fork_store)));
+    app.current_checkpoint_id = None;
+    session::mark_dirty(app);
+    app.conversation_panel.add_info_string(format!(
+        "Forked prompt #{checkpoint_id} into session {fork_uuid}. Source session {source_uuid} was preserved; prompt returned to the input."
+    ));
+    session::save_session(app);
 }
 
 fn is_promote_shortcut(key: KeyEvent) -> bool {

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -68,7 +68,12 @@ async fn handle_crossterm(
         }
         crossterm::event::Event::Paste(data) => keys::handle_paste(app, data),
         crossterm::event::Event::Mouse(_)
-            if app.provider_panel.is_some() || app.security_panel.is_some() => {}
+            if app.provider_panel.is_some()
+                || app.skills_panel.is_some()
+                || app.mcp_panel.is_some()
+                || app.diagnostics_panel.is_some()
+                || app.security_panel.is_some()
+                || app.rewind_panel.is_some() => {}
         // The task viewer owns the whole screen. Interactive tasks can forward
         // mouse input to their PTY; read-only tasks use the wheel to scroll.
         crossterm::event::Event::Mouse(mouse) if app.terminal_pane.is_some() => {
@@ -124,6 +129,9 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
             }
             if app.conversation_panel.receiving_response.is_some() {
                 app.conversation_panel.handle_response_stream_event(*chunk);
+                if app.conversation_panel.response_started() {
+                    app.cancel.response_started = true;
+                }
             }
         }
         AppEvent::ResponseCommitted(op_id) => {
@@ -131,6 +139,7 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                 return;
             }
             app.conversation_panel.commit_live();
+            app.cancel.response_started = true;
             app.sync_todos_from_store();
         }
         AppEvent::RunnerPhase(op_id, p) => {
@@ -148,6 +157,11 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                 RunnerPhase::RunningTools => ActivePhase::ToolRunning,
                 RunnerPhase::Checking => ActivePhase::Checking,
             };
+        }
+        AppEvent::UsageSafePoint(op_id, input_tokens) => {
+            if is_live_turn(app, op_id) {
+                commands::maybe_start_auto_compact(app, input_tokens);
+            }
         }
         AppEvent::ReviewRequest {
             call,
@@ -197,6 +211,8 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
             // earlier) turn are dropped and Esc won't try to cancel a
             // turn that has already ended.
             app.cancel.active_id = None;
+            app.cancel.turn_conversation_cutoff = None;
+            app.cancel.active_user_request = None;
             // A prompt may have been installed just before cancellation won the
             // race. Turn completion is the final defensive cleanup boundary.
             discard_reviews_for_operation(app, op_id);
@@ -254,15 +270,47 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
         AppEvent::FlushAgentNotifications(token) => {
             flush_agent_notifications(app, token).await;
         }
-        AppEvent::CompactFinished(op_id, result, cancel_token) => {
+        AppEvent::CompactFinished(op_id, cutoff, result, cancel_token) => {
             if !is_current_turn(app, op_id) {
                 return;
             }
-            handle_compact_finished(app, result, cancel_token);
+            handle_compact_finished(app, cutoff, result, cancel_token);
             // handle_compact_finished clears active_id and resets the phase
             // back to idle. If the user queued a message while compacting,
             // start it now — just like TurnFinished does for normal turns.
             start_queued_work(app).await;
+        }
+        AppEvent::AutoCompactFinished {
+            job_id,
+            history_epoch,
+            cutoff,
+            result,
+        } => {
+            if app.auto_compact.active_id != Some(job_id) {
+                return;
+            }
+            app.auto_compact.active_id = None;
+            if app.auto_compact.history_epoch != history_epoch {
+                return;
+            }
+            match result {
+                Ok(summary) => {
+                    if app.conversation_panel.apply_compaction_at(cutoff, summary) {
+                        if let Some(store) = &app.checkpoint_store
+                            && let Err(error) =
+                                store.lock().unwrap().record_conversation_insertion(cutoff)
+                        {
+                            app.conversation_panel.add_warning_string(format!(
+                                "could not update rewind checkpoints after compaction: {error}"
+                            ));
+                        }
+                        session::mark_dirty(app);
+                    }
+                }
+                Err(error) => app
+                    .conversation_panel
+                    .add_warning_string(format!("automatic context compaction failed: {error}")),
+            }
         }
         AppEvent::Quit => handle_quit_request(app),
         AppEvent::ProvidersChanged => reload_provider_manager(app),
@@ -291,6 +339,35 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
             generation,
             manager,
         } => handle_mcp_reloaded(app, generation, *manager),
+        AppEvent::DiagnosticsUpdated {
+            generation,
+            snapshot,
+        } => {
+            if generation != app.diagnostics_update_generation {
+                return;
+            }
+            app.diag.lsp_configured = crate::app::helpers::lsp_checker_configured();
+            match snapshot {
+                None => {
+                    app.diagnostics_state.lock().unwrap().baseline = None;
+                    app.conversation_panel.add_info_string(
+                        "No diagnostics profile configured. Use /diagnostics manage to add one.",
+                    );
+                }
+                Some(snapshot) => {
+                    let rendered = snapshot.render();
+                    app.diagnostics_state.lock().unwrap().baseline = Some(snapshot.diagnostics);
+                    if snapshot.errors.is_empty() {
+                        app.conversation_panel
+                            .add_info_string(format!("Diagnostics updated.\n{rendered}"));
+                    } else {
+                        app.conversation_panel.add_warning_string(format!(
+                            "Diagnostics updated with checker errors.\n{rendered}"
+                        ));
+                    }
+                }
+            }
+        }
         AppEvent::QuestionPrompt {
             question,
             answer_tx,
@@ -456,8 +533,10 @@ fn has_blocking_surface(app: &App<'_>) -> bool {
         || app.provider_panel.is_some()
         || app.skills_panel.is_some()
         || app.mcp_panel.is_some()
+        || app.diagnostics_panel.is_some()
         || app.security_panel.is_some()
         || app.todo_panel.is_some()
+        || app.rewind_panel.is_some()
         || app.terminal_pane.is_some()
         || app.agent_panel.is_some()
         || (app.work_mode == WorkMode::Plan
@@ -511,7 +590,21 @@ async fn handle_cancel(app: &mut App<'_>) {
     }
     // Cancel the turn's root token; the runner's spawned task checks this token
     // between every iteration and stops.
+    let restore_draft = !app.cancel.response_started;
     app.cancel.active.cancel();
+    if restore_draft && let Some(request) = app.cancel.active_user_request.take() {
+        app.conversation_panel.truncate(request.conversation_cutoff);
+        app.input_panel
+            .remove_last_history_if(&request.history_text);
+        app.input_panel.restore_draft(request.draft);
+        if let (Some(checkpoint_id), Some(store)) =
+            (app.current_checkpoint_id, app.checkpoint_store.as_ref())
+        {
+            let _ = store.lock().unwrap().truncate_after(checkpoint_id, None);
+        }
+        app.current_checkpoint_id = None;
+        session::mark_dirty(app);
+    }
     app.conversation_panel.abort_receiving();
     app.conversation_panel.phase = ActivePhase::Cancelling;
     app.conversation_panel.flush_usage();
@@ -537,6 +630,7 @@ fn handle_start_init(app: &mut App<'_>, prompt: String) {
             .add_warning_string("cannot initialize while a turn is in flight");
         return;
     }
+    let conversation_cutoff = app.conversation_panel.items_snapshot().len();
     app.conversation_panel
         .add_meta("\u{25B8} Initializing project\u{2026}", prompt);
     app.conversation_panel.reset_accumulated_usage();
@@ -547,10 +641,14 @@ fn handle_start_init(app: &mut App<'_>, prompt: String) {
     app.cancel.next_id = app.cancel.next_id.wrapping_add(1);
     let operation_id = app.cancel.next_id;
     app.cancel.active_id = Some(operation_id);
+    app.cancel.turn_conversation_cutoff = Some(conversation_cutoff);
+    app.cancel.response_started = false;
+    app.cancel.active_user_request = None;
 
     // Spawn the init turn through the same runner path.
     let Some(runner) = app.build_runner() else {
         app.cancel.active_id = None;
+        app.cancel.turn_conversation_cutoff = None;
         app.conversation_panel
             .add_error_string(format!("unknown provider/model: {}", app.current_model));
         return;
@@ -581,17 +679,26 @@ fn handle_start_init(app: &mut App<'_>, prompt: String) {
 /// cancelled compaction doesn't leave the UI stuck in Cancelling.
 fn handle_compact_finished(
     app: &mut App<'_>,
+    cutoff: usize,
     result: Result<String, String>,
     cancel_token: CancellationToken,
 ) {
     app.cancel.active_id = None;
+    app.cancel.turn_conversation_cutoff = None;
     app.conversation_panel.phase = ActivePhase::None;
     if cancel_token.is_cancelled() {
         return;
     }
     match result {
         Ok(summary) => {
-            app.conversation_panel.apply_compaction(summary);
+            if app.conversation_panel.apply_compaction_at(cutoff, summary)
+                && let Some(store) = &app.checkpoint_store
+                && let Err(error) = store.lock().unwrap().record_conversation_insertion(cutoff)
+            {
+                app.conversation_panel.add_warning_string(format!(
+                    "could not update rewind checkpoints after compaction: {error}"
+                ));
+            }
             app.conversation_panel.add_info_string(
                 "Context compacted — older history is summarized for the model \
                  (click the divider to read the summary) but stays visible here."
@@ -895,8 +1002,8 @@ pub(crate) fn update_completions(app: &mut App<'_>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConversationPanel, QUIT_CONFIRM_TIMEOUT, QUIT_CONFIRM_WARNING, is_current_turn_id,
-        is_live_turn_id, quit_confirmation_expired, quit_is_confirmed,
+        ConversationPanel, QUIT_CONFIRM_TIMEOUT, QUIT_CONFIRM_WARNING, handle_cancel,
+        is_current_turn_id, is_live_turn_id, quit_confirmation_expired, quit_is_confirmed,
         remove_quit_confirmation_warning, take_pending_request,
     };
     use crate::response::message_item::MessageItem;
@@ -1017,5 +1124,68 @@ mod tests {
         assert_eq!(taken_images.len(), 1);
         assert!(images.is_empty());
         assert!(take_pending_request(&mut panel, &mut images).is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelling_before_model_output_restores_the_original_draft() {
+        use async_openai::types::responses::{
+            ImageDetail, InputContent, InputImageContent, InputMessage, InputRole, OutputStatus,
+        };
+
+        let mut config = crate::config::programmer_config::ProgrammerConfig::default();
+        config.providers.clear();
+        let mut app = crate::app::App::new(
+            config,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            "cancel-draft-test".to_string(),
+            None,
+            Vec::new(),
+            false,
+            "test".to_string(),
+        )
+        .await;
+        app.input_panel.add_paste("first\nsecond".to_string());
+        assert!(app.input_panel.add_image(
+            InputImageContent {
+                detail: ImageDetail::Auto,
+                file_id: None,
+                image_url: Some("data:image/png;base64,AAAA".to_string()),
+            },
+            4,
+            4,
+        ));
+        let draft = app.input_panel.draft_snapshot();
+        let history_text = app.input_panel.expanded_content();
+        app.input_panel.push_history(history_text.clone());
+        app.input_panel.clear();
+        let cutoff = app.conversation_panel.items_snapshot().len();
+        app.conversation_panel.add_input_message(
+            async_openai::types::responses::MessageItem::Input(InputMessage {
+                content: vec![InputContent::InputText("sent".into())],
+                role: InputRole::User,
+                status: Some(OutputStatus::Completed),
+            }),
+        );
+        app.cancel.active_id = Some(1);
+        app.cancel.response_started = false;
+        app.cancel.active_user_request = Some(crate::app::ActiveUserRequest {
+            draft,
+            conversation_cutoff: cutoff,
+            history_text,
+        });
+
+        handle_cancel(&mut app).await;
+
+        assert!(app.input_panel.get_content().contains("[Pasted text #1"));
+        assert_eq!(app.input_panel.take_images().len(), 1);
+        assert!(app.input_panel.history.is_empty());
+        assert!(
+            !app.conversation_panel
+                .items_snapshot()
+                .iter()
+                .any(|item| { matches!(item, MessageItem::Input(_)) })
+        );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,13 +30,15 @@ use crate::config::programmer_config::ProgrammerConfig;
 use crate::mcp::McpServerStatus;
 use crate::providers::{ProviderManager, ProviderModelStatus};
 use crate::response::message_item::MessageItem;
-use crate::session::SessionManager;
+use crate::session::{AutoCompactOverride, ModelOverride, SessionManager};
 use crate::ui::components::conversation_panel::conversation_panel::ConversationPanel;
+use crate::ui::components::diagnostics_panel::DiagnosticsPanel;
 use crate::ui::components::footer::footer::Footer;
 use crate::ui::components::input_panel::input_panel::InputPanel;
 use crate::ui::components::mcp_panel::McpPanel;
 use crate::ui::components::provider_panel::ProviderPanel;
 use crate::ui::components::question_panel::QuestionPanel;
+use crate::ui::components::rewind_panel::RewindPanel;
 use crate::ui::components::security_panel::SecurityPanel;
 use crate::ui::components::sidebar::Sidebar;
 use crate::ui::components::skills_panel::SkillsPanel;
@@ -100,8 +102,23 @@ pub(crate) struct CancelState {
     /// arrives, so the UI never races between "start" and "what is my id?" and
     /// stale events from an earlier turn are always dropped.
     pub(crate) active_id: Option<u64>,
+    /// Conversation length immediately before the active turn was appended.
+    /// Automatic compaction may only summarize items before this boundary.
+    pub(crate) turn_conversation_cutoff: Option<usize>,
     /// True while the stream task is backing off between connection retries.
     pub(crate) stream_retrying: Arc<AtomicBool>,
+    /// Becomes true after the current request produces any model output. It
+    /// stays true after the live response has been committed.
+    pub(crate) response_started: bool,
+    /// Original editable draft for a user request, retained until completion
+    /// so an early cancellation can put it back in the input.
+    pub(crate) active_user_request: Option<ActiveUserRequest>,
+}
+
+pub(crate) struct ActiveUserRequest {
+    pub(crate) draft: crate::ui::components::input_panel::input_panel::InputDraft,
+    pub(crate) conversation_cutoff: usize,
+    pub(crate) history_text: String,
 }
 
 /// Session identity, persistence handle, and the deferred-save dirty flag.
@@ -118,6 +135,20 @@ pub(crate) struct SessionState {
     /// so a burst of changes within a turn collapses into a single save at turn
     /// end instead of writing after every event.
     pub(crate) dirty: bool,
+    pub(crate) classifier_model_override: ModelOverride,
+    pub(crate) classifier_top_logprobs_override: Option<u8>,
+    pub(crate) compact_model_override: ModelOverride,
+    pub(crate) auto_compact_override: AutoCompactOverride,
+    pub(crate) compact_keep_recent_turns_override: Option<usize>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AutoCompactState {
+    pub(crate) next_id: u64,
+    pub(crate) active_id: Option<u64>,
+    pub(crate) history_epoch: u64,
+    pub(crate) last_cutoff: Option<usize>,
+    pub(crate) last_input_tokens: Option<u32>,
 }
 
 pub(crate) struct TaskNotificationState {
@@ -238,12 +269,16 @@ pub struct App<'a> {
     pub skills_panel: Option<SkillsPanel>,
     /// Full-screen MCP server management panel, when open.
     pub mcp_panel: Option<McpPanel>,
+    /// Full-screen project diagnostics management panel, when open.
+    pub diagnostics_panel: Option<DiagnosticsPanel>,
     /// Full-screen security profile management panel, when open.
     pub security_panel: Option<SecurityPanel>,
     /// Modal question panel shown when the model calls `ask_user`.
     pub question_panel: Option<QuestionPanel>,
     /// Todo-list panel shown with `/todo`.
     pub todo_panel: Option<TodoPanel>,
+    /// Full-screen checkpoint selector opened by `/rewind`.
+    pub rewind_panel: Option<RewindPanel>,
     /// Full-screen interactive terminal panel, when open (`/terminal`).
     pub terminal_pane: Option<crate::ui::components::terminal_panel::TerminalPane>,
     /// Full-screen read-only child conversation, opened from the Agents sidebar.
@@ -289,12 +324,19 @@ pub struct App<'a> {
     /// feedback (baseline + edit-turn counter). The TUI holds this so it
     /// persists across per-turn engines.
     pub(crate) diagnostics_state: Arc<std::sync::Mutex<crate::runner::DiagnosticsState>>,
+    /// Rejects stale results when diagnostics are manually refreshed twice.
+    pub(crate) diagnostics_update_generation: u64,
     /// Tracks whether the current mouse-drag started in the sidebar area.
     pub(crate) sidebar_click_active: bool,
     /// Cancellation tokens for the current request lifecycle.
     pub(crate) cancel: CancelState,
     /// Session identity, persistence handle, and deferred-save flag.
     pub(crate) session: SessionState,
+    /// Background automatic compaction bookkeeping. This is deliberately
+    /// independent from the foreground turn phase and cancellation token.
+    pub(crate) auto_compact: AutoCompactState,
+    pub(crate) checkpoint_store: Option<Arc<Mutex<crate::checkpoint::CheckpointStore>>>,
+    pub(crate) current_checkpoint_id: Option<u64>,
     /// Project directory name for the terminal title.
     pub(crate) project_name: String,
     /// Plan mode sub-phase. Only meaningful when `work_mode == WorkMode::Plan`.
@@ -344,6 +386,11 @@ impl App<'_> {
         let mut work_mode = WorkMode::default();
         let mut vision_enabled = false;
         let mut thinking_level = crate::thinking::ThinkingLevel::default();
+        let mut classifier_model_override = ModelOverride::Inherit;
+        let mut classifier_top_logprobs_override = None;
+        let mut compact_model_override = ModelOverride::Inherit;
+        let mut auto_compact_override = AutoCompactOverride::Inherit;
+        let mut compact_keep_recent_turns_override = None;
 
         let mut saved_activated_skills: Option<Vec<String>> = None;
         if let Some(mgr) = &session_mgr
@@ -359,9 +406,11 @@ impl App<'_> {
             }
             vision_enabled = saved.vision_enabled;
             thinking_level = saved.thinking_level;
-            if saved.classifier_model.is_some() {
-                config.classifier_model = saved.classifier_model;
-            }
+            classifier_model_override = saved.classifier_model_override;
+            classifier_top_logprobs_override = saved.classifier_top_logprobs_override;
+            compact_model_override = saved.compact_model_override;
+            auto_compact_override = saved.auto_compact_override;
+            compact_keep_recent_turns_override = saved.compact_keep_recent_turns_override;
             if saved.skill_selection_saved || !saved.activated_skills.is_empty() {
                 saved_activated_skills = Some(saved.activated_skills);
             }
@@ -394,6 +443,8 @@ impl App<'_> {
             .map(|server| McpServerStatus::connecting(server.name.clone()))
             .collect();
         let provider_model_statuses = ProviderModelStatus::from_config(&config);
+        let checkpoint_store = crate::checkpoint::CheckpointStore::for_session(&session_uuid)
+            .map(|store| Arc::new(Mutex::new(store)));
         let mut app = Self {
             running: true,
             quit_requested_at: None,
@@ -412,9 +463,11 @@ impl App<'_> {
             provider_panel: open_provider_panel.then(ProviderPanel::new),
             skills_panel: None,
             mcp_panel: None,
+            diagnostics_panel: None,
             security_panel: None,
             question_panel: None,
             todo_panel: None,
+            rewind_panel: None,
             terminal_pane: None,
             agent_panel: None,
             task_notifications: TaskNotificationState::new(),
@@ -437,19 +490,31 @@ impl App<'_> {
             diagnostics_state: Arc::new(std::sync::Mutex::new(
                 crate::runner::DiagnosticsState::default(),
             )),
+            diagnostics_update_generation: 0,
             sidebar_click_active: false,
             cancel: CancelState {
                 active: CancellationToken::new(),
                 next_id: 0,
                 active_id: None,
+                turn_conversation_cutoff: None,
                 stream_retrying: Arc::new(AtomicBool::new(false)),
+                response_started: false,
+                active_user_request: None,
             },
             session: SessionState {
                 uuid: session_uuid,
                 mgr: session_mgr,
                 dirty: false,
                 did_save: false,
+                classifier_model_override,
+                classifier_top_logprobs_override,
+                compact_model_override,
+                auto_compact_override,
+                compact_keep_recent_turns_override,
             },
+            auto_compact: AutoCompactState::default(),
+            checkpoint_store,
+            current_checkpoint_id: None,
             skill_registry: crate::skills::SkillRegistry::load(),
             mcp_manager: None,
             mcp_server_statuses,
@@ -522,6 +587,61 @@ impl App<'_> {
         }
     }
 
+    pub(crate) fn effective_classifier_model(&self) -> String {
+        self.effective_model_override(
+            &self.session.classifier_model_override,
+            self.config.classifier_model.as_deref(),
+        )
+    }
+
+    pub(crate) fn effective_classifier_top_logprobs(&self) -> u8 {
+        self.session
+            .classifier_top_logprobs_override
+            .unwrap_or(self.config.classifier_top_logprobs)
+    }
+
+    pub(crate) fn effective_compact_model(&self) -> String {
+        self.effective_model_override(
+            &self.session.compact_model_override,
+            self.config.compact_model.as_deref(),
+        )
+    }
+
+    pub(crate) fn effective_auto_compact_tokens(&self) -> Option<u32> {
+        match self.session.auto_compact_override {
+            AutoCompactOverride::Inherit => {
+                (self.config.auto_compact_tokens > 0).then_some(self.config.auto_compact_tokens)
+            }
+            AutoCompactOverride::Disabled => None,
+            AutoCompactOverride::Tokens(tokens) => Some(tokens),
+        }
+    }
+
+    pub(crate) fn effective_compact_keep_recent_turns(&self) -> usize {
+        self.session
+            .compact_keep_recent_turns_override
+            .unwrap_or(self.config.compact_keep_recent_turns)
+    }
+
+    pub(crate) fn checkpoint_recorder(&self) -> Option<crate::checkpoint::CheckpointRecorder> {
+        Some(crate::checkpoint::CheckpointRecorder {
+            store: self.checkpoint_store.as_ref()?.clone(),
+            checkpoint_id: self.current_checkpoint_id?,
+        })
+    }
+
+    fn effective_model_override(
+        &self,
+        model_override: &ModelOverride,
+        global: Option<&str>,
+    ) -> String {
+        match model_override {
+            ModelOverride::Inherit => global.unwrap_or(&self.current_model).to_string(),
+            ModelOverride::Current => self.current_model.clone(),
+            ModelOverride::Model(model) => model.clone(),
+        }
+    }
+
     /// Build a fresh [`crate::runner::TurnRunner`] for the current app state.
     /// Called at the start of every turn; the runner is immutable during a turn
     /// and is dropped when the spawned task finishes.
@@ -538,10 +658,10 @@ impl App<'_> {
         // Unify every tool source behind the registry: the local built-ins are
         // one provider, all connected MCP servers another.
         let mut base_providers: Vec<Arc<dyn ToolProvider>> = vec![
-            Arc::new(LocalToolProvider::new(
-                self.todo_store.clone(),
-                self.security.clone(),
-            )),
+            Arc::new(
+                LocalToolProvider::new(self.todo_store.clone(), self.security.clone())
+                    .with_checkpoint(self.checkpoint_recorder()),
+            ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];
         if let Some(mcp) = &self.mcp_manager {
@@ -554,23 +674,20 @@ impl App<'_> {
                 crate::agents::AgentPolicyFactory::Sync(self.work_mode),
             ),
             WorkMode::Auto => {
-                let model_str = self
-                    .config
-                    .classifier_model
-                    .clone()
-                    .unwrap_or_else(|| self.provider_manager.default_classifier_model());
+                let model_str = self.effective_classifier_model();
                 let (c_client, c_model_name) = self.provider_manager.resolve(&model_str)?;
+                let top_logprobs = self.effective_classifier_top_logprobs();
                 (
                     RunnerPolicy::Llm(Box::new(LlmPolicy {
                         client: c_client.clone(),
                         model_name: c_model_name.clone(),
-                        top_logprobs: self.config.classifier_top_logprobs,
+                        top_logprobs,
                         no_logprobs: self.classifier_no_logprobs.clone(),
                     })),
                     crate::agents::AgentPolicyFactory::Llm(Box::new(LlmPolicy {
                         client: c_client.clone(),
                         model_name: c_model_name,
-                        top_logprobs: self.config.classifier_top_logprobs,
+                        top_logprobs,
                         no_logprobs: self.classifier_no_logprobs.clone(),
                     })),
                 )
@@ -596,6 +713,7 @@ impl App<'_> {
                 self.work_mode.icon(),
                 self.work_mode.label()
             ),
+            checkpoint: self.checkpoint_recorder(),
         };
         base_providers.push(Arc::new(crate::tools::provider::AgentToolProvider::new(
             self.agents.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -136,7 +136,6 @@ pub(crate) struct SessionState {
     /// end instead of writing after every event.
     pub(crate) dirty: bool,
     pub(crate) classifier_model_override: ModelOverride,
-    pub(crate) classifier_top_logprobs_override: Option<u8>,
     pub(crate) compact_model_override: ModelOverride,
     pub(crate) auto_compact_override: AutoCompactOverride,
     pub(crate) compact_keep_recent_turns_override: Option<usize>,
@@ -387,7 +386,6 @@ impl App<'_> {
         let mut vision_enabled = false;
         let mut thinking_level = crate::thinking::ThinkingLevel::default();
         let mut classifier_model_override = ModelOverride::Inherit;
-        let mut classifier_top_logprobs_override = None;
         let mut compact_model_override = ModelOverride::Inherit;
         let mut auto_compact_override = AutoCompactOverride::Inherit;
         let mut compact_keep_recent_turns_override = None;
@@ -407,7 +405,6 @@ impl App<'_> {
             vision_enabled = saved.vision_enabled;
             thinking_level = saved.thinking_level;
             classifier_model_override = saved.classifier_model_override;
-            classifier_top_logprobs_override = saved.classifier_top_logprobs_override;
             compact_model_override = saved.compact_model_override;
             auto_compact_override = saved.auto_compact_override;
             compact_keep_recent_turns_override = saved.compact_keep_recent_turns_override;
@@ -507,7 +504,6 @@ impl App<'_> {
                 dirty: false,
                 did_save: false,
                 classifier_model_override,
-                classifier_top_logprobs_override,
                 compact_model_override,
                 auto_compact_override,
                 compact_keep_recent_turns_override,
@@ -594,12 +590,6 @@ impl App<'_> {
         )
     }
 
-    pub(crate) fn effective_classifier_top_logprobs(&self) -> u8 {
-        self.session
-            .classifier_top_logprobs_override
-            .unwrap_or(self.config.classifier_top_logprobs)
-    }
-
     pub(crate) fn effective_compact_model(&self) -> String {
         self.effective_model_override(
             &self.session.compact_model_override,
@@ -676,7 +666,7 @@ impl App<'_> {
             WorkMode::Auto => {
                 let model_str = self.effective_classifier_model();
                 let (c_client, c_model_name) = self.provider_manager.resolve(&model_str)?;
-                let top_logprobs = self.effective_classifier_top_logprobs();
+                let top_logprobs = self.config.classifier_top_logprobs;
                 (
                     RunnerPolicy::Llm(Box::new(LlmPolicy {
                         client: c_client.clone(),

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -93,7 +93,6 @@ fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
     session.vision_enabled = app.vision_enabled;
     session.thinking_level = app.thinking_level;
     session.classifier_model_override = app.session.classifier_model_override.clone();
-    session.classifier_top_logprobs_override = app.session.classifier_top_logprobs_override;
     session.compact_model_override = app.session.compact_model_override.clone();
     session.auto_compact_override = app.session.auto_compact_override.clone();
     session.compact_keep_recent_turns_override = app.session.compact_keep_recent_turns_override;

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -73,7 +73,11 @@ pub(crate) fn save_session(app: &mut App<'_>) {
     session.current_model = Some(app.current_model.clone());
     session.vision_enabled = app.vision_enabled;
     session.thinking_level = app.thinking_level;
-    session.classifier_model = app.config.classifier_model.clone();
+    session.classifier_model_override = app.session.classifier_model_override.clone();
+    session.classifier_top_logprobs_override = app.session.classifier_top_logprobs_override;
+    session.compact_model_override = app.session.compact_model_override.clone();
+    session.auto_compact_override = app.session.auto_compact_override.clone();
+    session.compact_keep_recent_turns_override = app.session.compact_keep_recent_turns_override;
     session.todos = app.todo_list.todos.clone();
     session.activated_skills = app.skill_registry.activated_names().to_vec();
     session.skill_selection_saved = true;
@@ -115,11 +119,17 @@ pub(crate) fn persist_config(app: &mut App<'_>) {
 
 /// Delete the session file and start a fresh session with a new UUID.
 pub(crate) fn delete_session(app: &mut App<'_>) {
+    if let Some(store) = &app.checkpoint_store {
+        let _ = store.lock().unwrap().delete_all();
+    }
     if let Some(mgr) = &app.session.mgr {
         let _ = mgr.delete(&app.session.uuid);
         let new_session = mgr.create();
         app.session.uuid = new_session.uuid;
     }
+    app.checkpoint_store = crate::checkpoint::CheckpointStore::for_session(&app.session.uuid)
+        .map(|store| std::sync::Arc::new(std::sync::Mutex::new(store)));
+    app.current_checkpoint_id = None;
 }
 
 #[cfg(test)]

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -44,9 +44,28 @@ pub(crate) fn flush_if_dirty(app: &mut App<'_>) {
 
 /// Persist the current conversation to the session file.
 pub(crate) fn save_session(app: &mut App<'_>) {
+    if let Err(e) = persist_session(app) {
+        app.conversation_panel
+            .add_error_string(format!("session save: {e}"));
+    }
+}
+
+/// Persist the current session and report failures to callers that must not
+/// proceed without a durable source snapshot (notably conversation forks).
+pub(crate) fn save_session_checked(app: &mut App<'_>) -> Result<(), String> {
+    if persist_session(app)? {
+        Ok(())
+    } else {
+        Err("the current session has no persistable user input".to_string())
+    }
+}
+
+fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
     app.session.dirty = false;
     app.sync_todos_from_store();
-    let Some(mgr) = &app.session.mgr else { return };
+    let Some(mgr) = &app.session.mgr else {
+        return Ok(false);
+    };
     let mut items: Vec<MessageItem> = app.conversation_panel.items_snapshot();
     remove_transient_items(&mut items);
     // Don't persist a session with no user input — there's nothing worth
@@ -54,7 +73,7 @@ pub(crate) fn save_session(app: &mut App<'_>) {
     // (developer-role) input message, which `first_user_text` picks up, so a
     // session that ran `/init` still counts as having input.
     if helpers::first_user_text(&items).is_none() {
-        return;
+        return Ok(false);
     }
     let mut session = mgr.load(&app.session.uuid).unwrap_or_else(|| {
         let mut s = mgr.create();
@@ -82,12 +101,9 @@ pub(crate) fn save_session(app: &mut App<'_>) {
     session.activated_skills = app.skill_registry.activated_names().to_vec();
     session.skill_selection_saved = true;
     session.tasks = crate::tasks::persist_all();
-    match mgr.save(&mut session) {
-        Ok(()) => app.session.did_save = true,
-        Err(e) => app
-            .conversation_panel
-            .add_error_string(format!("session save: {e}")),
-    }
+    mgr.save(&mut session)?;
+    app.session.did_save = true;
+    Ok(true)
 }
 
 fn remove_transient_items(items: &mut Vec<MessageItem>) {

--- a/src/app/surface.rs
+++ b/src/app/surface.rs
@@ -48,6 +48,9 @@ impl AgentSurface for TuiSurface {
             RunnerEvent::StreamChunk(b) => AppEvent::ChunkReceived(self.operation_id, Box::new(*b)),
             RunnerEvent::ResponseCommitted => AppEvent::ResponseCommitted(self.operation_id),
             RunnerEvent::Phase(p) => AppEvent::RunnerPhase(self.operation_id, p),
+            RunnerEvent::UsageSafePoint { input_tokens } => {
+                AppEvent::UsageSafePoint(self.operation_id, input_tokens)
+            }
             // These are read from the shared conversation directly.
             RunnerEvent::Assistant(_) | RunnerEvent::ToolCall { .. } => return,
         };

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,562 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+//! Per-session rewind checkpoints for conversation state and built-in file
+//! edits. File bodies are content-addressed so repeated edits do not duplicate
+//! data on disk.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FileChange {
+    #[serde(default)]
+    pub(crate) sequence: u64,
+    pub(crate) path: PathBuf,
+    pub(crate) existed: bool,
+    pub(crate) before_blob: Option<String>,
+    pub(crate) after_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Checkpoint {
+    pub(crate) id: u64,
+    pub(crate) prompt: String,
+    #[serde(default)]
+    pub(crate) label: Option<String>,
+    pub(crate) conversation_cutoff: usize,
+    pub(crate) todos: Vec<crate::todos::Todo>,
+    pub(crate) files: Vec<FileChange>,
+    #[serde(default)]
+    pub(crate) recovery: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Manifest {
+    #[serde(default)]
+    checkpoints: Vec<Checkpoint>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RestoreReport {
+    pub(crate) restored: usize,
+    pub(crate) conflicts: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CheckpointStore {
+    root: PathBuf,
+    manifest: Manifest,
+    next_id: u64,
+    next_sequence: u64,
+}
+
+impl CheckpointStore {
+    pub(crate) fn for_session(uuid: &str) -> Option<Self> {
+        let root = dirs::config_dir()?
+            .join("programmer")
+            .join("checkpoints")
+            .join(uuid);
+        Some(Self::at(root))
+    }
+
+    fn at(root: PathBuf) -> Self {
+        let manifest: Manifest = std::fs::read(root.join("manifest.json"))
+            .ok()
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            .unwrap_or_default();
+        let next_id = manifest
+            .checkpoints
+            .iter()
+            .map(|checkpoint| checkpoint.id)
+            .max()
+            .unwrap_or(0)
+            .wrapping_add(1);
+        let next_sequence = manifest
+            .checkpoints
+            .iter()
+            .flat_map(|checkpoint| checkpoint.files.iter())
+            .map(|change| change.sequence)
+            .max()
+            .unwrap_or(0)
+            .wrapping_add(1);
+        Self {
+            root,
+            manifest,
+            next_id,
+            next_sequence,
+        }
+    }
+
+    pub(crate) fn checkpoints(&self) -> &[Checkpoint] {
+        &self.manifest.checkpoints
+    }
+
+    pub(crate) fn checkpoint(&self, id: u64) -> Option<&Checkpoint> {
+        self.manifest
+            .checkpoints
+            .iter()
+            .find(|checkpoint| checkpoint.id == id)
+    }
+
+    pub(crate) fn has_file_changes_for_restore(&self, target_id: u64) -> bool {
+        let target_is_recovery = self
+            .checkpoint(target_id)
+            .is_some_and(|checkpoint| checkpoint.recovery);
+        self.manifest.checkpoints.iter().any(|checkpoint| {
+            let selected = if target_is_recovery {
+                checkpoint.id == target_id
+            } else {
+                checkpoint.id >= target_id && !checkpoint.recovery
+            };
+            selected && !checkpoint.files.is_empty()
+        })
+    }
+
+    pub(crate) fn begin(
+        &mut self,
+        prompt: String,
+        conversation_cutoff: usize,
+        todos: Vec<crate::todos::Todo>,
+    ) -> Result<u64, String> {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.manifest.checkpoints.push(Checkpoint {
+            id,
+            prompt,
+            label: None,
+            conversation_cutoff,
+            todos,
+            files: Vec::new(),
+            recovery: false,
+        });
+        self.persist()?;
+        Ok(id)
+    }
+
+    pub(crate) fn record_before(&mut self, id: u64, path: &Path) -> Result<(), String> {
+        let path = absolute(path)?;
+        let Some(checkpoint_index) = self
+            .manifest
+            .checkpoints
+            .iter()
+            .position(|checkpoint| checkpoint.id == id)
+        else {
+            return Ok(());
+        };
+        if self.manifest.checkpoints[checkpoint_index]
+            .files
+            .iter()
+            .any(|change| change.path == path)
+        {
+            return Ok(());
+        }
+        let before = match std::fs::read(&path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => return Err(format!("read {}: {error}", path.display())),
+        };
+        let before_blob = before
+            .as_deref()
+            .map(|bytes| self.write_blob(bytes))
+            .transpose()?;
+        let sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.manifest.checkpoints[checkpoint_index]
+            .files
+            .push(FileChange {
+                sequence,
+                path,
+                existed: before.is_some(),
+                before_blob,
+                after_hash: None,
+            });
+        self.persist()
+    }
+
+    pub(crate) fn record_after(&mut self, id: u64, path: &Path) -> Result<(), String> {
+        let path = absolute(path)?;
+        let after_hash = std::fs::read(&path).ok().map(|bytes| hash(&bytes));
+        let Some(change) = self
+            .manifest
+            .checkpoints
+            .iter_mut()
+            .find(|checkpoint| checkpoint.id == id)
+            .and_then(|checkpoint| {
+                checkpoint
+                    .files
+                    .iter_mut()
+                    .find(|change| change.path == path)
+            })
+        else {
+            return Ok(());
+        };
+        change.after_hash = after_hash;
+        self.persist()
+    }
+
+    pub(crate) fn discard_unfinished(&mut self, id: u64, path: &Path) -> Result<(), String> {
+        let path = absolute(path)?;
+        if let Some(checkpoint) = self
+            .manifest
+            .checkpoints
+            .iter_mut()
+            .find(|checkpoint| checkpoint.id == id)
+        {
+            checkpoint
+                .files
+                .retain(|change| change.path != path || change.after_hash.is_some());
+        }
+        self.persist()
+    }
+
+    pub(crate) fn restore_files(&mut self, target_id: u64) -> Result<RestoreReport, String> {
+        let target_is_recovery = self
+            .checkpoint(target_id)
+            .is_some_and(|checkpoint| checkpoint.recovery);
+        let mut changes = self
+            .manifest
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| {
+                if target_is_recovery {
+                    checkpoint.id == target_id
+                } else {
+                    checkpoint.id >= target_id && !checkpoint.recovery
+                }
+            })
+            .rev()
+            .flat_map(|checkpoint| checkpoint.files.iter().rev().cloned())
+            .collect::<Vec<_>>();
+        changes.sort_by_key(|change| std::cmp::Reverse(change.sequence));
+        let mut report = RestoreReport {
+            restored: 0,
+            conflicts: Vec::new(),
+        };
+        let mut seen = std::collections::HashSet::new();
+        for change in &changes {
+            if !seen.insert(change.path.clone()) {
+                continue;
+            }
+            let current = std::fs::read(&change.path).ok();
+            let current_hash = current.as_deref().map(hash);
+            if current_hash != change.after_hash {
+                report.conflicts.push(change.path.clone());
+            }
+        }
+        if !report.conflicts.is_empty() {
+            return Ok(report);
+        }
+        for change in changes {
+            if change.existed {
+                let blob = change
+                    .before_blob
+                    .as_deref()
+                    .ok_or_else(|| "checkpoint is missing a before blob".to_string())?;
+                let bytes = std::fs::read(self.root.join("blobs").join(blob))
+                    .map_err(|error| format!("read checkpoint blob {blob}: {error}"))?;
+                if let Some(parent) = change.path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+                }
+                std::fs::write(&change.path, bytes)
+                    .map_err(|error| format!("restore {}: {error}", change.path.display()))?;
+            } else if change.path.exists() {
+                std::fs::remove_file(&change.path)
+                    .map_err(|error| format!("remove {}: {error}", change.path.display()))?;
+            }
+            report.restored += 1;
+        }
+        Ok(report)
+    }
+
+    pub(crate) fn begin_recovery(
+        &mut self,
+        target_id: u64,
+        conversation_cutoff: usize,
+        todos: Vec<crate::todos::Todo>,
+    ) -> Result<u64, String> {
+        let target_is_recovery = self
+            .checkpoint(target_id)
+            .is_some_and(|checkpoint| checkpoint.recovery);
+        let paths = self
+            .manifest
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| {
+                if target_is_recovery {
+                    checkpoint.id == target_id
+                } else {
+                    checkpoint.id >= target_id && !checkpoint.recovery
+                }
+            })
+            .flat_map(|checkpoint| checkpoint.files.iter().map(|change| change.path.clone()))
+            .collect::<std::collections::HashSet<_>>();
+        let id = self.begin(String::new(), conversation_cutoff, todos)?;
+        let checkpoint = self
+            .manifest
+            .checkpoints
+            .iter_mut()
+            .find(|checkpoint| checkpoint.id == id)
+            .expect("new recovery checkpoint exists");
+        checkpoint.recovery = true;
+        checkpoint.label = Some(format!("Recovery before rewind to #{target_id}"));
+        self.persist()?;
+        for path in paths {
+            self.record_before(id, &path)?;
+        }
+        Ok(id)
+    }
+
+    pub(crate) fn finalize_recovery(&mut self, id: u64) -> Result<(), String> {
+        let paths = self
+            .checkpoint(id)
+            .map(|checkpoint| {
+                checkpoint
+                    .files
+                    .iter()
+                    .map(|change| change.path.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for path in paths {
+            self.record_after(id, &path)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn discard_checkpoint(&mut self, id: u64) -> Result<(), String> {
+        self.manifest
+            .checkpoints
+            .retain(|checkpoint| checkpoint.id != id);
+        self.persist()
+    }
+
+    /// Keep prompt cutoffs aligned when a compaction marker is inserted into
+    /// the middle of the persisted conversation.
+    pub(crate) fn record_conversation_insertion(&mut self, at: usize) -> Result<(), String> {
+        for checkpoint in &mut self.manifest.checkpoints {
+            if checkpoint.conversation_cutoff >= at {
+                checkpoint.conversation_cutoff = checkpoint.conversation_cutoff.saturating_add(1);
+            }
+        }
+        self.persist()
+    }
+
+    pub(crate) fn truncate_after(
+        &mut self,
+        target_id: u64,
+        preserve_id: Option<u64>,
+    ) -> Result<(), String> {
+        self.manifest
+            .checkpoints
+            .retain(|checkpoint| checkpoint.id < target_id || Some(checkpoint.id) == preserve_id);
+        self.persist()
+    }
+
+    pub(crate) fn delete_all(&mut self) -> Result<(), String> {
+        if self.root.exists() {
+            std::fs::remove_dir_all(&self.root)
+                .map_err(|error| format!("delete checkpoints: {error}"))?;
+        }
+        self.manifest = Manifest::default();
+        Ok(())
+    }
+
+    fn write_blob(&self, bytes: &[u8]) -> Result<String, String> {
+        let digest = hash(bytes);
+        let dir = self.root.join("blobs");
+        std::fs::create_dir_all(&dir)
+            .map_err(|error| format!("create checkpoint blobs: {error}"))?;
+        let path = dir.join(&digest);
+        if !path.exists() {
+            std::fs::write(&path, bytes)
+                .map_err(|error| format!("write checkpoint blob: {error}"))?;
+        }
+        Ok(digest)
+    }
+
+    fn persist(&self) -> Result<(), String> {
+        std::fs::create_dir_all(&self.root)
+            .map_err(|error| format!("create checkpoint directory: {error}"))?;
+        let path = self.root.join("manifest.json");
+        let temp = self.root.join("manifest.tmp");
+        let json = serde_json::to_vec_pretty(&self.manifest)
+            .map_err(|error| format!("serialize checkpoints: {error}"))?;
+        std::fs::write(&temp, json)
+            .map_err(|error| format!("write checkpoint manifest: {error}"))?;
+        std::fs::rename(&temp, &path)
+            .map_err(|error| format!("replace checkpoint manifest: {error}"))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CheckpointRecorder {
+    pub(crate) store: std::sync::Arc<std::sync::Mutex<CheckpointStore>>,
+    pub(crate) checkpoint_id: u64,
+}
+
+impl CheckpointRecorder {
+    pub(crate) fn before_path(&self, path: &Path) -> Result<(), String> {
+        self.store
+            .lock()
+            .map_err(|_| "checkpoint store lock poisoned".to_string())?
+            .record_before(self.checkpoint_id, path)
+    }
+
+    pub(crate) fn after_path(&self, path: &Path) -> Result<(), String> {
+        self.store
+            .lock()
+            .map_err(|_| "checkpoint store lock poisoned".to_string())?
+            .record_after(self.checkpoint_id, path)
+    }
+
+    pub(crate) fn discard_path(&self, path: &Path) -> Result<(), String> {
+        self.store
+            .lock()
+            .map_err(|_| "checkpoint store lock poisoned".to_string())?
+            .discard_unfinished(self.checkpoint_id, path)
+    }
+}
+
+pub(crate) fn path_from_tool_arguments(arguments: &str) -> Option<PathBuf> {
+    serde_json::from_str::<serde_json::Value>(arguments)
+        .ok()?
+        .get("path")?
+        .as_str()
+        .map(PathBuf::from)
+}
+
+fn absolute(path: &Path) -> Result<PathBuf, String> {
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("current directory: {error}"))?
+            .join(path)
+    };
+    if joined.exists() {
+        return std::fs::canonicalize(&joined)
+            .map_err(|error| format!("resolve {}: {error}", joined.display()));
+    }
+    let parent = joined.parent().unwrap_or_else(|| Path::new("."));
+    let resolved_parent = std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+    Ok(joined
+        .file_name()
+        .map_or(resolved_parent.clone(), |name| resolved_parent.join(name)))
+}
+
+fn hash(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (PathBuf, CheckpointStore) {
+        let root =
+            std::env::temp_dir().join(format!("programmer-checkpoint-{}", uuid::Uuid::new_v4()));
+        let store = CheckpointStore::at(root.clone());
+        (root, store)
+    }
+
+    #[test]
+    fn restores_multiple_versions_in_reverse_order() {
+        let (root, mut store) = temp_store();
+        std::fs::create_dir_all(&root).unwrap();
+        let file = root.join("file.txt");
+        std::fs::write(&file, b"a").unwrap();
+
+        let first = store.begin("first".into(), 0, Vec::new()).unwrap();
+        store.record_before(first, &file).unwrap();
+        std::fs::write(&file, b"b").unwrap();
+        store.record_after(first, &file).unwrap();
+
+        let second = store.begin("second".into(), 0, Vec::new()).unwrap();
+        store.record_before(second, &file).unwrap();
+        std::fs::write(&file, b"c").unwrap();
+        store.record_after(second, &file).unwrap();
+
+        let report = store.restore_files(first).unwrap();
+        assert!(report.conflicts.is_empty());
+        assert_eq!(std::fs::read(&file).unwrap(), b"a");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn external_changes_abort_before_any_file_is_restored() {
+        let (root, mut store) = temp_store();
+        std::fs::create_dir_all(&root).unwrap();
+        let first_file = root.join("first.txt");
+        let second_file = root.join("second.txt");
+        std::fs::write(&first_file, b"before-1").unwrap();
+        std::fs::write(&second_file, b"before-2").unwrap();
+        let checkpoint = store.begin("change".into(), 0, Vec::new()).unwrap();
+        for (path, after) in [
+            (&first_file, b"after-1".as_slice()),
+            (&second_file, b"after-2".as_slice()),
+        ] {
+            store.record_before(checkpoint, path).unwrap();
+            std::fs::write(path, after).unwrap();
+            store.record_after(checkpoint, path).unwrap();
+        }
+        std::fs::write(&second_file, b"external").unwrap();
+
+        let report = store.restore_files(checkpoint).unwrap();
+        assert_eq!(
+            report.conflicts,
+            vec![std::fs::canonicalize(&second_file).unwrap()]
+        );
+        assert_eq!(std::fs::read(&first_file).unwrap(), b"after-1");
+        assert_eq!(std::fs::read(&second_file).unwrap(), b"external");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn recovery_checkpoint_can_undo_a_rewind() {
+        let (root, mut store) = temp_store();
+        std::fs::create_dir_all(&root).unwrap();
+        let file = root.join("file.txt");
+        std::fs::write(&file, b"before").unwrap();
+        let checkpoint = store.begin("change".into(), 0, Vec::new()).unwrap();
+        store.record_before(checkpoint, &file).unwrap();
+        std::fs::write(&file, b"after").unwrap();
+        store.record_after(checkpoint, &file).unwrap();
+
+        let recovery = store.begin_recovery(checkpoint, 0, Vec::new()).unwrap();
+        assert!(
+            store
+                .restore_files(checkpoint)
+                .unwrap()
+                .conflicts
+                .is_empty()
+        );
+        store.finalize_recovery(recovery).unwrap();
+        store.truncate_after(checkpoint, Some(recovery)).unwrap();
+        assert_eq!(std::fs::read(&file).unwrap(), b"before");
+
+        assert!(store.restore_files(recovery).unwrap().conflicts.is_empty());
+        assert_eq!(std::fs::read(&file).unwrap(), b"after");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn compaction_insertion_keeps_conversation_cutoffs_aligned() {
+        let (root, mut store) = temp_store();
+        let before = store.begin("before".into(), 2, Vec::new()).unwrap();
+        let at = store.begin("at".into(), 5, Vec::new()).unwrap();
+        let after = store.begin("after".into(), 8, Vec::new()).unwrap();
+
+        store.record_conversation_insertion(5).unwrap();
+
+        assert_eq!(store.checkpoint(before).unwrap().conversation_cutoff, 2);
+        assert_eq!(store.checkpoint(at).unwrap().conversation_cutoff, 6);
+        assert_eq!(store.checkpoint(after).unwrap().conversation_cutoff, 9);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -358,6 +358,37 @@ impl CheckpointStore {
         self.persist()
     }
 
+    /// Seed a fork with the conversation checkpoints preceding `target_id`.
+    /// File snapshots belong to the source branch's code timeline, so they are
+    /// deliberately omitted from the fork.
+    pub(crate) fn copy_conversation_history_before(
+        &mut self,
+        source: &Self,
+        target_id: u64,
+    ) -> Result<(), String> {
+        self.manifest.checkpoints = source
+            .manifest
+            .checkpoints
+            .iter()
+            .filter(|checkpoint| checkpoint.id < target_id && !checkpoint.recovery)
+            .cloned()
+            .map(|mut checkpoint| {
+                checkpoint.files.clear();
+                checkpoint
+            })
+            .collect();
+        self.next_id = self
+            .manifest
+            .checkpoints
+            .iter()
+            .map(|checkpoint| checkpoint.id)
+            .max()
+            .unwrap_or(0)
+            .wrapping_add(1);
+        self.next_sequence = 1;
+        self.persist()
+    }
+
     pub(crate) fn delete_all(&mut self) -> Result<(), String> {
         if self.root.exists() {
             std::fs::remove_dir_all(&self.root)
@@ -558,5 +589,37 @@ mod tests {
         assert_eq!(store.checkpoint(at).unwrap().conversation_cutoff, 6);
         assert_eq!(store.checkpoint(after).unwrap().conversation_cutoff, 9);
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn fork_copies_only_earlier_conversation_checkpoints() {
+        let (source_root, mut source) = temp_store();
+        let (fork_root, mut fork) = temp_store();
+        std::fs::create_dir_all(&source_root).unwrap();
+        let file = source_root.join("file.txt");
+        std::fs::write(&file, b"before").unwrap();
+
+        let first = source.begin("first".into(), 0, Vec::new()).unwrap();
+        source.record_before(first, &file).unwrap();
+        std::fs::write(&file, b"after").unwrap();
+        source.record_after(first, &file).unwrap();
+        let selected = source.begin("selected".into(), 2, Vec::new()).unwrap();
+        let later = source.begin("later".into(), 4, Vec::new()).unwrap();
+
+        fork.copy_conversation_history_before(&source, selected)
+            .unwrap();
+
+        assert_eq!(fork.checkpoints().len(), 1);
+        assert_eq!(fork.checkpoints()[0].id, first);
+        assert!(fork.checkpoints()[0].files.is_empty());
+        assert!(fork.checkpoint(selected).is_none());
+        assert!(fork.checkpoint(later).is_none());
+        assert_eq!(
+            fork.begin("branch".into(), 2, Vec::new()).unwrap(),
+            selected
+        );
+
+        std::fs::remove_dir_all(source_root).unwrap();
+        std::fs::remove_dir_all(fork_root).unwrap();
     }
 }

--- a/src/classifier/llm.rs
+++ b/src/classifier/llm.rs
@@ -61,37 +61,44 @@ enum FastResult {
     NoLogprobs,
 }
 
+/// Shared configuration and context for a batch of LLM classifications.
+///
+/// Bundles the fields that stay constant across every call in a batch (client,
+/// model, the two context strings, and the logprobs ceiling) so the per-call
+/// function takes one value instead of six.
+pub struct ClassifyContext<'a> {
+    pub client: &'a Client<OpenAIConfig>,
+    pub model: &'a str,
+    /// `light_context` (fast path) carries just the working directory and user
+    /// request — enough to anchor the yes/no decision without burning tokens on
+    /// assistant replies and tool outputs that the single-token probe can't use.
+    pub light_context: &'a str,
+    /// `full_context` (reasoned fallback) adds assistant replies, tool outputs,
+    /// and the recent call history — it is only sent when the fast path couldn't
+    /// confidently approve, so the model has the full picture when it re-evaluates
+    /// with reasoning.
+    pub full_context: &'a str,
+    pub top_logprobs: u8,
+}
+
 /// Classify one tool call with the LLM.
-///
-/// `light_context` (fast path) carries just the working directory and user
-/// request — enough to anchor the yes/no decision without burning tokens on
-/// assistant replies and tool outputs that the single-token probe can't use.
-///
-/// `full_context` (reasoned fallback) adds assistant replies, tool outputs,
-/// and the recent call history — it is only sent when the fast path couldn't
-/// confidently approve, so the model has the full picture when it re-evaluates
-/// with reasoning.
 ///
 /// `try_logprobs` should be `false` when the model is already known not to
 /// support logprobs, so we skip straight to the merged reason-generating call.
 pub async fn classify_tool_call(
-    client: &Client<OpenAIConfig>,
-    model: &str,
+    ctx: &ClassifyContext<'_>,
     tool_name: &str,
     arguments: &str,
-    light_context: &str,
-    full_context: &str,
     try_logprobs: bool,
-    top_logprobs: u8,
 ) -> ClassifyOutcome {
     if try_logprobs {
         match classify_fast(
-            client,
-            model,
+            ctx.client,
+            ctx.model,
             tool_name,
             arguments,
-            light_context,
-            top_logprobs,
+            ctx.light_context,
+            ctx.top_logprobs,
         )
         .await
         {
@@ -106,22 +113,40 @@ pub async fn classify_tool_call(
                 // reasoning so the model gets a chance to approve after seeing
                 // the bigger picture, reducing false positives.
                 return ClassifyOutcome {
-                    verdict: classify_reasoned(client, model, tool_name, arguments, full_context)
-                        .await,
+                    verdict: classify_reasoned(
+                        ctx.client,
+                        ctx.model,
+                        tool_name,
+                        arguments,
+                        ctx.full_context,
+                    )
+                    .await,
                     logprobs_missing: false,
                 };
             }
             Ok(FastResult::Ambiguous) => {
                 return ClassifyOutcome {
-                    verdict: classify_reasoned(client, model, tool_name, arguments, full_context)
-                        .await,
+                    verdict: classify_reasoned(
+                        ctx.client,
+                        ctx.model,
+                        tool_name,
+                        arguments,
+                        ctx.full_context,
+                    )
+                    .await,
                     logprobs_missing: false,
                 };
             }
             Ok(FastResult::NoLogprobs) => {
                 return ClassifyOutcome {
-                    verdict: classify_reasoned(client, model, tool_name, arguments, full_context)
-                        .await,
+                    verdict: classify_reasoned(
+                        ctx.client,
+                        ctx.model,
+                        tool_name,
+                        arguments,
+                        ctx.full_context,
+                    )
+                    .await,
                     logprobs_missing: true,
                 };
             }
@@ -138,7 +163,14 @@ pub async fn classify_tool_call(
 
     // Known to lack logprobs: go straight to the merged path.
     ClassifyOutcome {
-        verdict: classify_reasoned(client, model, tool_name, arguments, full_context).await,
+        verdict: classify_reasoned(
+            ctx.client,
+            ctx.model,
+            tool_name,
+            arguments,
+            ctx.full_context,
+        )
+        .await,
         logprobs_missing: true,
     }
 }

--- a/src/classifier/mod.rs
+++ b/src/classifier/mod.rs
@@ -221,7 +221,7 @@ pub fn needs_review(tool_name: &str, arguments: &str) -> bool {
 // ---------------------------------------------------------------------------
 
 mod llm;
-pub use llm::classify_tool_call;
+pub use llm::{ClassifyContext, classify_tool_call};
 
 #[cfg(test)]
 mod tests {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -89,7 +89,7 @@ pub fn copy(text: &str) -> bool {
         if set_clipboard_windows(text) {
             return true;
         }
-        return osc52(text).is_ok();
+        osc52(text).is_ok()
     }
     #[cfg(not(windows))]
     {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -44,19 +44,21 @@ pub enum Command {
     Help,
     Session,
     Usage,
+    Rewind,
     Todo,
     /// `/skill <name|list|off>` — activate, list, or clear skills.
     Skill(String),
     /// `/mcp <show|manage>` — list or manage MCP servers.
     Mcp(String),
+    /// `/diagnostics <manage|update>` — edit the project diagnostics profile
+    /// or immediately refresh its current findings.
+    Diagnostics(String),
     /// `/plan <approve|cancel>` — plan mode control.
     Plan(String),
     /// `/terminal [id|clear]` — open a task or clear finished tasks.
     Terminal(String),
-    /// `/compact [provider/model]` — summarize the conversation so far and
-    /// shrink the context the model sees to that summary plus everything
-    /// after it. The optional argument picks a different model for the
-    /// summarization request only.
+    /// `/compact` compacts immediately; `show` and `set` inspect or change the
+    /// current session's compaction settings.
     Compact(String),
     /// `/thinking [level]` — set or show the reasoning effort used by the main
     /// conversation and `/compact`.
@@ -83,9 +85,11 @@ enum CommandKind {
     Help,
     Session,
     Usage,
+    Rewind,
     Todo,
     Skill,
     Mcp,
+    Diagnostics,
     Plan,
     Terminal,
     Compact,
@@ -100,6 +104,7 @@ enum CompletionKind {
     None,
     Model,
     Classifier,
+    Compact,
     Fixed(&'static [&'static str]),
     Providers,
     Skill,
@@ -155,9 +160,11 @@ impl CommandKind {
             Self::Help => Command::Help,
             Self::Session => Command::Session,
             Self::Usage => Command::Usage,
+            Self::Rewind => Command::Rewind,
             Self::Todo => Command::Todo,
             Self::Skill => Command::Skill(args),
             Self::Mcp => Command::Mcp(args),
+            Self::Diagnostics => Command::Diagnostics(args),
             Self::Plan => Command::Plan(args),
             Self::Terminal => Command::Terminal(args),
             Self::Compact => Command::Compact(args),
@@ -193,7 +200,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["n"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 20,
+            order: 22,
             usage: "/new | /n",
             description: "Start a new session (saves current)",
         }],
@@ -205,17 +212,17 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         completion: CompletionKind::Providers,
         help: &[
             HelpEntry {
-                order: 21,
+                order: 23,
                 usage: "/providers show",
                 description: "List all configured providers and models",
             },
             HelpEntry {
-                order: 22,
+                order: 24,
                 usage: "/providers manage",
                 description: "Open the provider management panel",
             },
             HelpEntry {
-                order: 23,
+                order: 25,
                 usage: "/providers refresh [provider]",
                 description: "Refetch auto-discovered provider models",
             },
@@ -227,7 +234,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["s"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 24,
+            order: 26,
             usage: "/session | /s",
             description: "Show current session info",
         }],
@@ -238,9 +245,20 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 25,
+            order: 27,
             usage: "/usage",
             description: "Show token usage for the current session",
+        }],
+    },
+    CommandSpec {
+        kind: CommandKind::Rewind,
+        name: "rewind",
+        aliases: &[],
+        completion: CompletionKind::None,
+        help: &[HelpEntry {
+            order: 28,
+            usage: "/rewind",
+            description: "Restore conversation and built-in file edits to a user prompt",
         }],
     },
     CommandSpec {
@@ -261,7 +279,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         completion: CompletionKind::Classifier,
         help: &[HelpEntry {
             order: 2,
-            usage: "/classifier [provider/model | logprobs <0-20>]",
+            usage: "/classifier [show | provider/model | current | default | logprobs <0-20|default>]",
             description: "Set/show the Auto-mode classifier settings",
         }],
     },
@@ -282,7 +300,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["t"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 19,
+            order: 21,
             usage: "/todo | /t",
             description: "Open the todo list panel",
         }],
@@ -324,6 +342,24 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         ],
     },
     CommandSpec {
+        kind: CommandKind::Diagnostics,
+        name: "diagnostics",
+        aliases: &["diag"],
+        completion: CompletionKind::Fixed(&["manage", "update"]),
+        help: &[
+            HelpEntry {
+                order: 10,
+                usage: "/diagnostics manage",
+                description: "Open the project diagnostics management panel",
+            },
+            HelpEntry {
+                order: 11,
+                usage: "/diagnostics update",
+                description: "Re-run configured checkers and refresh current diagnostics",
+            },
+        ],
+    },
+    CommandSpec {
         kind: CommandKind::Plan,
         name: "plan",
         aliases: &[],
@@ -348,12 +384,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         completion: CompletionKind::Terminal,
         help: &[
             HelpEntry {
-                order: 10,
+                order: 12,
                 usage: "/terminal [id]",
                 description: "Open the terminal viewer for a task",
             },
             HelpEntry {
-                order: 11,
+                order: 13,
                 usage: "/terminal clear",
                 description: "Clear completed, failed, and killed tasks",
             },
@@ -363,10 +399,10 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         kind: CommandKind::Compact,
         name: "compact",
         aliases: &[],
-        completion: CompletionKind::Model,
+        completion: CompletionKind::Compact,
         help: &[HelpEntry {
-            order: 12,
-            usage: "/compact [provider/model]",
+            order: 14,
+            usage: "/compact [show | set model|tokens|keep ...]",
             description: "Summarize older history to shrink the model's context",
         }],
     },
@@ -376,7 +412,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         completion: CompletionKind::Fixed(crate::thinking::ThinkingLevel::COMPLETIONS),
         help: &[HelpEntry {
-            order: 13,
+            order: 15,
             usage: "/thinking [auto|none|minimal|low|medium|high|xhigh]",
             description: "Set/show reasoning effort for chat and compaction",
         }],
@@ -387,7 +423,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         completion: CompletionKind::Fixed(&["on", "off"]),
         help: &[HelpEntry {
-            order: 14,
+            order: 16,
             usage: "/vision <on|off>",
             description: "Enable or disable image attachments for this session",
         }],
@@ -398,7 +434,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         completion: CompletionKind::Fixed(&["on", "off"]),
         help: &[HelpEntry {
-            order: 15,
+            order: 17,
             usage: "/select [on|off]",
             description: "Toggle native terminal text selection and copying",
         }],
@@ -410,17 +446,17 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         completion: CompletionKind::Permission,
         help: &[
             HelpEntry {
-                order: 16,
+                order: 18,
                 usage: "/permission show | manage",
                 description: "Show security status or open the profile management panel",
             },
             HelpEntry {
-                order: 17,
+                order: 19,
                 usage: "/permission profile <list|use|create|rename|delete>",
                 description: "List, switch, or manage named security profiles",
             },
             HelpEntry {
-                order: 18,
+                order: 20,
                 usage: "/permission mode <restricted|network|off> | <setting> <on|off>",
                 description: "Configure the active profile mode, settings, paths, and environment",
             },
@@ -432,7 +468,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["c"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 26,
+            order: 29,
             usage: "/clear | /c",
             description: "Delete this session; reset chat, todos, images, and diagnostics",
         }],
@@ -443,7 +479,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["q", "exit"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 27,
+            order: 30,
             usage: "/quit | /q",
             description: "Exit the application",
         }],
@@ -454,7 +490,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["?"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 28,
+            order: 31,
             usage: "/help | /?",
             description: "Show this help",
         }],
@@ -617,6 +653,7 @@ impl CompletionEngine {
             CompletionKind::None => None,
             CompletionKind::Model => Self::complete_model(text, cmd, pm),
             CompletionKind::Classifier => Self::complete_classifier(text, cmd, pm),
+            CompletionKind::Compact => Self::complete_compact(text, cmd, pm),
             CompletionKind::Fixed(values) => Self::complete_subcommand(text, cmd, values),
             CompletionKind::Providers => Self::complete_providers(text, cmd, pm),
             CompletionKind::Skill => Self::complete_skill(text, cmd, skill_registry),
@@ -881,7 +918,7 @@ impl CompletionEngine {
             return None;
         }
 
-        let mut candidates = ["clear", "logprobs"]
+        let mut candidates = ["show", "current", "default", "logprobs"]
             .into_iter()
             .filter(|candidate| candidate.starts_with(after_cmd))
             .map(str::to_string)
@@ -895,6 +932,61 @@ impl CompletionEngine {
             );
         }
         CompletionState::new(format!("/{cmd} "), candidates)
+    }
+
+    fn complete_compact(text: &str, cmd: &str, pm: &ProviderManager) -> Option<CompletionState> {
+        let after_cmd = text[cmd.len()..].trim_start();
+        let trailing_space = after_cmd.ends_with(char::is_whitespace);
+        let parts = after_cmd.split_whitespace().collect::<Vec<_>>();
+        if parts.is_empty() || (parts.len() == 1 && !trailing_space) {
+            let typed = parts.first().copied().unwrap_or("");
+            return CompletionState::new(
+                format!("/{cmd} "),
+                ["show", "set"]
+                    .into_iter()
+                    .filter(|value| value.starts_with(typed))
+                    .map(str::to_string)
+                    .collect(),
+            );
+        }
+        if parts.first() != Some(&"set") {
+            return None;
+        }
+        if parts.len() == 1 || (parts.len() == 2 && !trailing_space) {
+            let typed = parts.get(1).copied().unwrap_or("");
+            return CompletionState::new(
+                format!("/{cmd} set "),
+                ["model", "tokens", "keep"]
+                    .into_iter()
+                    .filter(|value| value.starts_with(typed))
+                    .map(str::to_string)
+                    .collect(),
+            );
+        }
+        let setting = parts[1];
+        let typed = parts
+            .get(2)
+            .copied()
+            .filter(|_| !trailing_space)
+            .unwrap_or("");
+        if parts.len() > 3 || (parts.len() == 3 && trailing_space) {
+            return None;
+        }
+        let mut candidates = match setting {
+            "model" => vec!["current".to_string(), "default".to_string()],
+            "tokens" => vec!["off".to_string(), "default".to_string()],
+            "keep" => vec!["default".to_string()],
+            _ => return None,
+        };
+        if setting == "model" {
+            for provider in pm.provider_names() {
+                for model in pm.models_for(provider) {
+                    candidates.push(format!("{provider}/{model}"));
+                }
+            }
+        }
+        candidates.retain(|value| value.starts_with(typed));
+        CompletionState::new(format!("/{cmd} set {setting} "), candidates)
     }
 
     fn complete_skill(
@@ -1551,12 +1643,14 @@ mod tests {
             "providers",
             "session",
             "usage",
+            "rewind",
             "mode",
             "classifier",
             "init",
             "todo",
             "skill",
             "mcp",
+            "diagnostics",
             "plan",
             "terminal",
             "compact",
@@ -1605,7 +1699,7 @@ mod tests {
                 "Set work mode (or cycle with Ctrl+T)",
             ),
             (
-                "/classifier [provider/model | logprobs <0-20>]",
+                "/classifier [show | provider/model | current | default | logprobs <0-20|default>]",
                 "Set/show the Auto-mode classifier settings",
             ),
             (
@@ -1621,13 +1715,21 @@ mod tests {
             ("/skill manage", "Open the skills management panel"),
             ("/mcp show", "List configured MCP servers and their status"),
             ("/mcp manage", "Open the MCP server management panel"),
+            (
+                "/diagnostics manage",
+                "Open the project diagnostics management panel",
+            ),
+            (
+                "/diagnostics update",
+                "Re-run configured checkers and refresh current diagnostics",
+            ),
             ("/terminal [id]", "Open the terminal viewer for a task"),
             (
                 "/terminal clear",
                 "Clear completed, failed, and killed tasks",
             ),
             (
-                "/compact [provider/model]",
+                "/compact [show | set model|tokens|keep ...]",
                 "Summarize older history to shrink the model's context",
             ),
             (
@@ -1667,6 +1769,10 @@ mod tests {
             ),
             ("/session | /s", "Show current session info"),
             ("/usage", "Show token usage for the current session"),
+            (
+                "/rewind",
+                "Restore conversation and built-in file edits to a user prompt",
+            ),
             (
                 "/clear | /c",
                 "Delete this session; reset chat, todos, images, and diagnostics",

--- a/src/config/programmer_config.rs
+++ b/src/config/programmer_config.rs
@@ -51,6 +51,17 @@ pub struct ProgrammerConfig {
         deserialize_with = "deserialize_classifier_top_logprobs"
     )]
     pub classifier_top_logprobs: u8,
+    /// Model used for manual and automatic context compaction. When absent,
+    /// the current chat model is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compact_model: Option<String>,
+    /// Start a background context compaction after an API response reports at
+    /// least this many input tokens. Zero disables automatic compaction.
+    #[serde(default = "default_auto_compact_tokens")]
+    pub auto_compact_tokens: u32,
+    /// Number of complete recent turns kept verbatim after a compaction.
+    #[serde(default = "default_compact_keep_recent_turns")]
+    pub compact_keep_recent_turns: usize,
     /// YOLO mode (run every tool call unchecked) is gated behind this flag so
     /// it can't be reached by the normal Ctrl+T cycle or a bare `/mode yolo`.
     #[serde(default)]
@@ -107,10 +118,6 @@ pub struct ProviderConfig {
     /// list (auto-discovered or manual) is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_model: Option<String>,
-    /// Model used for Auto-mode tool-call classification for this provider.
-    /// When absent, falls back to [`default_model`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub classifier_model: Option<String>,
 }
 
 /// Default co-author trailer. It's a placeholder — replace the email with one
@@ -129,6 +136,14 @@ fn default_true() -> bool {
 
 fn default_classifier_top_logprobs() -> u8 {
     crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS
+}
+
+fn default_auto_compact_tokens() -> u32 {
+    100_000
+}
+
+fn default_compact_keep_recent_turns() -> usize {
+    2
 }
 
 fn deserialize_classifier_top_logprobs<'de, D>(deserializer: D) -> Result<u8, D::Error>
@@ -156,7 +171,6 @@ impl Default for ProgrammerConfig {
                 api_key: "sk-...".to_string(),
                 models: None,
                 default_model: None,
-                classifier_model: None,
             },
         );
         let security = crate::security::SecurityConfig::default();
@@ -165,6 +179,9 @@ impl Default for ProgrammerConfig {
             providers,
             classifier_model: None,
             classifier_top_logprobs: default_classifier_top_logprobs(),
+            compact_model: None,
+            auto_compact_tokens: default_auto_compact_tokens(),
+            compact_keep_recent_turns: default_compact_keep_recent_turns(),
             allow_yolo: false,
             security,
             // Kept empty until normalization so deserialization can distinguish
@@ -221,7 +238,6 @@ impl ProgrammerConfig {
                 api_key,
                 models: Some(vec![model]),
                 default_model: None,
-                classifier_model: None,
             },
         );
         self.default_provider = "openai".to_string();

--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -201,6 +201,86 @@ impl Conversation {
         self.items.push(MessageItem::Compacted { summary });
     }
 
+    /// Return the insertion point for a compaction boundary that leaves the
+    /// requested number of most-recent turns verbatim.
+    pub fn compaction_cutoff(&self, keep_recent_turns: usize) -> Option<usize> {
+        self.compaction_cutoff_before(keep_recent_turns, self.items.len())
+    }
+
+    /// Like compaction_cutoff, but only considers the stable prefix before
+    /// stable_end. Automatic compaction passes the start of the in-flight turn
+    /// here so that turn is never summarized.
+    pub fn compaction_cutoff_before(
+        &self,
+        keep_recent_turns: usize,
+        stable_end: usize,
+    ) -> Option<usize> {
+        let stable_end = stable_end.min(self.items.len());
+        let live_start = self.items[..stable_end]
+            .iter()
+            .rposition(|item| matches!(item, MessageItem::Compacted { .. }))
+            .map_or(0, |index| index + 1);
+
+        // A request begins with one or more adjacent user/developer messages.
+        // Count that group as a single turn. This deliberately does not depend
+        // on Usage items because some compatible providers omit usage data.
+        let mut turn_starts = Vec::new();
+        let mut in_initial_input_group = false;
+        for (offset, item) in self.items[live_start..stable_end].iter().enumerate() {
+            let is_request_input = matches!(
+                item,
+                MessageItem::Input(InputItem::Item(Item::Message(ApiMessageItem::Input(_))))
+            );
+            if is_request_input {
+                if !in_initial_input_group {
+                    turn_starts.push(live_start + offset);
+                }
+                in_initial_input_group = true;
+            } else {
+                in_initial_input_group = false;
+            }
+        }
+        if turn_starts.len() <= keep_recent_turns {
+            return None;
+        }
+        let cutoff = if keep_recent_turns == 0 {
+            stable_end
+        } else {
+            turn_starts[turn_starts.len() - keep_recent_turns]
+        };
+        self.items[live_start..cutoff]
+            .iter()
+            .any(|item| matches!(item, MessageItem::Input(_) | MessageItem::Output(_)))
+            .then_some(cutoff)
+    }
+
+    /// Build the model input for the stable prefix ending at `cutoff`.
+    pub fn input_param_for_prefix(
+        &self,
+        cutoff: usize,
+        current_model: &str,
+        vision_enabled: bool,
+    ) -> InputParam {
+        let prefix = Conversation {
+            items: self.items[..cutoff.min(self.items.len())].to_vec(),
+            accumulated_usage: (0, 0),
+            mutation_version: 0,
+        };
+        prefix.to_input_param_with_vision(current_model, None, None, None, vision_enabled)
+    }
+
+    /// Install a compaction boundary at a snapshotted historical cutoff. New
+    /// messages appended while the summary was generated remain after it.
+    pub fn apply_compaction_at(&mut self, cutoff: usize, summary: String) -> bool {
+        if cutoff > self.items.len() {
+            return false;
+        }
+        self.items
+            .insert(cutoff, MessageItem::Compacted { summary });
+        self.mutation_version = self.mutation_version.wrapping_add(1);
+        true
+    }
+
     pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32) {
         self.accumulated_usage.0 += input_tokens;
         self.accumulated_usage.1 += output_tokens;
@@ -257,6 +337,12 @@ impl Conversation {
     pub fn restore_items(&mut self, items: Vec<MessageItem>) {
         self.items = items;
         self.mutation_version += 1;
+    }
+
+    pub fn truncate(&mut self, cutoff: usize) {
+        self.items.truncate(cutoff);
+        self.accumulated_usage = (0, 0);
+        self.mutation_version = self.mutation_version.wrapping_add(1);
     }
 
     /// Iterate over the current conversation items (for persistence and the
@@ -598,6 +684,57 @@ mod tests {
         assert!(matches!(&conv.items[1], MessageItem::Warning(text) if text == "keep warning"));
         assert!(!conv.remove_warning_string("missing"));
         assert_eq!(conv.mutation_version, 1);
+    }
+
+    #[test]
+    fn compaction_cutoff_keeps_recent_complete_and_active_turns() {
+        let mut conv = Conversation::new();
+        for turn in 1..=3 {
+            conv.add_input_message(user_message(&format!("turn {turn}")));
+            conv.add_output(assistant_text(&format!("answer {turn}")));
+            conv.add_usage(10, 2);
+            conv.flush_usage();
+        }
+        let stable_end = conv.items.len();
+        conv.add_input_message(user_message("active turn"));
+
+        let cutoff = conv
+            .compaction_cutoff_before(1, stable_end)
+            .expect("old prefix");
+        assert!(matches!(conv.items[cutoff - 1], MessageItem::Usage(_, _)));
+        assert!(
+            conv.items[cutoff..]
+                .iter()
+                .any(|item| { matches!(item, MessageItem::Input(_)) })
+        );
+
+        assert!(conv.apply_compaction_at(cutoff, "summary".to_string()));
+        let InputParam::Items(items) = conv.to_input_param("test/model", None, None, None) else {
+            panic!("expected item input");
+        };
+        let rendered = format!("{items:?}");
+        assert!(rendered.contains("summary"));
+        assert!(rendered.contains("turn 3"));
+        assert!(rendered.contains("active turn"));
+        assert!(!rendered.contains("turn 1"));
+    }
+
+    #[test]
+    fn compaction_cutoff_does_not_require_provider_usage() {
+        let mut conv = Conversation::new();
+        for turn in 1..=3 {
+            conv.add_input_message(user_message(&format!("turn {turn}")));
+            conv.add_output(assistant_text(&format!("answer {turn}")));
+        }
+
+        let cutoff = conv.compaction_cutoff(1).expect("old prefix");
+        let prefix = format!(
+            "{:?}",
+            conv.input_param_for_prefix(cutoff, "test/model", false)
+        );
+        assert!(prefix.contains("turn 1"));
+        assert!(prefix.contains("turn 2"));
+        assert!(!prefix.contains("turn 3"));
     }
 
     #[test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -193,7 +193,7 @@ impl HeadlessAgent {
                     .classifier_model
                     .clone()
                     .or_else(|| config.classifier_model.clone())
-                    .unwrap_or_else(|| provider_manager.default_classifier_model());
+                    .unwrap_or_else(|| model.clone());
                 let (classifier_client, classifier_name) = provider_manager
                     .resolve(&classifier_model)
                     .map(|(client, name)| (client.clone(), name))
@@ -245,6 +245,7 @@ impl HeadlessAgent {
                 args.work_mode.icon(),
                 args.work_mode.label()
             ),
+            checkpoint: None,
         };
         base_providers.push(Arc::new(AgentToolProvider::new(
             agents.clone(),
@@ -362,6 +363,7 @@ impl AgentSurface for CliSurface {
                 "type": "phase",
                 "phase": phase_label(phase),
             }),
+            RunnerEvent::UsageSafePoint { .. } => return,
         };
         println!("{event}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use std::path::Path;
 mod agents;
 mod app;
 mod cancel;
+mod checkpoint;
 mod classifier;
 mod cli;
 mod clipboard;
@@ -61,7 +62,7 @@ async fn build_mcp_classifier() -> Option<(
     let model = config
         .classifier_model
         .clone()
-        .unwrap_or_else(|| pm.default_classifier_model());
+        .unwrap_or_else(|| pm.default_model());
     pm.resolve(&model)
         .map(|(client, name)| (client.clone(), name, config.classifier_top_logprobs))
 }

--- a/src/mcp/http_server.rs
+++ b/src/mcp/http_server.rs
@@ -221,17 +221,14 @@ impl ServerState {
         let Some((client, model, top_logprobs)) = &self.classifier else {
             return Err("auto mode has no classifier model configured; refusing".to_string());
         };
-        let outcome = crate::classifier::classify_tool_call(
+        let ctx = crate::classifier::ClassifyContext {
             client,
             model,
-            name,
-            args,
-            "",
-            "",
-            true,
-            *top_logprobs,
-        )
-        .await;
+            light_context: "",
+            full_context: "",
+            top_logprobs: *top_logprobs,
+        };
+        let outcome = crate::classifier::classify_tool_call(&ctx, name, args, true).await;
         match outcome.verdict {
             Verdict::Allow => Ok(()),
             Verdict::Deny { reason } | Verdict::Ask { reason } => {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -245,17 +245,14 @@ impl McpServer {
                     .to_string(),
             );
         };
-        let outcome = crate::classifier::classify_tool_call(
+        let ctx = crate::classifier::ClassifyContext {
             client,
             model,
-            name,
-            args,
-            "",
-            "",
-            true,
-            *top_logprobs,
-        )
-        .await;
+            light_context: "",
+            full_context: "",
+            top_logprobs: *top_logprobs,
+        };
+        let outcome = crate::classifier::classify_tool_call(&ctx, name, args, true).await;
         match outcome.verdict {
             Verdict::Allow => Ok(()),
             Verdict::Deny { reason } | Verdict::Ask { reason } => {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -239,25 +239,6 @@ impl ProviderManager {
         format!("{}/{}", self.default_provider, model)
     }
 
-    /// The model string to use for Auto-mode tool-call classification when no
-    /// global `classifier_model` is configured.
-    ///
-    /// Resolution: provider's `classifier_model` → `default_model` → first in
-    /// list → `"default"`.
-    pub fn default_classifier_model(&self) -> String {
-        let config = self.configs.get(&self.default_provider);
-        let model = config
-            .and_then(|c| c.classifier_model.as_deref())
-            .or_else(|| config.and_then(|c| c.default_model.as_deref()))
-            .or_else(|| {
-                self.models
-                    .get(&self.default_provider)
-                    .and_then(|m| m.first().map(|s| s.as_str()))
-            })
-            .unwrap_or("default");
-        format!("{}/{}", self.default_provider, model)
-    }
-
     pub fn provider_names(&self) -> Vec<&str> {
         self.configs.keys().map(|s| s.as_str()).collect()
     }
@@ -340,7 +321,6 @@ mod tests {
                 api_key: "unused".to_string(),
                 models: None,
                 default_model: None,
-                classifier_model: None,
             },
         );
         let config = ProgrammerConfig {
@@ -348,6 +328,9 @@ mod tests {
             providers,
             classifier_model: None,
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
+            compact_model: None,
+            auto_compact_tokens: 100_000,
+            compact_keep_recent_turns: 2,
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),

--- a/src/runner/classify.rs
+++ b/src/runner/classify.rs
@@ -20,10 +20,8 @@
 //! calls them inline.
 
 use crate::cancel::CancellationToken;
-use crate::classifier::{Classifier, Verdict};
+use crate::classifier::{Classifier, ClassifyContext, Verdict};
 use crate::response::message_item::MessageItem;
-use async_openai::Client;
-use async_openai::config::OpenAIConfig;
 use async_openai::types::responses::{FunctionCallOutput, FunctionToolCall, OutputItem};
 use futures::StreamExt;
 use std::collections::{HashMap, HashSet};
@@ -115,12 +113,8 @@ pub(crate) fn classify_sync(
 /// caller has already run the provider front gate, so every call here genuinely
 /// needs review; each is sent straight to the LLM. Returns `None` if cancelled.
 pub(crate) async fn classify_llm(
-    client: &Client<OpenAIConfig>,
-    model_name: &str,
-    top_logprobs: u8,
+    ctx: &ClassifyContext<'_>,
     no_logprobs: &Arc<Mutex<HashSet<String>>>,
-    light_context: &str,
-    full_context: &str,
     calls: Vec<FunctionToolCall>,
     cancel: &CancellationToken,
 ) -> Option<ClassificationOutcome> {
@@ -134,20 +128,16 @@ pub(crate) async fn classify_llm(
             if cancel.is_cancelled() {
                 return None;
             }
-            let try_logprobs = !no_logprobs.lock().unwrap().contains(model_name);
+            let try_logprobs = !no_logprobs.lock().unwrap().contains(ctx.model);
             let outcome = crate::classifier::classify_tool_call(
-                client,
-                model_name,
+                ctx,
                 &call.name,
                 &call.arguments,
-                light_context,
-                full_context,
                 try_logprobs,
-                top_logprobs,
             )
             .await;
             if outcome.logprobs_missing {
-                no_logprobs.lock().unwrap().insert(model_name.to_string());
+                no_logprobs.lock().unwrap().insert(ctx.model.to_string());
             }
 
             Some(match outcome.verdict {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -178,6 +178,9 @@ pub(crate) enum RunnerEvent<'a> {
     ToolCall { name: &'a str },
     /// The turn moved to a new phase.
     Phase(RunnerPhase),
+    /// A completed API response reported its real input token count and all
+    /// function calls from that response (if any) now have paired outputs.
+    UsageSafePoint { input_tokens: u32 },
 }
 
 /// When a turn is cancelled after assistant function calls have already been
@@ -333,6 +336,9 @@ impl TurnRunner {
 
             // ---- no tool calls → the turn is done ----
             if calls.is_empty() {
+                if let Some((input_tokens, _)) = usage {
+                    surface.on_event(RunnerEvent::UsageSafePoint { input_tokens });
+                }
                 let usage = conversation.lock().unwrap().accumulated_usage;
                 return Ok(TurnResult {
                     final_text: assistant_text,
@@ -407,6 +413,9 @@ impl TurnRunner {
                         )
                         .await;
                     }
+                    if let Some((input_tokens, _)) = usage {
+                        surface.on_event(RunnerEvent::UsageSafePoint { input_tokens });
+                    }
                 }
                 None => {
                     ensure_tool_output_pairing(conversation);
@@ -473,17 +482,14 @@ impl TurnRunner {
                     let items: Vec<&MessageItem> = conv.items().collect();
                     classify::build_classifier_context(&items)
                 };
-                classify::classify_llm(
-                    &p.client,
-                    &p.model_name,
-                    p.top_logprobs,
-                    &p.no_logprobs,
-                    &light,
-                    &full,
-                    to_classify,
-                    cancel,
-                )
-                .await?
+                let ctx = crate::classifier::ClassifyContext {
+                    client: &p.client,
+                    model: &p.model_name,
+                    light_context: &light,
+                    full_context: &full,
+                    top_logprobs: p.top_logprobs,
+                };
+                classify::classify_llm(&ctx, &p.no_logprobs, to_classify, cancel).await?
             }
         };
         // Front-gate auto-approvals join whatever the classifier cleared.
@@ -983,7 +989,8 @@ mod tests {
                 // Ephemeral progress events aren't asserted on in these tests.
                 RunnerEvent::StreamChunk(_)
                 | RunnerEvent::ResponseCommitted
-                | RunnerEvent::Phase(_) => return,
+                | RunnerEvent::Phase(_)
+                | RunnerEvent::UsageSafePoint { .. } => return,
             };
             self.events.lock().unwrap().push(label);
         }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -201,11 +201,9 @@ pub(crate) struct Session {
     #[serde(default)]
     pub(crate) thinking_level: crate::thinking::ThinkingLevel,
     /// Session-only overrides. Slash commands update these values; provider
-    /// management updates the global defaults instead.
+    /// management updates their global defaults instead.
     #[serde(default)]
     pub(crate) classifier_model_override: ModelOverride,
-    #[serde(default)]
-    pub(crate) classifier_top_logprobs_override: Option<u8>,
     #[serde(default)]
     pub(crate) compact_model_override: ModelOverride,
     #[serde(default)]
@@ -288,7 +286,6 @@ impl SessionManager {
             vision_enabled: false,
             thinking_level: crate::thinking::ThinkingLevel::default(),
             classifier_model_override: ModelOverride::Inherit,
-            classifier_top_logprobs_override: None,
             compact_model_override: ModelOverride::Inherit,
             auto_compact_override: AutoCompactOverride::Inherit,
             compact_keep_recent_turns_override: None,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -26,6 +26,24 @@ use async_openai::types::responses::{
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ModelOverride {
+    #[default]
+    Inherit,
+    Current,
+    Model(String),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AutoCompactOverride {
+    #[default]
+    Inherit,
+    Disabled,
+    Tokens(u32),
+}
+
 // ---------------------------------------------------------------------------
 // Serializable mirror
 // ---------------------------------------------------------------------------
@@ -182,9 +200,18 @@ pub(crate) struct Session {
     /// Reasoning effort for main chat and compaction requests.
     #[serde(default)]
     pub(crate) thinking_level: crate::thinking::ThinkingLevel,
-    /// Auto-mode classifier model when last saved, restored on resume.
+    /// Session-only overrides. Slash commands update these values; provider
+    /// management updates the global defaults instead.
     #[serde(default)]
-    pub(crate) classifier_model: Option<String>,
+    pub(crate) classifier_model_override: ModelOverride,
+    #[serde(default)]
+    pub(crate) classifier_top_logprobs_override: Option<u8>,
+    #[serde(default)]
+    pub(crate) compact_model_override: ModelOverride,
+    #[serde(default)]
+    pub(crate) auto_compact_override: AutoCompactOverride,
+    #[serde(default)]
+    pub(crate) compact_keep_recent_turns_override: Option<usize>,
     /// Todo list carried with the session, restored on resume.
     #[serde(default)]
     pub(crate) todos: Vec<crate::todos::Todo>,
@@ -260,7 +287,11 @@ impl SessionManager {
             current_model: None,
             vision_enabled: false,
             thinking_level: crate::thinking::ThinkingLevel::default(),
-            classifier_model: None,
+            classifier_model_override: ModelOverride::Inherit,
+            classifier_top_logprobs_override: None,
+            compact_model_override: ModelOverride::Inherit,
+            auto_compact_override: AutoCompactOverride::Inherit,
+            compact_keep_recent_turns_override: None,
             todos: Vec::new(),
             activated_skills: Vec::new(),
             skill_selection_saved: false,

--- a/src/tools/provider.rs
+++ b/src/tools/provider.rs
@@ -180,6 +180,7 @@ pub(crate) struct LocalToolProvider {
     todos: Arc<Mutex<crate::todos::TodoList>>,
     security: Arc<crate::security::SecurityHandle>,
     file_scope: u64,
+    checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
 }
 
 impl LocalToolProvider {
@@ -191,6 +192,7 @@ impl LocalToolProvider {
             todos,
             security,
             file_scope: 0,
+            checkpoint: None,
         }
     }
 
@@ -203,7 +205,16 @@ impl LocalToolProvider {
             todos,
             security,
             file_scope,
+            checkpoint: None,
         }
+    }
+
+    pub(crate) fn with_checkpoint(
+        mut self,
+        checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
+    ) -> Self {
+        self.checkpoint = checkpoint;
+        self
     }
 }
 
@@ -308,14 +319,11 @@ impl ToolProvider for LocalToolProvider {
                 .map(FunctionCallOutput::Text)
         } else if call.name == write_file::NAME {
             let security = self.security.snapshot();
-            write_file::run_with_security_scope(&call.arguments, &security, self.file_scope)
-                .await
-                .map(FunctionCallOutput::Text)
+            self.run_checkpointed_file_call(call, &security, true).await
         } else if call.name == edit_file::NAME {
             let security = self.security.snapshot();
-            edit_file::run_with_security_scope(&call.arguments, &security, self.file_scope)
+            self.run_checkpointed_file_call(call, &security, false)
                 .await
-                .map(FunctionCallOutput::Text)
         } else if call.name == task::NAME {
             let security = self.security.snapshot();
             task::run_with_security(&call.arguments, &security)
@@ -328,6 +336,40 @@ impl ToolProvider for LocalToolProvider {
                 .await
                 .map(FunctionCallOutput::Text)
         }
+    }
+}
+
+impl LocalToolProvider {
+    async fn run_checkpointed_file_call(
+        &self,
+        call: &FunctionToolCall,
+        security: &crate::security::SecurityManager,
+        write: bool,
+    ) -> Result<FunctionCallOutput, String> {
+        let path = match (
+            self.checkpoint.as_ref(),
+            crate::checkpoint::path_from_tool_arguments(&call.arguments),
+        ) {
+            (Some(_), Some(path)) => {
+                Some(security.authorize_path(crate::security::policy::AccessKind::Write, path)?)
+            }
+            _ => None,
+        };
+        if let (Some(recorder), Some(path)) = (&self.checkpoint, path.as_deref()) {
+            recorder.before_path(path)?;
+        }
+        let result = if write {
+            write_file::run_with_security_scope(&call.arguments, security, self.file_scope).await
+        } else {
+            edit_file::run_with_security_scope(&call.arguments, security, self.file_scope).await
+        };
+        if let (Some(recorder), Some(path)) = (&self.checkpoint, path.as_deref()) {
+            match &result {
+                Ok(_) => recorder.after_path(path)?,
+                Err(_) => recorder.discard_path(path)?,
+            }
+        }
+        result.map(FunctionCallOutput::Text)
     }
 }
 

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -742,6 +742,57 @@ impl ConversationPanel {
         self.stick_to_bottom = true;
     }
 
+    pub fn response_started(&self) -> bool {
+        self.receiving_response
+            .as_ref()
+            .is_some_and(crate::response::partial_response::PartialResponse::started)
+    }
+
+    pub fn compaction_cutoff(&self, keep_recent_turns: usize) -> Option<usize> {
+        self.conversation
+            .lock()
+            .unwrap()
+            .compaction_cutoff(keep_recent_turns)
+    }
+
+    pub fn compaction_cutoff_before(
+        &self,
+        keep_recent_turns: usize,
+        stable_end: usize,
+    ) -> Option<usize> {
+        self.conversation
+            .lock()
+            .unwrap()
+            .compaction_cutoff_before(keep_recent_turns, stable_end)
+    }
+
+    pub fn input_param_for_prefix(
+        &self,
+        cutoff: usize,
+        current_model: &str,
+        vision_enabled: bool,
+    ) -> InputParam {
+        self.conversation.lock().unwrap().input_param_for_prefix(
+            cutoff,
+            current_model,
+            vision_enabled,
+        )
+    }
+
+    pub fn apply_compaction_at(&mut self, cutoff: usize, summary: String) -> bool {
+        let applied = self
+            .conversation
+            .lock()
+            .unwrap()
+            .apply_compaction_at(cutoff, summary);
+        if applied {
+            self.expanded_items.clear();
+            self.expanded_tool_groups.clear();
+            self.stick_to_bottom = true;
+        }
+        applied
+    }
+
     pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32) {
         self.conversation
             .lock()
@@ -776,6 +827,15 @@ impl ConversationPanel {
         self.conversation.lock().unwrap().restore_items(items);
         self.expanded_items.clear();
         self.expanded_tool_groups.clear();
+        self.stick_to_bottom = true;
+    }
+
+    pub fn truncate(&mut self, cutoff: usize) {
+        self.conversation.lock().unwrap().truncate(cutoff);
+        self.abort_receiving();
+        self.expanded_items.clear();
+        self.expanded_tool_groups.clear();
+        self.selection = None;
         self.stick_to_bottom = true;
     }
 

--- a/src/ui/components/diagnostics_panel.rs
+++ b/src/ui/components/diagnostics_panel.rs
@@ -1,0 +1,382 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+//! Full-screen editor for `.programmer/diagnostics.toml`.
+
+use crate::diagnostics::{Checker, CheckerKind, DiagnosticsProfile};
+use crate::ui::markdown_theme::palette;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Widget};
+
+const LABELS: [&str; 7] = [
+    "name",
+    "kind (command/lsp)",
+    "command",
+    "parser",
+    "pattern",
+    "run_on (comma-separated)",
+    "lint (true/false)",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PanelAction {
+    None,
+    Close,
+    Saved(DiagnosticsProfile),
+}
+
+#[derive(Debug)]
+struct Form {
+    original: Option<usize>,
+    fields: [String; 7],
+    focus: usize,
+    error: Option<String>,
+}
+
+impl Default for Form {
+    fn default() -> Self {
+        Self {
+            original: None,
+            fields: [
+                String::new(),
+                "command".to_string(),
+                String::new(),
+                "gnu".to_string(),
+                String::new(),
+                String::new(),
+                "false".to_string(),
+            ],
+            focus: 0,
+            error: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Mode {
+    List,
+    ConfirmDelete(usize),
+    Form(Box<Form>),
+}
+
+#[derive(Debug)]
+pub struct DiagnosticsPanel {
+    profile: DiagnosticsProfile,
+    selected: usize,
+    mode: Mode,
+}
+
+impl DiagnosticsPanel {
+    pub(crate) fn load() -> Result<Self, String> {
+        let cwd = std::env::current_dir().map_err(|error| error.to_string())?;
+        let profile = match DiagnosticsProfile::load(&cwd) {
+            Some(result) => result?,
+            None => DiagnosticsProfile::default(),
+        };
+        Ok(Self {
+            profile,
+            selected: 0,
+            mode: Mode::List,
+        })
+    }
+
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) -> PanelAction {
+        match &mut self.mode {
+            Mode::List => self.handle_list_key(key),
+            Mode::ConfirmDelete(_) => self.handle_confirm_key(key),
+            Mode::Form(_) => self.handle_form_key(key),
+        }
+    }
+
+    pub(crate) fn handle_paste(&mut self, data: &str) {
+        if let Mode::Form(form) = &mut self.mode {
+            let clean = data.replace(['\r', '\n'], " ");
+            form.fields[form.focus].push_str(&clean);
+        }
+    }
+
+    fn handle_list_key(&mut self, key: KeyEvent) -> PanelAction {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => return PanelAction::Close,
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.selected =
+                    (self.selected + 1).min(self.profile.checkers.len().saturating_sub(1));
+            }
+            KeyCode::Char('a') => self.mode = Mode::Form(Box::default()),
+            KeyCode::Char('e') | KeyCode::Enter => {
+                if let Some(checker) = self.profile.checkers.get(self.selected) {
+                    self.mode = Mode::Form(Box::new(Form {
+                        original: Some(self.selected),
+                        fields: checker_fields(checker),
+                        focus: 0,
+                        error: None,
+                    }));
+                }
+            }
+            KeyCode::Char('d') if !self.profile.checkers.is_empty() => {
+                self.mode = Mode::ConfirmDelete(self.selected);
+            }
+            _ => {}
+        }
+        PanelAction::None
+    }
+
+    fn handle_confirm_key(&mut self, key: KeyEvent) -> PanelAction {
+        match key.code {
+            KeyCode::Char('y' | 'Y') => {
+                let Mode::ConfirmDelete(index) = self.mode else {
+                    unreachable!();
+                };
+                self.profile.checkers.remove(index);
+                self.selected = self
+                    .selected
+                    .min(self.profile.checkers.len().saturating_sub(1));
+                self.mode = Mode::List;
+                PanelAction::Saved(self.profile.clone())
+            }
+            KeyCode::Esc | KeyCode::Char('n' | 'N') => {
+                self.mode = Mode::List;
+                PanelAction::None
+            }
+            _ => PanelAction::None,
+        }
+    }
+
+    fn handle_form_key(&mut self, key: KeyEvent) -> PanelAction {
+        let Mode::Form(form) = &mut self.mode else {
+            unreachable!();
+        };
+        match key.code {
+            KeyCode::Esc => self.mode = Mode::List,
+            KeyCode::Tab | KeyCode::Down => form.focus = (form.focus + 1) % LABELS.len(),
+            KeyCode::BackTab | KeyCode::Up => {
+                form.focus = (form.focus + LABELS.len() - 1) % LABELS.len();
+            }
+            KeyCode::Backspace => {
+                form.fields[form.focus].pop();
+            }
+            KeyCode::Char(character) => form.fields[form.focus].push(character),
+            KeyCode::Enter => return self.submit_form(),
+            _ => {}
+        }
+        PanelAction::None
+    }
+
+    fn submit_form(&mut self) -> PanelAction {
+        let Mode::Form(form) = &mut self.mode else {
+            unreachable!();
+        };
+        let checker = match checker_from_fields(&form.fields) {
+            Ok(checker) => checker,
+            Err(error) => {
+                form.error = Some(error);
+                return PanelAction::None;
+            }
+        };
+        let mut candidate = self.profile.clone();
+        if let Some(index) = form.original {
+            candidate.checkers[index] = checker;
+        } else {
+            candidate.checkers.push(checker);
+            self.selected = candidate.checkers.len() - 1;
+        }
+        if let Err(error) = candidate.validate() {
+            form.error = Some(error);
+            return PanelAction::None;
+        }
+        self.profile = candidate;
+        self.mode = Mode::List;
+        PanelAction::Saved(self.profile.clone())
+    }
+
+    pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Min(4),
+                Constraint::Length(2),
+            ])
+            .split(area);
+        Paragraph::new(Line::from(vec![
+            Span::styled("◇ Diagnostics", Style::default().fg(palette::BLUE).bold()),
+            Span::styled(
+                format!("  ({} checkers)", self.profile.checkers.len()),
+                Style::default().fg(palette::MUTED),
+            ),
+        ]))
+        .render(chunks[0], buf);
+
+        match &self.mode {
+            Mode::List | Mode::ConfirmDelete(_) => {
+                let items = self.profile.checkers.iter().map(|checker| {
+                    let kind = match checker.kind {
+                        CheckerKind::Command => "command",
+                        CheckerKind::Lsp => "lsp",
+                    };
+                    let lint = if checker.lint { "  lint" } else { "" };
+                    ListItem::new(vec![
+                        Line::from(vec![
+                            Span::styled(&checker.name, Style::default().fg(palette::TEXT).bold()),
+                            Span::styled(format!("  {kind}"), Style::default().fg(palette::CYAN)),
+                            Span::styled(lint, Style::default().fg(palette::PURPLE)),
+                        ]),
+                        Line::from(vec![
+                            Span::styled("  ", Style::default()),
+                            Span::styled(&checker.command, Style::default().fg(palette::MUTED)),
+                            Span::styled(
+                                format!("  · {}", checker.parser),
+                                Style::default().fg(palette::FAINT),
+                            ),
+                        ]),
+                    ])
+                });
+                let list = List::new(items)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(palette::BORDER))
+                            .title(" .programmer/diagnostics.toml "),
+                    )
+                    .highlight_style(Style::default().bg(palette::SURFACE))
+                    .highlight_symbol("› ");
+                let mut state = ListState::default()
+                    .with_selected((!self.profile.checkers.is_empty()).then_some(self.selected));
+                ratatui::widgets::StatefulWidget::render(list, chunks[1], buf, &mut state);
+
+                let hint = if matches!(self.mode, Mode::ConfirmDelete(_)) {
+                    Line::from(vec![
+                        Span::styled("Delete checker?  ", Style::default().fg(palette::YELLOW)),
+                        Span::styled("y", Style::default().fg(palette::GREEN).bold()),
+                        Span::styled(" yes  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("n/Esc", Style::default().fg(palette::RED).bold()),
+                        Span::styled(" cancel", Style::default().fg(palette::MUTED)),
+                    ])
+                } else {
+                    Line::from("↑↓ navigate  a add  Enter/e edit  d delete  q/Esc close")
+                };
+                Paragraph::new(hint).render(chunks[2], buf);
+            }
+            Mode::Form(form) => {
+                let mut lines = LABELS
+                    .iter()
+                    .enumerate()
+                    .map(|(index, label)| {
+                        let focused = index == form.focus;
+                        let style = if focused {
+                            Style::default().fg(palette::BLUE).bold()
+                        } else {
+                            Style::default().fg(palette::MUTED)
+                        };
+                        Line::from(vec![
+                            Span::styled(format!("{label:>26}: "), style),
+                            Span::styled(&form.fields[index], Style::default().fg(palette::TEXT)),
+                            Span::styled(
+                                if focused { "▌" } else { "" },
+                                Style::default().fg(palette::BLUE),
+                            ),
+                        ])
+                    })
+                    .collect::<Vec<_>>();
+                if let Some(error) = &form.error {
+                    lines.push(Line::from(Span::styled(
+                        error,
+                        Style::default().fg(palette::RED),
+                    )));
+                }
+                Paragraph::new(lines)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(palette::BORDER))
+                            .title(if form.original.is_some() {
+                                " Edit checker "
+                            } else {
+                                " Add checker "
+                            }),
+                    )
+                    .render(chunks[1], buf);
+                Paragraph::new("Tab/↑↓ field  Enter save  Esc cancel").render(chunks[2], buf);
+            }
+        }
+    }
+}
+
+fn checker_fields(checker: &Checker) -> [String; 7] {
+    [
+        checker.name.clone(),
+        match checker.kind {
+            CheckerKind::Command => "command",
+            CheckerKind::Lsp => "lsp",
+        }
+        .to_string(),
+        checker.command.clone(),
+        checker.parser.clone(),
+        checker.pattern.clone().unwrap_or_default(),
+        checker.run_on.join(", "),
+        checker.lint.to_string(),
+    ]
+}
+
+fn checker_from_fields(fields: &[String; 7]) -> Result<Checker, String> {
+    let name = fields[0].trim();
+    if name.is_empty() {
+        return Err("name is required".to_string());
+    }
+    let kind = match fields[1].trim().to_ascii_lowercase().as_str() {
+        "command" => CheckerKind::Command,
+        "lsp" => CheckerKind::Lsp,
+        _ => return Err("kind must be command or lsp".to_string()),
+    };
+    let lint = fields[6]
+        .trim()
+        .parse::<bool>()
+        .map_err(|_| "lint must be true or false".to_string())?;
+    Ok(Checker {
+        name: name.to_string(),
+        kind,
+        command: fields[2].trim().to_string(),
+        parser: fields[3].trim().to_string(),
+        pattern: (!fields[4].trim().is_empty()).then(|| fields[4].trim().to_string()),
+        run_on: fields[5]
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+        lint,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fields_parse_command_checker() {
+        let fields = [
+            "cargo".into(),
+            "command".into(),
+            "cargo check --message-format=json".into(),
+            "rustc-json".into(),
+            String::new(),
+            "*.rs, Cargo.toml".into(),
+            "false".into(),
+        ];
+        let checker = checker_from_fields(&fields).unwrap();
+        assert_eq!(checker.run_on, ["*.rs", "Cargo.toml"]);
+        assert_eq!(checker.kind, CheckerKind::Command);
+    }
+}

--- a/src/ui/components/input_panel/input_panel.rs
+++ b/src/ui/components/input_panel/input_panel.rs
@@ -35,6 +35,14 @@ pub struct InputPanel<'a> {
     next_image_id: usize,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct InputDraft {
+    content: String,
+    pastes: Vec<(String, String)>,
+    images: Vec<(String, InputImageContent)>,
+    next_image_id: usize,
+}
+
 impl InputPanel<'_> {
     pub fn new() -> Self {
         let mut text_area = TextArea::default();
@@ -88,6 +96,31 @@ impl InputPanel<'_> {
             text = text.replace(placeholder.as_str(), content.as_str());
         }
         text
+    }
+
+    pub(crate) fn draft_snapshot(&self) -> InputDraft {
+        InputDraft {
+            content: self.get_content(),
+            pastes: self.pastes.clone(),
+            images: self.images.clone(),
+            next_image_id: self.next_image_id,
+        }
+    }
+
+    pub(crate) fn restore_draft(&mut self, draft: InputDraft) {
+        self.clear();
+        self.text_area.insert_str(&draft.content);
+        self.pastes = draft.pastes;
+        self.images = draft.images;
+        self.next_image_id = draft.next_image_id;
+        self.history_index = -1;
+    }
+
+    pub(crate) fn remove_last_history_if(&mut self, value: &str) {
+        if self.history.last().is_some_and(|entry| entry == value) {
+            self.history.pop();
+        }
+        self.history_index = -1;
     }
 
     /// Insert pasted text at the cursor as-is.
@@ -337,6 +370,24 @@ mod tests {
         assert!(panel.add_image(image(), 320, 200));
         panel.set_content("placeholder removed");
         assert!(panel.take_images().is_empty());
+    }
+
+    #[test]
+    fn draft_snapshot_restores_pastes_and_images_after_send_drains_them() {
+        let mut panel = InputPanel::new();
+        panel.add_paste("first\nsecond".to_string());
+        assert!(panel.add_image(image(), 640, 480));
+        let expected_content = panel.get_content();
+        let expected_expanded = panel.expanded_content();
+        let draft = panel.draft_snapshot();
+
+        assert_eq!(panel.take_images().len(), 1);
+        panel.clear();
+        panel.restore_draft(draft);
+
+        assert_eq!(panel.get_content(), expected_content);
+        assert_eq!(panel.expanded_content(), expected_expanded);
+        assert_eq!(panel.take_images().len(), 1);
     }
 
     #[test]

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -16,6 +16,7 @@
 pub mod agent_panel;
 pub mod completion_popup;
 pub mod conversation_panel;
+pub mod diagnostics_panel;
 pub mod footer;
 pub mod input_panel;
 pub mod logo;
@@ -24,6 +25,7 @@ pub mod messages;
 pub mod panel_search;
 pub mod provider_panel;
 pub mod question_panel;
+pub mod rewind_panel;
 pub mod security_panel;
 pub mod sidebar;
 pub mod skills_panel;

--- a/src/ui/components/provider_panel/mod.rs
+++ b/src/ui/components/provider_panel/mod.rs
@@ -24,6 +24,7 @@ use crate::config::programmer_config::{ProgrammerConfig, ProviderConfig};
 use crate::providers::ProviderManager;
 use crate::ui::components::completion_popup::CompletionPopup;
 use crate::ui::components::panel_search::{PanelSearch, SearchKey};
+use crate::ui::markdown_theme::palette;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -70,6 +71,13 @@ struct Form {
 }
 
 #[derive(Debug)]
+struct GlobalForm {
+    fields: [String; 3],
+    focus: usize,
+    error: Option<String>,
+}
+
+#[derive(Debug)]
 enum Mode {
     List,
     ConfirmDelete(String),
@@ -80,6 +88,12 @@ enum Mode {
         filter: String,
         selected: usize,
     },
+    RoleMenu {
+        provider: String,
+        model: String,
+        selected: usize,
+    },
+    GlobalSettings(GlobalForm),
 }
 
 #[derive(Debug)]
@@ -87,6 +101,15 @@ pub struct ProviderPanel {
     mode: Mode,
     selected: usize,
     search: PanelSearch,
+}
+
+fn rename_global_model_provider(value: &mut Option<String>, old: &str, new: &str) {
+    if let Some(model) = value
+        && let Some((provider, name)) = model.split_once('/')
+        && provider == old
+    {
+        *model = format!("{new}/{name}");
+    }
 }
 
 impl ProviderPanel {
@@ -132,6 +155,8 @@ impl ProviderPanel {
             Mode::ConfirmDelete(_) => self.handle_confirm_key(key, config),
             Mode::Form(_) => self.handle_form_key(key, config, pm),
             Mode::Models { .. } => self.handle_models_key(key, config, pm),
+            Mode::RoleMenu { .. } => self.handle_role_key(key, config),
+            Mode::GlobalSettings(_) => self.handle_global_settings_key(key, config),
         }
     }
 
@@ -180,6 +205,17 @@ impl ProviderPanel {
                 }
             }
             KeyCode::Char('r') => return PanelAction::RefreshModels,
+            KeyCode::Char('g') => {
+                self.mode = Mode::GlobalSettings(GlobalForm {
+                    fields: [
+                        config.classifier_top_logprobs.to_string(),
+                        config.auto_compact_tokens.to_string(),
+                        config.compact_keep_recent_turns.to_string(),
+                    ],
+                    focus: 0,
+                    error: None,
+                });
+            }
             KeyCode::Char('e') => {
                 if let Some(name) = names.get(self.selected) {
                     let p = &config.providers[name];
@@ -223,6 +259,20 @@ impl ProviderPanel {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 let name = name.clone();
                 config.providers.remove(&name);
+                if config
+                    .classifier_model
+                    .as_deref()
+                    .is_some_and(|model| model.starts_with(&format!("{name}/")))
+                {
+                    config.classifier_model = None;
+                }
+                if config
+                    .compact_model
+                    .as_deref()
+                    .is_some_and(|model| model.starts_with(&format!("{name}/")))
+                {
+                    config.compact_model = None;
+                }
                 // Keep default_provider pointing at something that exists.
                 if config.default_provider == name {
                     config.default_provider = Self::sorted_names(config)
@@ -388,6 +438,8 @@ impl ProviderPanel {
                     if config.default_provider == *original {
                         config.default_provider = name.clone();
                     }
+                    rename_global_model_provider(&mut config.classifier_model, original, &name);
+                    rename_global_model_provider(&mut config.compact_model, original, &name);
                 }
                 config.providers.insert(
                     name.clone(),
@@ -396,7 +448,6 @@ impl ProviderPanel {
                         api_key,
                         models: None,
                         default_model: (!default_model.is_empty()).then_some(default_model),
-                        classifier_model: None,
                     },
                 );
                 // First provider ever: make it the default.
@@ -446,7 +497,7 @@ impl ProviderPanel {
     fn handle_models_key(
         &mut self,
         key: KeyEvent,
-        config: &mut ProgrammerConfig,
+        _config: &mut ProgrammerConfig,
         pm: &ProviderManager,
     ) -> PanelAction {
         let Mode::Models {
@@ -458,15 +509,23 @@ impl ProviderPanel {
             unreachable!("handle_models_key called outside Models mode");
         };
         match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
+            KeyCode::Esc => {
                 self.mode = Mode::List;
                 return PanelAction::None;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up => {
                 *selected = selected.saturating_sub(1);
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                *selected = selected.saturating_add(1);
+            KeyCode::Down => {
+                let needle = filter.to_lowercase();
+                let match_count = pm
+                    .models_for(provider)
+                    .iter()
+                    .filter(|model| model.to_lowercase().contains(&needle))
+                    .count();
+                *selected = selected
+                    .saturating_add(1)
+                    .min(match_count.saturating_sub(1));
             }
             KeyCode::Backspace => {
                 filter.pop();
@@ -485,11 +544,107 @@ impl ProviderPanel {
                     .collect();
                 let sel = (*selected).min(filtered.len().saturating_sub(1));
                 if let Some(model) = filtered.get(sel) {
-                    if let Some(pc) = config.providers.get_mut(provider) {
-                        pc.default_model = Some(model.to_string());
+                    self.mode = Mode::RoleMenu {
+                        provider: provider.clone(),
+                        model: model.to_string(),
+                        selected: 0,
+                    };
+                }
+            }
+            _ => {}
+        }
+        PanelAction::None
+    }
+
+    fn handle_role_key(&mut self, key: KeyEvent, config: &mut ProgrammerConfig) -> PanelAction {
+        let Mode::RoleMenu {
+            provider,
+            model,
+            selected,
+        } = &mut self.mode
+        else {
+            unreachable!("handle_role_key called outside RoleMenu mode");
+        };
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.mode = Mode::Models {
+                    provider: provider.clone(),
+                    filter: String::new(),
+                    selected: 0,
+                };
+                PanelAction::None
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                *selected = selected.saturating_sub(1);
+                PanelAction::None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                *selected = (*selected + 1).min(4);
+                PanelAction::None
+            }
+            KeyCode::Enter => {
+                let qualified = format!("{provider}/{model}");
+                match *selected {
+                    0 => {
+                        if let Some(provider_config) = config.providers.get_mut(provider) {
+                            provider_config.default_model = Some(model.clone());
+                        }
                     }
-                    self.mode = Mode::List;
-                    return PanelAction::Saved;
+                    1 => config.classifier_model = Some(qualified),
+                    2 => config.compact_model = Some(qualified),
+                    3 => config.classifier_model = None,
+                    4 => config.compact_model = None,
+                    _ => unreachable!(),
+                }
+                self.mode = Mode::List;
+                PanelAction::Saved
+            }
+            _ => PanelAction::None,
+        }
+    }
+
+    fn handle_global_settings_key(
+        &mut self,
+        key: KeyEvent,
+        config: &mut ProgrammerConfig,
+    ) -> PanelAction {
+        let Mode::GlobalSettings(form) = &mut self.mode else {
+            unreachable!("handle_global_settings_key called outside GlobalSettings mode");
+        };
+        match key.code {
+            KeyCode::Esc => self.mode = Mode::List,
+            KeyCode::Tab | KeyCode::Down => form.focus = (form.focus + 1) % form.fields.len(),
+            KeyCode::BackTab | KeyCode::Up => {
+                form.focus = (form.focus + form.fields.len() - 1) % form.fields.len();
+            }
+            KeyCode::Backspace => {
+                form.fields[form.focus].pop();
+            }
+            KeyCode::Char(character) if character.is_ascii_digit() => {
+                form.fields[form.focus].push(character);
+            }
+            KeyCode::Enter => {
+                let parsed = (
+                    form.fields[0].parse::<u8>(),
+                    form.fields[1].parse::<u32>(),
+                    form.fields[2].parse::<usize>(),
+                );
+                match parsed {
+                    (Ok(top), Ok(tokens), Ok(keep))
+                        if top <= crate::consts::MAX_CLASSIFIER_TOP_LOGPROBS =>
+                    {
+                        config.classifier_top_logprobs = top;
+                        config.auto_compact_tokens = tokens;
+                        config.compact_keep_recent_turns = keep;
+                        self.mode = Mode::List;
+                        return PanelAction::Saved;
+                    }
+                    _ => {
+                        form.error = Some(
+                            "logprobs must be 0-20; tokens and keep must be non-negative integers"
+                                .to_string(),
+                        );
+                    }
                 }
             }
             _ => {}
@@ -623,6 +778,8 @@ impl ProviderPanel {
                     Span::styled(" models  ", Style::default().fg(Color::Gray)),
                     Span::styled("r", Style::default().fg(Color::Cyan).bold()),
                     Span::styled(" refresh  ", Style::default().fg(Color::Gray)),
+                    Span::styled("g", Style::default().fg(Color::Cyan).bold()),
+                    Span::styled(" global settings  ", Style::default().fg(Color::Gray)),
                 ];
                 help.extend(PanelSearch::help_spans());
                 help.extend([
@@ -777,23 +934,23 @@ impl ProviderPanel {
                 let sel = (*selected).min(filtered.len().saturating_sub(1));
                 let items: Vec<ListItem> = filtered
                     .iter()
-                    .enumerate()
-                    .map(|(i, m)| {
-                        let is_sel = i == sel;
-                        let prefix = if is_sel { "❯ " } else { "  " };
-                        let style = if is_sel {
-                            Style::default()
-                                .fg(Color::Black)
-                                .bg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default().fg(Color::White)
-                        };
-                        let line = if f.is_empty() {
-                            Line::from(Span::styled(format!("{prefix}{m}"), style))
+                    .map(|m| {
+                        let style = Style::default().fg(palette::TEXT);
+                        let qualified = format!("{provider}/{m}");
+                        let is_chat = config
+                            .providers
+                            .get(provider)
+                            .and_then(|p| p.default_model.as_deref())
+                            == Some(**m);
+                        let is_classifier =
+                            config.classifier_model.as_deref() == Some(qualified.as_str());
+                        let is_compact =
+                            config.compact_model.as_deref() == Some(qualified.as_str());
+                        let mut spans = if f.is_empty() {
+                            vec![Span::styled((*m).to_string(), style)]
                         } else {
                             let lower = m.to_lowercase();
-                            let mut spans: Vec<Span> = vec![Span::styled(prefix, style)];
+                            let mut spans = Vec::new();
                             let mut pos = 0;
                             while let Some(idx) = lower[pos..].find(&f) {
                                 let start = pos + idx;
@@ -803,37 +960,57 @@ impl ProviderPanel {
                                 }
                                 spans.push(Span::styled(
                                     m[start..end].to_string(),
-                                    style.add_modifier(Modifier::UNDERLINED),
+                                    Style::default()
+                                        .fg(palette::BLUE)
+                                        .add_modifier(Modifier::BOLD),
                                 ));
                                 pos = end;
                             }
                             if pos < m.len() {
                                 spans.push(Span::styled(m[pos..].to_string(), style));
                             }
-                            Line::from(spans)
+                            spans
                         };
-                        ListItem::new(line)
+                        if is_chat {
+                            spans.push(Span::styled("  chat", Style::default().fg(palette::GREEN)));
+                        }
+                        if is_classifier {
+                            spans.push(Span::styled(
+                                "  classifier",
+                                Style::default().fg(palette::PURPLE),
+                            ));
+                        }
+                        if is_compact {
+                            spans.push(Span::styled(
+                                "  compact",
+                                Style::default().fg(palette::CYAN),
+                            ));
+                        }
+                        ListItem::new(Line::from(spans))
                     })
                     .collect();
 
-                let list_area = Rect {
-                    y: chunks[1].y,
-                    height: chunks[1].height + chunks[2].height,
-                    ..chunks[1]
-                };
+                // The provider list is rendered first for list/confirmation
+                // modes. This mode replaces it, so clear both replacement
+                // regions before drawing or the provider highlight background
+                // leaks through model spans that only set a foreground color.
+                let list_area = chunks[1];
+                Clear.render(list_area, buf);
+                Clear.render(chunks[2], buf);
                 let list = List::new(items)
                     .block(
                         Block::default()
                             .borders(Borders::ALL)
-                            .border_style(Style::default().fg(Color::Cyan))
+                            .border_style(Style::default().fg(palette::BORDER))
+                            .title_style(Style::default().fg(palette::BLUE).bold())
                             .title(title),
                     )
                     .highlight_style(
                         Style::default()
-                            .fg(Color::Black)
-                            .bg(Color::Cyan)
+                            .bg(palette::SURFACE)
                             .add_modifier(Modifier::BOLD),
-                    );
+                    )
+                    .highlight_symbol("› ");
                 let mut list_state = ListState::default();
                 if !filtered.is_empty() {
                     list_state.select(Some(sel));
@@ -842,30 +1019,111 @@ impl ProviderPanel {
 
                 let hint = if f.is_empty() {
                     Line::from(vec![
-                        Span::styled(" type", Style::default().fg(Color::Cyan).bold()),
-                        Span::styled(" to filter  ", Style::default().fg(Color::Gray)),
-                        Span::styled("↑↓", Style::default().fg(Color::Cyan).bold()),
-                        Span::styled(" navigate  ", Style::default().fg(Color::Gray)),
-                        Span::styled("Enter", Style::default().fg(Color::Green).bold()),
-                        Span::styled(" set as default_model  ", Style::default().fg(Color::Gray)),
-                        Span::styled("Esc", Style::default().fg(Color::Cyan).bold()),
-                        Span::styled(" back", Style::default().fg(Color::Gray)),
+                        Span::styled("type", Style::default().fg(palette::BLUE).bold()),
+                        Span::styled(" to filter  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("↑↓", Style::default().fg(palette::BLUE).bold()),
+                        Span::styled(" navigate  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("Enter", Style::default().fg(palette::GREEN).bold()),
+                        Span::styled(" choose role  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("Esc", Style::default().fg(palette::BLUE).bold()),
+                        Span::styled(" back", Style::default().fg(palette::MUTED)),
                     ])
                 } else {
                     Line::from(vec![
                         Span::styled(
                             format!(" filter: \"{filter}\"  "),
-                            Style::default().fg(Color::Yellow),
+                            Style::default().fg(palette::BLUE),
                         ),
-                        Span::styled("↑↓", Style::default().fg(Color::Cyan).bold()),
-                        Span::styled(" navigate  ", Style::default().fg(Color::Gray)),
-                        Span::styled("Enter", Style::default().fg(Color::Green).bold()),
-                        Span::styled(" set as default_model  ", Style::default().fg(Color::Gray)),
-                        Span::styled("Esc", Style::default().fg(Color::Cyan).bold()),
-                        Span::styled(" back", Style::default().fg(Color::Gray)),
+                        Span::styled("↑↓", Style::default().fg(palette::BLUE).bold()),
+                        Span::styled(" navigate  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("Enter", Style::default().fg(palette::GREEN).bold()),
+                        Span::styled(" choose role  ", Style::default().fg(palette::MUTED)),
+                        Span::styled("Esc", Style::default().fg(palette::BLUE).bold()),
+                        Span::styled(" back", Style::default().fg(palette::MUTED)),
                     ])
                 };
                 Paragraph::new(hint).render(chunks[2], buf);
+            }
+            Mode::RoleMenu {
+                provider,
+                model,
+                selected,
+            } => {
+                Clear.render(chunks[1], buf);
+                Clear.render(chunks[2], buf);
+                let choices = [
+                    "Set as provider chat default",
+                    "Set as global classifier model",
+                    "Set as global compact model",
+                    "Clear global classifier model",
+                    "Clear global compact model",
+                ];
+                let items = choices.iter().enumerate().map(|(index, choice)| {
+                    let style = if index == *selected {
+                        Style::default()
+                            .fg(palette::BLUE)
+                            .bg(palette::SURFACE)
+                            .bold()
+                    } else {
+                        Style::default().fg(palette::TEXT)
+                    };
+                    ListItem::new(Line::from(Span::styled(*choice, style)))
+                });
+                let list = List::new(items).block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(palette::BORDER))
+                        .title_style(Style::default().fg(palette::BLUE).bold())
+                        .title(format!(" Model role: {provider}/{model} ")),
+                );
+                let mut state = ListState::default().with_selected(Some(*selected));
+                ratatui::widgets::StatefulWidget::render(list, chunks[1], buf, &mut state);
+                Paragraph::new("↑↓ navigate  Enter apply globally  Esc back")
+                    .render(chunks[2], buf);
+            }
+            Mode::GlobalSettings(form) => {
+                Clear.render(chunks[1], buf);
+                Clear.render(chunks[2], buf);
+                let labels = [
+                    "classifier_top_logprobs",
+                    "auto_compact_tokens (0=off)",
+                    "compact_keep_recent_turns",
+                ];
+                let mut lines = labels
+                    .iter()
+                    .enumerate()
+                    .map(|(index, label)| {
+                        let style = if index == form.focus {
+                            Style::default().fg(palette::BLUE).bold()
+                        } else {
+                            Style::default().fg(palette::MUTED)
+                        };
+                        Line::from(vec![
+                            Span::styled(format!("{label:>30}: "), style),
+                            Span::styled(
+                                form.fields[index].clone(),
+                                Style::default().fg(palette::TEXT),
+                            ),
+                        ])
+                    })
+                    .collect::<Vec<_>>();
+                if let Some(error) = &form.error {
+                    lines.push(Line::from(Span::styled(
+                        error.clone(),
+                        Style::default().fg(palette::RED),
+                    )));
+                }
+                Paragraph::new(lines)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(palette::BORDER))
+                            .title_style(Style::default().fg(palette::BLUE).bold())
+                            .title(" Global model-role settings "),
+                    )
+                    .render(chunks[1], buf);
+                Paragraph::new("Tab/arrows field  Enter save globally  Esc cancel")
+                    .render(chunks[2], buf);
             }
         }
     }
@@ -895,7 +1153,6 @@ mod tests {
                     api_key: "k".into(),
                     models: None,
                     default_model: None,
-                    classifier_model: None,
                 },
             );
         }
@@ -904,6 +1161,9 @@ mod tests {
             providers,
             classifier_model: None,
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
+            compact_model: None,
+            auto_compact_tokens: 100_000,
+            compact_keep_recent_turns: 2,
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),
@@ -1010,6 +1270,73 @@ mod tests {
         );
         assert_eq!(config.default_provider, "alpha");
         assert_eq!(config.providers.len(), 1);
+    }
+
+    #[test]
+    fn model_filter_accepts_vim_letters_as_text() {
+        let mut config = config_with(&["alpha"]);
+        let mut models = HashMap::new();
+        models.insert(
+            "alpha".to_string(),
+            vec!["deepseek-chat".to_string(), "qwen-coder".to_string()],
+        );
+        let pm = ProviderManager::stub(models);
+        let mut panel = ProviderPanel::new();
+        panel.mode = Mode::Models {
+            provider: "alpha".to_string(),
+            filter: String::new(),
+            selected: 0,
+        };
+
+        for character in "deepseek".chars() {
+            assert_eq!(
+                panel.handle_key(key(KeyCode::Char(character)), &mut config, &pm),
+                PanelAction::None
+            );
+        }
+
+        assert!(matches!(
+            &panel.mode,
+            Mode::Models { filter, .. } if filter == "deepseek"
+        ));
+    }
+
+    #[test]
+    fn model_browser_clears_the_provider_list_before_rendering() {
+        let config = config_with(&["llmhub"]);
+        let mut models = HashMap::new();
+        models.insert(
+            "llmhub".to_string(),
+            vec![
+                "deepseek/deepseek-v4-flash".to_string(),
+                "deepseek/deepseek-v4-pro".to_string(),
+            ],
+        );
+        let pm = ProviderManager::stub(models);
+        let mut panel = ProviderPanel::new();
+        panel.mode = Mode::Models {
+            provider: "llmhub".to_string(),
+            filter: "deepseek".to_string(),
+            selected: 0,
+        };
+        let area = Rect::new(0, 0, 120, 14);
+        let mut buf = Buffer::empty(area);
+
+        panel.render(&config, &pm, area, &mut buf);
+
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!rendered.contains("default_model:"), "{rendered}");
+        assert!(rendered.contains("deepseek-v4-flash"), "{rendered}");
+        assert!(
+            (0..area.height).all(|y| { (0..area.width).all(|x| buf[(x, y)].bg != Color::Cyan) })
+        );
     }
 
     #[test]

--- a/src/ui/components/rewind_panel.rs
+++ b/src/ui/components/rewind_panel.rs
@@ -23,6 +23,9 @@ pub(crate) enum RestoreMode {
 pub(crate) enum PanelAction {
     None,
     Close,
+    Fork {
+        checkpoint_id: u64,
+    },
     Restore {
         checkpoint_id: u64,
         mode: RestoreMode,
@@ -110,7 +113,7 @@ impl RewindPanel {
                     let last = if self.entries[self.selected].recovery {
                         1
                     } else {
-                        3
+                        4
                     };
                     self.action_selected = (self.action_selected + 1).min(last);
                     PanelAction::None
@@ -118,9 +121,14 @@ impl RewindPanel {
                 KeyCode::Enter => {
                     let recovery = self.entries[self.selected].recovery;
                     if (recovery && self.action_selected == 1)
-                        || (!recovery && self.action_selected == 3)
+                        || (!recovery && self.action_selected == 4)
                     {
                         return PanelAction::Close;
+                    }
+                    if !recovery && self.action_selected == 3 {
+                        return PanelAction::Fork {
+                            checkpoint_id: self.entries[self.selected].id,
+                        };
                     }
                     let mode = if recovery {
                         RestoreMode::CodeOnly
@@ -202,6 +210,7 @@ impl RewindPanel {
                         "Restore code and conversation",
                         "Restore conversation only",
                         "Restore code only",
+                        "Fork conversation from here",
                         "Cancel",
                     ]
                 };
@@ -220,5 +229,49 @@ impl RewindPanel {
                 Paragraph::new("↑↓ navigate  Enter confirm  Esc back").render(chunks[2], buf);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn checkpoint(recovery: bool) -> crate::checkpoint::Checkpoint {
+        crate::checkpoint::Checkpoint {
+            id: 7,
+            prompt: "try another approach".to_string(),
+            label: recovery.then(|| "recovery".to_string()),
+            conversation_cutoff: 3,
+            todos: Vec::new(),
+            files: Vec::new(),
+            recovery,
+        }
+    }
+
+    #[test]
+    fn fork_is_available_for_prompt_checkpoints() {
+        let mut panel = RewindPanel::new(&[checkpoint(false)]);
+        assert_eq!(panel.handle_key(key(KeyCode::Enter)), PanelAction::None);
+        for _ in 0..3 {
+            assert_eq!(panel.handle_key(key(KeyCode::Down)), PanelAction::None);
+        }
+        assert_eq!(
+            panel.handle_key(key(KeyCode::Enter)),
+            PanelAction::Fork { checkpoint_id: 7 }
+        );
+    }
+
+    #[test]
+    fn recovery_checkpoints_do_not_offer_fork() {
+        let mut panel = RewindPanel::new(&[checkpoint(true)]);
+        assert_eq!(panel.handle_key(key(KeyCode::Enter)), PanelAction::None);
+        assert_eq!(panel.handle_key(key(KeyCode::Down)), PanelAction::None);
+        assert_eq!(panel.handle_key(key(KeyCode::Down)), PanelAction::None);
+        assert_eq!(panel.handle_key(key(KeyCode::Enter)), PanelAction::Close);
     }
 }

--- a/src/ui/components/rewind_panel.rs
+++ b/src/ui/components/rewind_panel.rs
@@ -1,0 +1,224 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Widget};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RestoreMode {
+    CodeAndConversation,
+    ConversationOnly,
+    CodeOnly,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PanelAction {
+    None,
+    Close,
+    Restore {
+        checkpoint_id: u64,
+        mode: RestoreMode,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    id: u64,
+    prompt: String,
+    file_count: usize,
+    recovery: bool,
+}
+
+#[derive(Debug)]
+enum Mode {
+    Checkpoints,
+    Actions,
+}
+
+#[derive(Debug)]
+pub struct RewindPanel {
+    entries: Vec<Entry>,
+    selected: usize,
+    action_selected: usize,
+    mode: Mode,
+}
+
+impl RewindPanel {
+    pub(crate) fn new(checkpoints: &[crate::checkpoint::Checkpoint]) -> Self {
+        let entries = checkpoints
+            .iter()
+            .rev()
+            .map(|checkpoint| Entry {
+                id: checkpoint.id,
+                prompt: checkpoint
+                    .label
+                    .clone()
+                    .unwrap_or_else(|| checkpoint.prompt.clone()),
+                file_count: checkpoint.files.len(),
+                recovery: checkpoint.recovery,
+            })
+            .collect();
+        Self {
+            entries,
+            selected: 0,
+            action_selected: 0,
+            mode: Mode::Checkpoints,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub(crate) fn handle_key(&mut self, key: KeyEvent) -> PanelAction {
+        match self.mode {
+            Mode::Checkpoints => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => PanelAction::Close,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.selected = self.selected.saturating_sub(1);
+                    PanelAction::None
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.selected = (self.selected + 1).min(self.entries.len().saturating_sub(1));
+                    PanelAction::None
+                }
+                KeyCode::Enter if !self.entries.is_empty() => {
+                    self.mode = Mode::Actions;
+                    self.action_selected = 0;
+                    PanelAction::None
+                }
+                _ => PanelAction::None,
+            },
+            Mode::Actions => match key.code {
+                KeyCode::Esc => {
+                    self.mode = Mode::Checkpoints;
+                    PanelAction::None
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.action_selected = self.action_selected.saturating_sub(1);
+                    PanelAction::None
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    let last = if self.entries[self.selected].recovery {
+                        1
+                    } else {
+                        3
+                    };
+                    self.action_selected = (self.action_selected + 1).min(last);
+                    PanelAction::None
+                }
+                KeyCode::Enter => {
+                    let recovery = self.entries[self.selected].recovery;
+                    if (recovery && self.action_selected == 1)
+                        || (!recovery && self.action_selected == 3)
+                    {
+                        return PanelAction::Close;
+                    }
+                    let mode = if recovery {
+                        RestoreMode::CodeOnly
+                    } else {
+                        match self.action_selected {
+                            0 => RestoreMode::CodeAndConversation,
+                            1 => RestoreMode::ConversationOnly,
+                            2 => RestoreMode::CodeOnly,
+                            _ => unreachable!(),
+                        }
+                    };
+                    PanelAction::Restore {
+                        checkpoint_id: self.entries[self.selected].id,
+                        mode,
+                    }
+                }
+                _ => PanelAction::None,
+            },
+        }
+    }
+
+    pub(crate) fn render(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Min(3),
+                Constraint::Length(2),
+            ])
+            .split(area);
+        Paragraph::new(Line::from(vec![
+            Span::styled("↶ Rewind", Style::default().fg(Color::Cyan).bold()),
+            Span::styled(
+                "  Built-in write_file/edit_file changes only",
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]))
+        .render(chunks[0], buf);
+
+        match self.mode {
+            Mode::Checkpoints => {
+                let items = self.entries.iter().map(|entry| {
+                    let prompt = entry.prompt.lines().next().unwrap_or("");
+                    let prompt = if prompt.chars().count() > 90 {
+                        format!("{}…", prompt.chars().take(90).collect::<String>())
+                    } else {
+                        prompt.to_string()
+                    };
+                    ListItem::new(format!(
+                        "#{:<4} {}  ({} files)",
+                        entry.id, prompt, entry.file_count
+                    ))
+                });
+                let list = List::new(items)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title(" Checkpoints "),
+                    )
+                    .highlight_style(
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .highlight_symbol("❯ ");
+                let mut state = ListState::default()
+                    .with_selected((!self.entries.is_empty()).then_some(self.selected));
+                ratatui::widgets::StatefulWidget::render(list, chunks[1], buf, &mut state);
+                Paragraph::new("↑↓ navigate  Enter choose restore mode  Esc close")
+                    .render(chunks[2], buf);
+            }
+            Mode::Actions => {
+                let choices: &[&str] = if self.entries[self.selected].recovery {
+                    &["Restore code (undo rewind)", "Cancel"]
+                } else {
+                    &[
+                        "Restore code and conversation",
+                        "Restore conversation only",
+                        "Restore code only",
+                        "Cancel",
+                    ]
+                };
+                let items = choices.iter().map(|choice| ListItem::new(*choice));
+                let list = List::new(items)
+                    .block(Block::default().borders(Borders::ALL).title(" Restore "))
+                    .highlight_style(
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .highlight_symbol("❯ ");
+                let mut state = ListState::default().with_selected(Some(self.action_selected));
+                ratatui::widgets::StatefulWidget::render(list, chunks[1], buf, &mut state);
+                Paragraph::new("↑↓ navigate  Enter confirm  Esc back").render(chunks[2], buf);
+            }
+        }
+    }
+}

--- a/src/ui/event.rs
+++ b/src/ui/event.rs
@@ -57,6 +57,8 @@ pub enum AppEvent {
     /// The runner's turn moved to a new phase (classifying, running tools, …).
     /// Tagged with the operation id.
     RunnerPhase(u64, crate::runner::RunnerPhase),
+    /// Real input usage reported by a response at a call/output-safe point.
+    UsageSafePoint(u64, u32),
     /// The runner asks the user to review a tool call the classifier flagged
     /// (`Ask` verdict). Carries the call, the classifier's reason, the call's
     /// 1-based position and batch total, and the oneshot the decision goes
@@ -82,7 +84,15 @@ pub enum AppEvent {
     /// context boundary, `Err` the error to surface. The token identifies the
     /// run so a summary from a cancelled compaction is dropped. Tagged with
     /// the operation id.
-    CompactFinished(u64, Result<String, String>, CancellationToken),
+    CompactFinished(u64, usize, Result<String, String>, CancellationToken),
+    /// A seamless background compaction finished. The job id and history
+    /// epoch make stale summaries harmless after clear/rewind/session changes.
+    AutoCompactFinished {
+        job_id: u64,
+        history_epoch: u64,
+        cutoff: usize,
+        result: Result<String, String>,
+    },
     /// A background process entered a terminal state.
     TaskStateChanged(crate::tasks::TaskLifecycleEvent),
     /// An in-process sub-agent entered a terminal state.
@@ -136,6 +146,12 @@ pub enum AppEvent {
         generation: u64,
         manager: Box<crate::mcp::McpManager>,
     },
+    /// `/diagnostics update` finished collecting the project profile. A
+    /// missing snapshot means no diagnostics profile is configured.
+    DiagnosticsUpdated {
+        generation: u64,
+        snapshot: Option<crate::diagnostics::Snapshot>,
+    },
     /// The `ask_user` tool is prompting the user. Carries the question and a
     /// oneshot sender that the UI uses to send the answer back. Tagged with
     /// the operation id so questions from stale turns are dropped.
@@ -181,6 +197,11 @@ impl std::fmt::Debug for AppEvent {
                 .finish(),
             Self::ResponseCommitted(id) => f.debug_tuple("ResponseCommitted").field(id).finish(),
             Self::RunnerPhase(id, _) => f.debug_tuple("RunnerPhase").field(id).finish(),
+            Self::UsageSafePoint(id, tokens) => f
+                .debug_tuple("UsageSafePoint")
+                .field(id)
+                .field(tokens)
+                .finish(),
             Self::ReviewRequest {
                 call, operation_id, ..
             } => f
@@ -193,10 +214,16 @@ impl std::fmt::Debug for AppEvent {
                 .field(id)
                 .field(&r.as_ref().map(|_| "..").map_err(|e| e.to_string()))
                 .finish(),
-            Self::CompactFinished(id, r, _) => f
+            Self::CompactFinished(id, cutoff, r, _) => f
                 .debug_tuple("CompactFinished")
                 .field(id)
+                .field(cutoff)
                 .field(&r.as_ref().map(|_| ".."))
+                .finish(),
+            Self::AutoCompactFinished { job_id, result, .. } => f
+                .debug_struct("AutoCompactFinished")
+                .field("job_id", job_id)
+                .field("result", &result.as_ref().map(|_| ".."))
                 .finish(),
             Self::TaskStateChanged(event) => f
                 .debug_tuple("TaskStateChanged")
@@ -240,6 +267,14 @@ impl std::fmt::Debug for AppEvent {
             Self::McpReloaded { generation, .. } => f
                 .debug_struct("McpReloaded")
                 .field("generation", generation)
+                .finish(),
+            Self::DiagnosticsUpdated {
+                generation,
+                snapshot,
+            } => f
+                .debug_struct("DiagnosticsUpdated")
+                .field("generation", generation)
+                .field("configured", &snapshot.is_some())
                 .finish(),
             Self::QuestionPrompt {
                 question,

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -303,6 +303,10 @@ impl Widget for &mut App<'_> {
             panel.render(&self.config, &self.provider_manager, area, buf);
             return;
         }
+        if let Some(panel) = &self.rewind_panel {
+            panel.render(area, buf);
+            return;
+        }
         // The skills management panel is modal and replaces the whole UI.
         if let Some(panel) = &self.skills_panel {
             panel.render(&self.skill_registry, area, buf);
@@ -311,6 +315,11 @@ impl Widget for &mut App<'_> {
         // The MCP management panel is modal and replaces the whole UI.
         if let Some(panel) = &self.mcp_panel {
             panel.render(&self.config, self.mcp_manager.as_deref(), area, buf);
+            return;
+        }
+        // The diagnostics management panel is modal and replaces the whole UI.
+        if let Some(panel) = &self.diagnostics_panel {
+            panel.render(area, buf);
             return;
         }
         // The security profile panel is modal and replaces the whole UI.

--- a/tests/cli_diagnostics.rs
+++ b/tests/cli_diagnostics.rs
@@ -21,14 +21,21 @@ fn diagnostics_json_reports_findings_and_sets_the_exit_status() {
     let project = std::env::temp_dir().join(unique);
     let profile_dir = project.join(".programmer");
     std::fs::create_dir_all(&profile_dir).unwrap();
+    let command = if cfg!(windows) {
+        "echo src/main.rs:7:3: error: broken"
+    } else {
+        "printf 'src/main.rs:7:3: error: broken\\n'"
+    };
     std::fs::write(
         profile_dir.join("diagnostics.toml"),
-        r#"
+        format!(
+            r#"
 [[checkers]]
 name = "fixture"
-command = "printf 'src/main.rs:7:3: error: broken\\n'"
+command = {command:?}
 parser = "gnu"
-"#,
+"#
+        ),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

- add `/rewind` checkpoints with code/conversation restore modes and session forking
- add manual and automatic context compaction with configurable models and thresholds
- add diagnostics management and refresh commands
- restore cancelled prompts before the first model response
- improve provider/model management UI and modal key routing
- make `classifier_top_logprobs` a single global persisted setting
- bump the package version to `0.2.2` and add release notes

## Validation

- `cargo test --bin programmer` (464 passed)
- `cargo check`
- `cargo check --locked`
- `cargo clippy --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #16