### PR TITLE
docs: improve project onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Report a reproducible problem in Programmer
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Remove API keys, private prompts, local usernames, and proprietary code from all fields, logs, and screenshots.
+  - type: input
+    id: version
+    attributes:
+      label: Programmer version
+      description: Run `programmer --version` or provide the release tag/commit.
+      placeholder: v0.2.2
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      description: Include the terminal application and shell.
+      placeholder: Windows Terminal with PowerShell 7
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: Provider and model
+      description: If relevant, include the provider name, base URL host, and model ID. Never include an API key.
+      placeholder: DeepSeek official API, api.deepseek.com, deepseek-v4-pro
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Give the shortest sequence that reliably triggers the problem.
+      placeholder: |
+        1. Start Programmer with ...
+        2. Run ...
+        3. Press ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the exact redacted error text if available.
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: Paste only the minimal relevant TOML with secrets replaced by `<redacted>`.
+      render: toml
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add redacted logs, screenshots, or notes about whether the issue reproduces on the latest release.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I removed API keys and other sensitive information.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose a user-visible improvement to Programmer
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow is difficult or impossible today? Describe the user need before the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Proposed behavior
+      description: Describe the commands, UI behavior, defaults, and persistence scope you expect.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Explain any current workaround or simpler alternative.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Include examples or redacted screenshots if they clarify the request.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for similar requests.
+          required: true
+        - label: This request describes one focused behavior.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to Programmer
+
+Thanks for helping improve Programmer. Bug reports, compatibility findings,
+documentation fixes, and focused pull requests are all welcome.
+
+## Before opening an issue
+
+- Search the existing issues first.
+- Upgrade to the latest release and check whether the problem still occurs.
+- Remove API keys, authorization headers, private prompts, local usernames,
+  and proprietary source code from logs and screenshots.
+- For provider problems, include the provider name, base URL host (without
+  credentials), model ID, and whether `/providers refresh <provider>` works.
+
+Use the bug-report template for reproducible failures and the feature-request
+template for proposed behavior. GitHub Issues are the primary support and
+feedback channel.
+
+## Development setup
+
+Programmer uses the latest stable Rust toolchain and the Rust 2024 edition.
+
+```sh
+git clone https://github.com/huangdihd/programmer.git
+cd programmer
+cargo build
+cargo test --locked --all-features --all-targets
+```
+
+The repository architecture and conventions are documented in
+[`PROGRAMMER.md`](PROGRAMMER.md). In particular:
+
+- avoid `unwrap()` in production code;
+- add the GPL-3.0-or-later header to new Rust source files;
+- keep platform-specific behavior working on Windows, macOS, and Linux;
+- add or update tests for behavior changes;
+- never commit real provider keys or private session data.
+
+## Pull requests
+
+1. Create a focused branch from `develop`.
+2. Make the smallest coherent change and add tests where applicable.
+3. Run the local checks:
+
+   ```sh
+   cargo fmt -- --check
+   cargo clippy --locked --all-features --all-targets
+   cargo test --locked --all-features --all-targets
+   cargo doc --no-deps --all-features
+   ```
+
+4. Open the pull request against `develop` and explain the user-visible
+   behavior, verification performed, and any provider or platform limitations.
+
+Do not mix unrelated refactors into a bug fix. Screenshots or short terminal
+recordings are useful for TUI changes, but redact sensitive information first.
+
+## Reporting provider compatibility
+
+OpenAI-compatible providers vary by endpoint and feature. A useful report says
+which of these operations succeeds or fails:
+
+- streamed Responses API text;
+- tool calls and tool outputs;
+- `GET /models` discovery;
+- usage fields such as `input_tokens`;
+- image input;
+- classifier logprobs.
+
+Include a minimal, redacted error response when possible. A provider can still
+be usable when model discovery or an optional capability is unavailable.
+
+## License
+
+By contributing, you agree that your contribution is licensed under the
+repository's [GPL-3.0-or-later license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -64,8 +64,41 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
 Both installers select the release asset for the current OS and architecture.
-Use `--version v0.2.0` with `install.sh`, or `-Version v0.2.0` with
+Use `--version v0.2.2` with `install.sh`, or `-Version v0.2.2` with
 `install.ps1`, to install a specific release.
+
+## Quick start
+
+1. Open the provider manager:
+
+   ```sh
+   programmer --providers
+   ```
+
+2. Press `a`, then enter a provider name, an OpenAI-compatible API base URL,
+   an API key, and a default model. Press `Enter` to save it, select the
+   provider, and press `Enter` again to make it the default.
+
+3. Start Programmer from the project you want it to work on:
+
+   ```sh
+   cd your-project
+   programmer
+   ```
+
+4. Send a concrete first task, for example:
+
+   ```text
+   Explain this repository and run its existing tests. Do not change files yet.
+   ```
+
+   Use `/init` if you want Programmer to create project guidance and configure
+   diagnostics before making changes. The default Auto mode asks a classifier
+   model to review mutating tool calls; use a non-reasoning model for that role.
+
+If the provider works but the model list is empty, configure `models` and
+`default_model` explicitly in `config.toml`; see
+[Provider compatibility](#provider-compatibility).
 
 ### Update or uninstall
 
@@ -74,7 +107,7 @@ Once installed, Programmer can update or remove its own executable:
 ```sh
 programmer upgrade --check
 programmer upgrade
-programmer upgrade --tag v0.2.0
+programmer upgrade --tag v0.2.2
 programmer uninstall
 programmer uninstall --purge
 ```
@@ -214,6 +247,52 @@ api_key = "sk-your-key-here"
 
 Each provider is a `[providers.<name>]` section. You can add as many as you want.
 
+## Provider compatibility
+
+Programmer uses the OpenAI **Responses API**, not only the older Chat
+Completions API. An endpoint describing itself as OpenAI-compatible may still
+implement only part of the protocol.
+
+| Capability | Requirement and fallback |
+|---|---|
+| `POST /responses` with streaming and tool calls | Required for normal agent conversations. A Chat Completions-only endpoint is not compatible. |
+| `GET /models` | Optional. If discovery fails or returns a non-standard response, set `models` and `default_model` manually. |
+| Response usage with `input_tokens` | Optional. Without it, `/usage` may be incomplete and token-triggered automatic compaction will not run; manual `/compact` still works. |
+| Image input in the Responses format | Optional. Keep `/vision off` when the selected model or provider does not accept image content. |
+| Output logprobs | Optional for chat, but used by the Auto classifier's fast probe. Missing or inconclusive logprobs fall back to the full classifier pass. Provider-specific limits may require a lower global `classifier_top_logprobs` value. |
+
+### DeepSeek official API
+
+The DeepSeek official API supports Responses API requests, but its `/models`
+entries omit creation-time metadata expected by Programmer's OpenAI client.
+Automatic model discovery therefore fails with a missing `created` or
+`created_at` field. Configure the current model IDs explicitly:
+
+```toml
+default_provider = "deepseek"
+
+[providers.deepseek]
+base_url = "https://api.deepseek.com"
+api_key = "sk-your-key-here"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default_model = "deepseek-v4-pro"
+```
+
+The provider remains usable when model discovery fails; the manual list powers
+startup model selection, `/model` completion, and the provider model browser.
+
+### Known limitations
+
+- Reasoning models are unsuitable for the Auto-mode classifier because their
+  first emitted token is not a direct yes/no decision. Use a non-reasoning
+  classifier model.
+- Provider support for logprobs and image content varies independently from
+  basic text and tool-call support.
+- Native process sandboxing is available only on supported Unix platforms.
+- `/rewind` can restore only successful changes made through Programmer's
+  built-in `write_file` and `edit_file` tools. Shell commands, MCP tools, IDE
+  edits, and remote side effects are not reversible by Programmer.
+
 ### Environment variables
 
 Environment variables override file values:
@@ -334,7 +413,7 @@ programmer
 | `/classifier <provider/model>` | Override the classifier model for this session |
 | `/classifier current` | Force this session to follow the current chat model |
 | `/classifier default` | Clear the session override and inherit the global setting |
-| `/classifier logprobs <0-20\|default>` | Override or inherit the fast-probe alternative-token count for this session |
+| `/classifier logprobs <0-20\|default>` | Set or reset the persisted global fast-probe alternative-token count |
 | `/init` | Create or refresh `PROGRAMMER.md` and project diagnostics |
 | `/diagnostics manage` | Open the project diagnostics checker management panel |
 | `/diagnostics update` | Re-run configured checkers and refresh the sidebar diagnostics |
@@ -381,9 +460,11 @@ Open with `/providers manage` or the `--providers` flag.
 | `g` | Edit global classifier logprobs and automatic-compaction settings |
 | `q` / `Esc` | Close panel |
 
-Slash commands change only the current session. Changes made in this panel are
-global and persisted to `config.toml`. Effective model precedence is session
-override → global role → current chat model.
+Classifier and compact model slash commands, plus compact thresholds and
+retention, change only the current session. `/classifier logprobs` is the
+exception: it changes the single global value and persists it to `config.toml`.
+Changes made in this panel are also global and persisted. Effective model
+precedence is session override → global role → current chat model.
 
 ### Rewind and automatic compaction
 
@@ -590,6 +671,14 @@ src/
 ├── upgrade.rs        # Release checks, self-update, and uninstall
 └── ui/               # Ratatui components, rendering, and terminal images
 ```
+
+## Contributing and feedback
+
+Found a bug or provider compatibility issue? Use the structured
+[GitHub issue templates](https://github.com/huangdihd/programmer/issues/new/choose).
+Pull requests are welcome; see [CONTRIBUTING.md](CONTRIBUTING.md) for the
+development workflow and required checks. Never include API keys, private
+prompts, or proprietary code in reports.
 
 ## License
 


### PR DESCRIPTION
## Summary

- add a three-minute quick start and correct v0.2.2 command examples
- document provider capability boundaries and the DeepSeek official /models limitation
- correct /classifier logprobs as a persisted global setting
- add contributing guidance and structured bug/feature issue forms

## Validation

- git diff --check
- documentation and GitHub configuration only; no runtime code changes