### PR TITLE
v0.2.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Programmer version
       description: Run `programmer --version` or provide the release tag/commit.
-      placeholder: v0.2.2
+      placeholder: v0.2.3
     validations:
       required: true
   - type: dropdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,7 +2928,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
- "tui-scrollview",
  "unicode-width 0.2.0",
  "uuid",
  "vt100",
@@ -4982,17 +4981,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tui-scrollview"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04907b1a2a41660933df8e64205abc7de4a4b320e808abcb00b9377069ac9d31"
-dependencies = [
- "indoc",
- "ratatui-core",
- "ratatui-widgets",
-]
 
 [[package]]
 name = "typeid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.2"
+version = "0.2.3"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ config = "0.15.25"
 ratatui-textarea = "0.9.2"
 dirs = "6.0.0"
 toml = "1.1.2"
-tui-scrollview = "0.6.7"
 thiserror = "2.0.18"
 serde_json = "1.0.150"
 jsonschema = { version = "0.49.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
 Both installers select the release asset for the current OS and architecture.
-Use `--version v0.2.2` with `install.sh`, or `-Version v0.2.2` with
+Use `--version v0.2.3` with `install.sh`, or `-Version v0.2.3` with
 `install.ps1`, to install a specific release.
 
 ## Quick start
@@ -107,7 +107,7 @@ Once installed, Programmer can update or remove its own executable:
 ```sh
 programmer upgrade --check
 programmer upgrade
-programmer upgrade --tag v0.2.2
+programmer upgrade --tag v0.2.3
 programmer uninstall
 programmer uninstall --purge
 ```

--- a/src/response/partial_response.rs
+++ b/src/response/partial_response.rs
@@ -69,6 +69,10 @@ pub struct PartialResponse {
     pub cancelled: CancellationToken,
     /// Token usage from the completed response: (input_tokens, output_tokens).
     pub usage: Option<(u32, u32)>,
+    /// Monotonically changes whenever another stream event is folded into this
+    /// response. The TUI uses it to reuse an unchanged live tool-group layout
+    /// across animation/timer frames without hashing or cloning the full text.
+    render_revision: u64,
 }
 
 impl PartialResponse {
@@ -79,6 +83,7 @@ impl PartialResponse {
             finish_reason: None,
             cancelled,
             usage: None,
+            render_revision: 0,
         }
     }
 
@@ -113,6 +118,7 @@ impl PartialResponse {
     }
 
     pub fn handle_response_stream_event(&mut self, response_stream_event: ResponseStreamEvent) {
+        self.render_revision = self.render_revision.wrapping_add(1);
         match response_stream_event {
             ResponseOutputItemAdded(item_added_event) => {
                 self.set_item(item_added_event.item, item_added_event.output_index);
@@ -496,6 +502,11 @@ impl PartialResponse {
             }
             _ => {}
         }
+    }
+
+    /// A cheap cache key for the current live rendering snapshot.
+    pub fn render_revision(&self) -> u64 {
+        self.render_revision
     }
 
     pub fn into_parts(self) -> (Option<ResponseFinishReason>, Vec<OutputItem>) {

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -144,8 +144,8 @@ fn is_foldable(item: &MessageItem) -> bool {
 /// Cached render output for a single finished message.
 ///
 /// Historical `items` are append-only and never mutate once added, so their
-/// markdown is parsed and laid out exactly once and reused across frames. Only
-/// the streaming `receiving_response` is re-rendered every frame.
+/// markdown is parsed and laid out exactly once and reused across frames. Live
+/// Exploring groups have their own revision-keyed cache below.
 #[derive(Debug)]
 pub(crate) struct CachedParagraph {
     pub paragraph: Paragraph<'static>,
@@ -190,6 +190,42 @@ pub(crate) struct ToolGroupLayout {
     /// both committed and streaming members. Indices at or above this base map
     /// back to `live_expanded_items`; lower indices are committed items.
     pub live_index_base: Option<usize>,
+}
+
+pub(crate) type LiveParagraph = (std::sync::Arc<Paragraph<'static>>, u16, Vec<CodeCopyButton>);
+pub(crate) type LiveGroupHeader = Option<(String, Vec<MemberHeader>)>;
+pub(crate) type MaterializedLiveCache = (Vec<LiveParagraph>, Vec<LiveGroupHeader>);
+
+/// One pre-rendered live slot. Exploring groups retain both outer fold states,
+/// so the first click only selects an `Arc` and never parses Markdown.
+#[derive(Debug, Clone)]
+pub(crate) enum CachedLiveSlot {
+    Fixed {
+        paragraph: LiveParagraph,
+        group_header: LiveGroupHeader,
+    },
+    Explore {
+        group_key: String,
+        collapsed: LiveParagraph,
+        collapsed_headers: Vec<MemberHeader>,
+        expanded: LiveParagraph,
+        expanded_headers: Vec<MemberHeader>,
+    },
+}
+
+/// A complete live Exploring snapshot generated when stream content changes.
+/// Timer/animation frames compare cheap revisions before cloning any output
+/// items, then materialize the requested fold state from these shared entries.
+#[derive(Debug, Clone)]
+pub(crate) struct LiveRenderCache {
+    pub response_revision: u64,
+    pub content_width: u16,
+    pub conversation_len: usize,
+    pub conversation_mutation_version: u64,
+    pub expanded_items: HashSet<usize>,
+    pub live_expanded_items: HashSet<usize>,
+    pub bridged_committed_items: HashSet<usize>,
+    pub slots: Vec<CachedLiveSlot>,
 }
 
 /// A mouse text selection over the conversation, in scroll-buffer coordinates
@@ -319,8 +355,19 @@ pub struct ConversationPanel {
     /// The current mouse text selection, if any.
     pub(crate) selection: Option<Selection>,
     /// The streaming items' paragraphs from the last render (paragraph, height,
-    /// copy buttons), kept for selection extraction and copy-button clicks.
-    pub(crate) live_paragraphs: Vec<(Paragraph<'static>, u16, Vec<CodeCopyButton>)>,
+    /// copy buttons). Exploring-group entries are moved forward unchanged on a
+    /// cache hit; all entries are also kept for selection and copy-button clicks.
+    pub(crate) live_paragraphs: Vec<LiveParagraph>,
+    /// Group header hit regions parallel to `live_paragraphs`. Keeping these
+    /// with the cached paragraph avoids rebuilding click geometry on cache hits.
+    pub(crate) live_group_headers: Vec<LiveGroupHeader>,
+    /// Present only when the whole live snapshot consists of Exploring groups
+    /// (plus their hidden zero-height member slots).
+    pub(crate) live_render_cache: Option<LiveRenderCache>,
+    #[cfg(test)]
+    pub(crate) live_explore_builds: u64,
+    #[cfg(test)]
+    pub(crate) live_explore_cache_hits: u64,
     /// Vertical extent `(top, height)` of the pending-message note in the last
     /// render, for selection extraction.
     pub(crate) pending_layout: Option<(u16, u16)>,
@@ -364,6 +411,12 @@ impl ConversationPanel {
             live_expanded_groups: HashSet::new(),
             selection: None,
             live_paragraphs: Vec::new(),
+            live_group_headers: Vec::new(),
+            live_render_cache: None,
+            #[cfg(test)]
+            live_explore_builds: 0,
+            #[cfg(test)]
+            live_explore_cache_hits: 0,
             pending_layout: None,
             last_content_height: 0,
         }
@@ -636,7 +689,7 @@ impl ConversationPanel {
                     top,
                     bottom.saturating_sub(top),
                     width,
-                    |b| paragraph.render(b.area, b),
+                    |b| paragraph.as_ref().render(b.area, b),
                 );
             }
         }
@@ -818,6 +871,7 @@ impl ConversationPanel {
         self.expanded_tool_groups.clear();
         self.live_expanded_items.clear();
         self.live_expanded_groups.clear();
+        self.live_render_cache = None;
         self.selection = None;
         self.stick_to_bottom = true;
     }
@@ -853,6 +907,7 @@ impl ConversationPanel {
     /// transferring live expanded state onto the now-committed items (which sit
     /// at the tail of the conversation).
     pub fn commit_live(&mut self) {
+        self.live_render_cache = None;
         if let Some(partial) = self.receiving_response.take() {
             let committed = partial.items.iter().flatten().count();
             let base_index = self
@@ -878,6 +933,7 @@ impl ConversationPanel {
     /// nothing for a response that errored or was cancelled mid-stream — and
     /// clearing the "receiving" state so the turn is no longer considered busy.
     pub fn abort_receiving(&mut self) {
+        self.live_render_cache = None;
         if let Some(partial) = self.receiving_response.take() {
             // Transfer live expanded state before items become historical,
             // so reasoning/tool-call items the user expanded during streaming

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -19,11 +19,11 @@ use async_openai::error::OpenAIError;
 use async_openai::types::responses::MessageItem as ApiMessageItem;
 use async_openai::types::responses::{InputParam, OutputItem, ResponseStreamEvent};
 use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
+use ratatui::layout::{Position, Rect};
 use ratatui::widgets::Widget;
 use ratatui_widgets::paragraph::Paragraph;
-use std::collections::HashSet;
-use tui_scrollview::ScrollViewState;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use unicode_width::UnicodeWidthStr;
 
 use super::tool_group::MemberHeader;
@@ -148,7 +148,7 @@ fn is_foldable(item: &MessageItem) -> bool {
 /// Exploring groups have their own revision-keyed cache below.
 #[derive(Debug)]
 pub(crate) struct CachedParagraph {
-    pub paragraph: Paragraph<'static>,
+    pub paragraph: Arc<Paragraph<'static>>,
     pub height: u16,
     /// Whether this slot was intentionally hidden when cached. Bridged live
     /// groups temporarily hide their committed members, then reveal them again
@@ -169,6 +169,44 @@ pub(crate) struct CachedParagraph {
     /// Present when this cache slot represents a derived tool-call group rather
     /// than its original single history item.
     pub tool_group: Option<CachedToolGroup>,
+}
+
+/// Scrolled clones for paragraphs crossing the viewport's top edge. Cloning a
+/// very large expanded group every 60 Hz tick would undo the benefit of virtual
+/// rendering, so retain one clone per source paragraph at the current offset.
+#[derive(Debug, Default)]
+pub(crate) struct ViewportParagraphCache {
+    viewport_top: u16,
+    entries: HashMap<(usize, u16), Arc<Paragraph<'static>>>,
+    used: HashSet<(usize, u16)>,
+}
+
+impl ViewportParagraphCache {
+    pub(crate) fn begin_frame(&mut self, viewport_top: u16) {
+        if self.viewport_top != viewport_top {
+            self.viewport_top = viewport_top;
+            self.entries.clear();
+        }
+        self.used.clear();
+    }
+
+    pub(crate) fn scrolled(
+        &mut self,
+        source: &Arc<Paragraph<'static>>,
+        offset: u16,
+    ) -> Arc<Paragraph<'static>> {
+        let source_id = Arc::as_ptr(source) as *const () as usize;
+        let key = (source_id, offset);
+        self.used.insert(key);
+        self.entries
+            .entry(key)
+            .or_insert_with(|| Arc::new(source.as_ref().clone().scroll((offset, 0))))
+            .clone()
+    }
+
+    pub(crate) fn finish_frame(&mut self) {
+        self.entries.retain(|key, _| self.used.contains(key));
+    }
 }
 
 #[derive(Debug)]
@@ -287,6 +325,69 @@ pub(crate) struct RenderCache {
     pub seen_mutation_version: u64,
 }
 
+/// Vertical scroll state for the conversation's virtual canvas.
+///
+/// Unlike `tui_scrollview::ScrollViewState`, this does not require allocating a
+/// backing buffer as tall as the entire conversation. The renderer records the
+/// virtual content/page height here and paints only the visible rows.
+#[derive(Debug, Default)]
+pub(crate) struct ConversationScrollState {
+    offset: u16,
+    content_height: u16,
+    page_height: u16,
+}
+
+impl ConversationScrollState {
+    pub(crate) fn offset(&self) -> Position {
+        Position::new(0, self.offset)
+    }
+
+    pub(crate) fn update(&mut self, content_height: u16, page_height: u16) {
+        self.content_height = content_height;
+        self.page_height = page_height;
+        self.offset = self.offset.min(self.max_offset());
+    }
+
+    pub(crate) fn scroll_up(&mut self) {
+        self.offset = self.offset.saturating_sub(1);
+    }
+
+    pub(crate) fn scroll_down(&mut self) {
+        self.offset = self.offset.saturating_add(1).min(self.max_offset());
+    }
+
+    pub(crate) fn scroll_page_up(&mut self) {
+        self.offset = self
+            .offset
+            .saturating_add(1)
+            .saturating_sub(self.page_height.max(1));
+    }
+
+    pub(crate) fn scroll_page_down(&mut self) {
+        self.offset = self
+            .offset
+            .saturating_add(self.page_height.max(1))
+            .saturating_sub(1)
+            .min(self.max_offset());
+    }
+
+    pub(crate) fn scroll_to_top(&mut self) {
+        self.offset = 0;
+    }
+
+    pub(crate) fn scroll_to_bottom(&mut self) {
+        self.offset = self.max_offset();
+    }
+
+    pub(crate) fn is_at_bottom(&self) -> bool {
+        self.offset >= self.max_offset()
+    }
+
+    fn max_offset(&self) -> u16 {
+        self.content_height.saturating_sub(self.page_height)
+    }
+}
+
 #[derive(Debug)]
 pub struct ConversationPanel {
     /// The UI-free conversation model: history items and turn-usage counter.
@@ -296,7 +397,7 @@ pub struct ConversationPanel {
     /// every access here locks briefly and never holds the guard across an
     /// await (there are none in the UI thread) or a render sub-call.
     pub(crate) conversation: std::sync::Arc<std::sync::Mutex<crate::conversation::Conversation>>,
-    pub(crate) scroll_view_state: ScrollViewState,
+    pub(crate) scroll_view_state: ConversationScrollState,
     pub pending_message: Option<String>,
     pub receiving_response: Option<PartialResponse>,
     /// The current active work phase of the turn. Replaces the old cluster of
@@ -342,6 +443,7 @@ pub struct ConversationPanel {
     /// alongside `item_layout` so clicks on streaming items can be mapped.
     live_item_layout: Vec<(usize, u16, u16)>,
     pub(crate) render_cache: RenderCache,
+    pub(crate) viewport_paragraph_cache: ViewportParagraphCache,
     /// Monotonic frame counter, incremented every render. Drives the animated
     /// "Thinking..." dots on the live reasoning indicator during streaming.
     pub(crate) frame_count: u64,
@@ -389,7 +491,7 @@ impl ConversationPanel {
     ) -> Self {
         ConversationPanel {
             conversation,
-            scroll_view_state: ScrollViewState::new(),
+            scroll_view_state: ConversationScrollState::default(),
             pending_message: None,
             receiving_response: None,
             phase: ActivePhase::None,
@@ -406,6 +508,7 @@ impl ConversationPanel {
             live_item_layout: Vec::new(),
             live_tool_group_layout: Vec::new(),
             render_cache: RenderCache::default(),
+            viewport_paragraph_cache: ViewportParagraphCache::default(),
             frame_count: 0,
             live_expanded_items: HashSet::new(),
             live_expanded_groups: HashSet::new(),
@@ -676,7 +779,7 @@ impl ConversationPanel {
                     top,
                     bottom.saturating_sub(top),
                     width,
-                    |b| (&entry.paragraph).render(b.area, b),
+                    |b| entry.paragraph.as_ref().render(b.area, b),
                 );
             }
         }
@@ -1179,6 +1282,35 @@ mod tests {
 
         assert!(!panel.stick_to_bottom);
         assert_eq!(panel.scroll_view_state.offset().y, before);
+    }
+
+    #[test]
+    fn virtual_scroll_state_clamps_without_a_content_buffer() {
+        let mut state = ConversationScrollState::default();
+        state.update(10_000, 20);
+        state.scroll_to_bottom();
+        assert_eq!(state.offset().y, 9_980);
+        assert!(state.is_at_bottom());
+
+        state.scroll_page_up();
+        assert_eq!(state.offset().y, 9_961);
+        assert!(!state.is_at_bottom());
+
+        state.update(10, 20);
+        assert_eq!(state.offset().y, 0);
+        assert!(state.is_at_bottom());
+    }
+
+    #[test]
+    fn clipped_paragraph_clone_is_reused_between_ticks() {
+        let source = Arc::new(Paragraph::new("line\n".repeat(10_000)));
+        let mut cache = ViewportParagraphCache::default();
+        cache.begin_frame(9_900);
+
+        let first = cache.scrolled(&source, 9_900);
+        let second = cache.scrolled(&source, 9_900);
+
+        assert!(Arc::ptr_eq(&first, &second));
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/tool_group.rs
+++ b/src/ui/components/conversation_panel/tool_group.rs
@@ -79,6 +79,12 @@ impl ToolGroup {
             .chain(self.absorbed.iter_mut())
             .for_each(|index| *index += offset);
     }
+
+    /// Explore groups are the common long-lived streaming groups: their
+    /// absorbed reasoning can be very large and expensive to lay out.
+    pub(crate) fn is_explore(&self) -> bool {
+        self.kind == ToolGroupKind::Explore
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -15,11 +15,12 @@
 
 use crate::response::message_item::MessageItem;
 use crate::ui::components::conversation_panel::conversation_panel::{
-    ActivePhase, CachedParagraph, CachedToolGroup, ConversationPanel, ToolGroupLayout,
+    ActivePhase, CachedLiveSlot, CachedParagraph, CachedToolGroup, ConversationPanel,
+    LiveGroupHeader, LiveParagraph, LiveRenderCache, MaterializedLiveCache, ToolGroupLayout,
 };
 use crate::ui::components::conversation_panel::tool_group::{
-    MemberHeader, ToolGroupMember, build_tool_group_paragraph, discover_tool_group_bridge,
-    discover_tool_groups, function_call, is_hidden_runtime_tool,
+    MemberHeader, ToolGroup, ToolGroupMember, build_tool_group_paragraph,
+    discover_tool_group_bridge, discover_tool_groups, function_call, is_hidden_runtime_tool,
 };
 use crate::ui::components::messages::assistant_message::AssistantMessage;
 use crate::ui::components::messages::compacting_message::CompactingMessage;
@@ -43,6 +44,7 @@ use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{StatefulWidget, Widget};
 use ratatui_widgets::paragraph::Paragraph;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 /// Rough height estimate for an item, used to avoid expensive markdown rendering
@@ -114,6 +116,202 @@ fn rough_line_count(text: &str, width: usize) -> u16 {
         .map(|l| (l.chars().count().max(1) / width.max(1)).max(1) as u16)
         .sum();
     lines.max(wrapped).max(1)
+}
+
+fn live_cache_matches(
+    cache: &LiveRenderCache,
+    response_revision: u64,
+    content_width: u16,
+    conversation_len: usize,
+    conversation_mutation_version: u64,
+    expanded_items: &HashSet<usize>,
+    live_expanded_items: &HashSet<usize>,
+) -> bool {
+    cache.response_revision == response_revision
+        && cache.content_width == content_width
+        && cache.conversation_len == conversation_len
+        && cache.conversation_mutation_version == conversation_mutation_version
+        && cache.expanded_items == *expanded_items
+        && cache.live_expanded_items == *live_expanded_items
+}
+
+fn materialize_live_cache(
+    cache: &LiveRenderCache,
+    live_expanded_groups: &HashSet<String>,
+    expanded_tool_groups: &HashSet<String>,
+) -> MaterializedLiveCache {
+    let mut paragraphs = Vec::with_capacity(cache.slots.len());
+    let mut headers = Vec::with_capacity(cache.slots.len());
+    for slot in &cache.slots {
+        let (paragraph, group_header) =
+            materialize_live_slot(slot, live_expanded_groups, expanded_tool_groups);
+        paragraphs.push(paragraph);
+        headers.push(group_header);
+    }
+    (paragraphs, headers)
+}
+
+fn materialize_live_slot(
+    slot: &CachedLiveSlot,
+    live_expanded_groups: &HashSet<String>,
+    expanded_tool_groups: &HashSet<String>,
+) -> (LiveParagraph, LiveGroupHeader) {
+    match slot {
+        CachedLiveSlot::Fixed {
+            paragraph,
+            group_header,
+        } => (paragraph.clone(), group_header.clone()),
+        CachedLiveSlot::Explore {
+            group_key,
+            collapsed,
+            collapsed_headers,
+            expanded,
+            expanded_headers,
+        } => {
+            let is_expanded = live_expanded_groups.contains(group_key)
+                || expanded_tool_groups.contains(group_key);
+            let (paragraph, headers) = if is_expanded {
+                (expanded, expanded_headers)
+            } else {
+                (collapsed, collapsed_headers)
+            };
+            (
+                paragraph.clone(),
+                Some((group_key.clone(), headers.clone())),
+            )
+        }
+    }
+}
+
+fn empty_live_slot() -> CachedLiveSlot {
+    CachedLiveSlot::Fixed {
+        paragraph: (Arc::new(Paragraph::new("")), 0, Vec::new()),
+        group_header: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_live_group_slot<'a>(
+    group: &ToolGroup,
+    conversation_items: &'a [MessageItem],
+    receiving_items: &'a [(OutputItem, bool)],
+    outputs_by_call: &HashMap<&'a str, (&'a FunctionCallOutputItemParam, bool, Option<&'a str>)>,
+    expanded_items: &HashSet<usize>,
+    live_expanded_items: &HashSet<usize>,
+    live_index_base: usize,
+    content_width: u16,
+    group_expanded: bool,
+) -> CachedLiveSlot {
+    let live_outputs: Vec<Option<String>> = group
+        .member_indices
+        .iter()
+        .map(|&member_index| {
+            if member_index >= live_index_base {
+                return None;
+            }
+            let call = function_call(&conversation_items[member_index]).unwrap();
+            (!outputs_by_call.contains_key(call.call_id.as_str())
+                && call.name == crate::tools::command::NAME)
+                .then(|| crate::tools::command::live_output(&call.call_id))
+                .flatten()
+        })
+        .collect();
+    let members: Vec<ToolGroupMember<'_>> = group
+        .member_indices
+        .iter()
+        .enumerate()
+        .map(|(position, &member_index)| {
+            if member_index < live_index_base {
+                let call = function_call(&conversation_items[member_index]).unwrap();
+                return ToolGroupMember {
+                    index: member_index,
+                    call,
+                    output: outputs_by_call.get(call.call_id.as_str()).copied(),
+                    live_output: live_outputs[position].as_deref(),
+                    expanded: expanded_items.contains(&member_index),
+                };
+            }
+            let live_index = member_index - live_index_base;
+            let call = match &receiving_items[live_index].0 {
+                OutputItem::FunctionCall(call) => call,
+                _ => unreachable!("group members are calls"),
+            };
+            ToolGroupMember {
+                index: member_index,
+                call,
+                output: None,
+                live_output: None,
+                expanded: live_expanded_items.contains(&live_index),
+            }
+        })
+        .collect();
+    let absorbed: Vec<(usize, &ReasoningItem, bool)> = group
+        .absorbed
+        .iter()
+        .map(|&index| {
+            if index < live_index_base {
+                let item = match &conversation_items[index] {
+                    MessageItem::Output(OutputItem::Reasoning(item)) => item,
+                    _ => unreachable!("absorbed items are reasoning"),
+                };
+                return (index, item, expanded_items.contains(&index));
+            }
+            let live_index = index - live_index_base;
+            let item = match &receiving_items[live_index].0 {
+                OutputItem::Reasoning(item) => item,
+                _ => unreachable!("absorbed items are reasoning"),
+            };
+            (index, item, live_expanded_items.contains(&live_index))
+        })
+        .collect();
+    let thought_in_progress = group
+        .absorbed
+        .iter()
+        .chain(group.member_indices.iter())
+        .filter(|&&index| index >= live_index_base)
+        .any(|&index| receiving_items[index - live_index_base].1);
+
+    if group.is_explore() {
+        let (collapsed, collapsed_headers) = build_tool_group_paragraph(
+            group,
+            &members,
+            &absorbed,
+            content_width,
+            false,
+            thought_in_progress,
+        );
+        let collapsed_height = collapsed.line_count(content_width) as u16;
+        let (expanded, expanded_headers) = build_tool_group_paragraph(
+            group,
+            &members,
+            &absorbed,
+            content_width,
+            true,
+            thought_in_progress,
+        );
+        let expanded_height = expanded.line_count(content_width) as u16;
+        CachedLiveSlot::Explore {
+            group_key: group.key.clone(),
+            collapsed: (Arc::new(collapsed), collapsed_height, Vec::new()),
+            collapsed_headers,
+            expanded: (Arc::new(expanded), expanded_height, Vec::new()),
+            expanded_headers,
+        }
+    } else {
+        let (paragraph, member_headers) = build_tool_group_paragraph(
+            group,
+            &members,
+            &absorbed,
+            content_width,
+            group_expanded,
+            thought_in_progress,
+        );
+        let height = paragraph.line_count(content_width) as u16;
+        CachedLiveSlot::Fixed {
+            paragraph: (Arc::new(paragraph), height, Vec::new()),
+            group_header: Some((group.key.clone(), member_headers)),
+        }
+    }
 }
 
 /// Builds the paragraph for a finished history item. Called at most once per
@@ -219,22 +417,58 @@ impl Widget for &mut ConversationPanel {
         let conv_arc = self.conversation.clone();
         let conv = conv_arc.lock().unwrap();
 
-        let receiving_items = self
+        let live_response_revision = self
             .receiving_response
             .as_ref()
-            .map(|receiving_response| receiving_response.get_message_items())
+            .map(|response| response.render_revision())
             .unwrap_or_default();
-        let live_message_items: Vec<MessageItem> = receiving_items
-            .iter()
-            .map(|(output_item, _)| MessageItem::Output(output_item.clone()))
-            .collect();
-        let bridge_group = discover_tool_group_bridge(&conv.items, &live_message_items);
-        let bridged_committed_items: HashSet<usize> = bridge_group
-            .iter()
-            .flat_map(|group| group.member_indices.iter().chain(group.absorbed.iter()))
-            .copied()
-            .filter(|&index| index < conv.items.len())
-            .collect();
+        let live_cache_hit = self.live_render_cache.as_ref().is_some_and(|cache| {
+            live_cache_matches(
+                cache,
+                live_response_revision,
+                content_width,
+                conv.items.len(),
+                conv.mutation_version,
+                &self.expanded_items,
+                &self.live_expanded_items,
+            )
+        });
+        let (receiving_items, live_message_items, bridge_group, bridged_committed_items) =
+            if live_cache_hit {
+                (
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    self.live_render_cache
+                        .as_ref()
+                        .unwrap()
+                        .bridged_committed_items
+                        .clone(),
+                )
+            } else {
+                let receiving_items = self
+                    .receiving_response
+                    .as_ref()
+                    .map(|receiving_response| receiving_response.get_message_items())
+                    .unwrap_or_default();
+                let live_message_items: Vec<MessageItem> = receiving_items
+                    .iter()
+                    .map(|(output_item, _)| MessageItem::Output(output_item.clone()))
+                    .collect();
+                let bridge_group = discover_tool_group_bridge(&conv.items, &live_message_items);
+                let bridged_committed_items: HashSet<usize> = bridge_group
+                    .iter()
+                    .flat_map(|group| group.member_indices.iter().chain(group.absorbed.iter()))
+                    .copied()
+                    .filter(|&index| index < conv.items.len())
+                    .collect();
+                (
+                    receiving_items,
+                    live_message_items,
+                    bridge_group,
+                    bridged_committed_items,
+                )
+            };
 
         // Tool calls render together with their result as one message: map each
         // call_id to its result, and collect the call ids so the standalone
@@ -576,180 +810,166 @@ impl Widget for &mut ConversationPanel {
             content_height = content_height.saturating_add(entry.height);
         }
 
-        // The streaming response is the only content that changes between frames,
-        // so it is the only thing re-rendered here. Streaming items use the same
-        // tool-run grouping as the committed transcript (a run still growing is
-        // open), so a thought is absorbed into its group as soon as the first
-        // call of the run appears instead of standing alone until the response
-        // is committed.
         let live_index_base = conv.items.len();
-        let mut live_groups = discover_tool_groups(&live_message_items);
-        for group in &mut live_groups {
-            group.offset_indices(live_index_base);
-        }
-        if let Some(bridge_group) = bridge_group {
-            live_groups.retain(|group| {
-                !group
-                    .member_indices
-                    .iter()
-                    .chain(group.absorbed.iter())
-                    .any(|&index| {
-                        bridge_group
-                            .member_indices
-                            .iter()
-                            .chain(bridge_group.absorbed.iter())
-                            .any(|&bridge_index| bridge_index == index)
-                    })
-            });
-            live_groups.push(bridge_group);
-            live_groups.sort_by_key(|group| {
-                group
-                    .member_indices
-                    .iter()
-                    .chain(group.absorbed.iter())
-                    .filter(|&&index| index >= live_index_base)
-                    .copied()
-                    .min()
-                    .unwrap_or(usize::MAX)
-            });
-        }
-        let mut live_group_by_item = vec![None; receiving_items.len()];
-        for (group_index, group) in live_groups.iter().enumerate() {
-            for &item_index in group.member_indices.iter().chain(group.absorbed.iter()) {
-                if item_index >= live_index_base {
-                    live_group_by_item[item_index - live_index_base] = Some(group_index);
+        if live_cache_hit {
+            #[cfg(test)]
+            {
+                self.live_explore_cache_hits = self.live_explore_cache_hits.wrapping_add(1);
+            }
+            let (paragraphs, headers) = materialize_live_cache(
+                self.live_render_cache.as_ref().unwrap(),
+                &self.live_expanded_groups,
+                &self.expanded_tool_groups,
+            );
+            self.live_paragraphs = paragraphs;
+            self.live_group_headers = headers;
+        } else {
+            // Generate a new live cache only when stream content or nested view
+            // state changes. Explore groups pre-render both outer fold states.
+            let mut live_groups = discover_tool_groups(&live_message_items);
+            for group in &mut live_groups {
+                group.offset_indices(live_index_base);
+            }
+            if let Some(bridge_group) = bridge_group {
+                live_groups.retain(|group| {
+                    !group
+                        .member_indices
+                        .iter()
+                        .chain(group.absorbed.iter())
+                        .any(|&index| {
+                            bridge_group
+                                .member_indices
+                                .iter()
+                                .chain(bridge_group.absorbed.iter())
+                                .any(|&bridge_index| bridge_index == index)
+                        })
+                });
+                live_groups.push(bridge_group);
+                live_groups.sort_by_key(|group| {
+                    group
+                        .member_indices
+                        .iter()
+                        .chain(group.absorbed.iter())
+                        .filter(|&&index| index >= live_index_base)
+                        .copied()
+                        .min()
+                        .unwrap_or(usize::MAX)
+                });
+            }
+            let mut live_group_by_item = vec![None; receiving_items.len()];
+            for (group_index, group) in live_groups.iter().enumerate() {
+                for &item_index in group.member_indices.iter().chain(group.absorbed.iter()) {
+                    if item_index >= live_index_base {
+                        live_group_by_item[item_index - live_index_base] = Some(group_index);
+                    }
                 }
             }
-        }
-        // Parallel to `live_paragraphs`: the group's key and clickable member
-        // header rows (relative to that paragraph) when the slot is a group.
-        let mut live_group_headers: Vec<Option<(String, Vec<MemberHeader>)>> =
-            Vec::with_capacity(receiving_items.len());
-        let mut live_paragraphs = Vec::with_capacity(receiving_items.len());
-        for i in 0..receiving_items.len() {
-            let (output_item, in_progress) = &receiving_items[i];
-            let expanded = self.live_expanded_items.contains(&i);
-            if let Some(group_index) = live_group_by_item[i] {
-                let group = &live_groups[group_index];
-                let first_live_index = group
-                    .member_indices
-                    .iter()
-                    .chain(group.absorbed.iter())
-                    .filter(|&&index| index >= live_index_base)
-                    .copied()
-                    .min()
-                    .expect("live group has a streaming item")
-                    - live_index_base;
-                if first_live_index != i {
-                    // Hidden inside the group's own paragraph. Keep a
-                    // zero-height slot so `live_group_headers` and
-                    // `live_paragraphs` stay index-aligned with
-                    // `receiving_items` (clicks toggle live indices directly).
+
+            let mut live_group_headers = Vec::with_capacity(receiving_items.len());
+            let mut live_paragraphs = Vec::with_capacity(receiving_items.len());
+            let mut cache_slots = Vec::with_capacity(receiving_items.len());
+            let mut cacheable = !receiving_items.is_empty();
+            let mut saw_explore = false;
+            for i in 0..receiving_items.len() {
+                let (output_item, in_progress) = &receiving_items[i];
+                let expanded = self.live_expanded_items.contains(&i);
+                if let Some(group_index) = live_group_by_item[i] {
+                    let group = &live_groups[group_index];
+                    let first_live_index = group
+                        .member_indices
+                        .iter()
+                        .chain(group.absorbed.iter())
+                        .filter(|&&index| index >= live_index_base)
+                        .copied()
+                        .min()
+                        .expect("live group has a streaming item")
+                        - live_index_base;
+                    if first_live_index != i {
+                        let slot = empty_live_slot();
+                        let (paragraph, group_header) = materialize_live_slot(
+                            &slot,
+                            &self.live_expanded_groups,
+                            &self.expanded_tool_groups,
+                        );
+                        live_paragraphs.push(paragraph);
+                        live_group_headers.push(group_header);
+                        cache_slots.push(slot);
+                        continue;
+                    }
+                    if group.is_explore() {
+                        saw_explore = true;
+                        #[cfg(test)]
+                        {
+                            self.live_explore_builds = self.live_explore_builds.wrapping_add(1);
+                        }
+                    } else {
+                        cacheable = false;
+                    }
+                    let group_expanded = self.live_expanded_groups.contains(&group.key)
+                        || self.expanded_tool_groups.contains(&group.key);
+                    let slot = build_live_group_slot(
+                        group,
+                        &conv.items,
+                        &receiving_items,
+                        &outputs_by_call,
+                        &self.expanded_items,
+                        &self.live_expanded_items,
+                        live_index_base,
+                        content_width,
+                        group_expanded,
+                    );
+                    let (paragraph, group_header) = materialize_live_slot(
+                        &slot,
+                        &self.live_expanded_groups,
+                        &self.expanded_tool_groups,
+                    );
+                    live_paragraphs.push(paragraph);
+                    live_group_headers.push(group_header);
+                    cache_slots.push(slot);
+                } else {
+                    if matches!(output_item, OutputItem::FunctionCall(call) if is_hidden_runtime_tool(call))
+                    {
+                        let slot = empty_live_slot();
+                        let (paragraph, group_header) = materialize_live_slot(
+                            &slot,
+                            &self.live_expanded_groups,
+                            &self.expanded_tool_groups,
+                        );
+                        live_paragraphs.push(paragraph);
+                        live_group_headers.push(group_header);
+                        cache_slots.push(slot);
+                        continue;
+                    }
+                    cacheable = false;
+                    let (paragraph, copy_buttons) =
+                        AssistantMessage::new(output_item, content_width)
+                            .in_progress(*in_progress)
+                            .expanded(expanded)
+                            .frame_count(self.frame_count)
+                            .into_paragraph();
+                    let height = paragraph.line_count(content_width) as u16;
+                    let paragraph = (Arc::new(paragraph), height, copy_buttons);
+                    live_paragraphs.push(paragraph.clone());
                     live_group_headers.push(None);
-                    live_paragraphs.push((Paragraph::new(""), 0, Vec::new()));
-                    continue;
+                    cache_slots.push(CachedLiveSlot::Fixed {
+                        paragraph,
+                        group_header: None,
+                    });
                 }
-                let live_outputs: Vec<Option<String>> = group
-                    .member_indices
-                    .iter()
-                    .map(|&member_index| {
-                        if member_index >= live_index_base {
-                            return None;
-                        }
-                        let call = function_call(&conv.items[member_index]).unwrap();
-                        (!outputs_by_call.contains_key(call.call_id.as_str())
-                            && call.name == crate::tools::command::NAME)
-                            .then(|| crate::tools::command::live_output(&call.call_id))
-                            .flatten()
-                    })
-                    .collect();
-                let members: Vec<ToolGroupMember<'_>> = group
-                    .member_indices
-                    .iter()
-                    .enumerate()
-                    .map(|(position, &member_index)| {
-                        if member_index < live_index_base {
-                            let call = function_call(&conv.items[member_index]).unwrap();
-                            return ToolGroupMember {
-                                index: member_index,
-                                call,
-                                output: outputs_by_call.get(call.call_id.as_str()).copied(),
-                                live_output: live_outputs[position].as_deref(),
-                                expanded: self.expanded_items.contains(&member_index),
-                            };
-                        }
-                        let live_index = member_index - live_index_base;
-                        let call = match &receiving_items[live_index].0 {
-                            OutputItem::FunctionCall(call) => call,
-                            _ => unreachable!("group members are calls"),
-                        };
-                        ToolGroupMember {
-                            index: member_index,
-                            call,
-                            output: None,
-                            live_output: None,
-                            expanded: self.live_expanded_items.contains(&live_index),
-                        }
-                    })
-                    .collect();
-                let absorbed: Vec<(usize, &ReasoningItem, bool)> = group
-                    .absorbed
-                    .iter()
-                    .map(|&index| {
-                        if index < live_index_base {
-                            let item = match &conv.items[index] {
-                                MessageItem::Output(OutputItem::Reasoning(item)) => item,
-                                _ => unreachable!("absorbed items are reasoning"),
-                            };
-                            return (index, item, self.expanded_items.contains(&index));
-                        }
-                        let live_index = index - live_index_base;
-                        let item = match &receiving_items[live_index].0 {
-                            OutputItem::Reasoning(item) => item,
-                            _ => unreachable!("absorbed items are reasoning"),
-                        };
-                        (index, item, self.live_expanded_items.contains(&live_index))
-                    })
-                    .collect();
-                // Live groups stay collapsed by default, same as committed
-                // ones; the streaming thought state rides on the muted summary
-                // line under the header.
-                let group_expanded = self.live_expanded_groups.contains(&group.key)
-                    || self.expanded_tool_groups.contains(&group.key);
-                let thought_in_progress = group
-                    .absorbed
-                    .iter()
-                    .chain(group.member_indices.iter())
-                    .filter(|&&index| index >= live_index_base)
-                    .any(|&index| receiving_items[index - live_index_base].1);
-                let (paragraph, member_headers) = build_tool_group_paragraph(
-                    group,
-                    &members,
-                    &absorbed,
-                    content_width,
-                    group_expanded,
-                    thought_in_progress,
-                );
-                let height = paragraph.line_count(content_width) as u16;
-                live_group_headers.push(Some((group.key.clone(), member_headers)));
-                live_paragraphs.push((paragraph, height, Vec::new()));
-            } else {
-                live_group_headers.push(None);
-                if matches!(output_item, OutputItem::FunctionCall(call) if is_hidden_runtime_tool(call))
-                {
-                    live_paragraphs.push((Paragraph::new(""), 0, Vec::new()));
-                    continue;
-                }
-                let (paragraph, copy_buttons) = AssistantMessage::new(output_item, content_width)
-                    .in_progress(*in_progress)
-                    .expanded(expanded)
-                    .frame_count(self.frame_count)
-                    .into_paragraph();
-                let height = paragraph.line_count(content_width) as u16;
-                live_paragraphs.push((paragraph, height, copy_buttons));
             }
+            self.live_paragraphs = live_paragraphs;
+            self.live_group_headers = live_group_headers;
+            self.live_render_cache = (cacheable && saw_explore).then(|| LiveRenderCache {
+                response_revision: live_response_revision,
+                content_width,
+                conversation_len: conv.items.len(),
+                conversation_mutation_version: conv.mutation_version,
+                expanded_items: self.expanded_items.clone(),
+                live_expanded_items: self.live_expanded_items.clone(),
+                bridged_committed_items: bridged_committed_items.clone(),
+                slots: cache_slots,
+            });
         }
-        self.live_paragraphs = live_paragraphs;
         for (_, height, _) in &self.live_paragraphs {
             content_height = content_height.saturating_add(*height);
         }
@@ -855,7 +1075,7 @@ impl Widget for &mut ConversationPanel {
         let mut live_tool_group_layout = Vec::new();
         for (i, (paragraph, height, _)) in self.live_paragraphs.iter().enumerate() {
             live_layout.push((i, y, y.saturating_add(*height)));
-            if let Some((key, headers)) = &live_group_headers[i] {
+            if let Some((key, headers)) = &self.live_group_headers[i] {
                 live_tool_group_layout.push(ToolGroupLayout {
                     key: key.clone(),
                     top: y,
@@ -872,7 +1092,8 @@ impl Widget for &mut ConversationPanel {
                 });
             }
             if visible(y, *height) {
-                scroll_view.render_widget(paragraph, Rect::new(0, y, content_width, *height));
+                scroll_view
+                    .render_widget(paragraph.as_ref(), Rect::new(0, y, content_width, *height));
             }
             y = y.saturating_add(*height);
         }
@@ -1234,6 +1455,80 @@ mod tests {
         panel.handle_click(2, header_row as u16);
         let expanded = render_text(&mut panel, area);
         assert!(expanded.contains("grep  {}"), "{expanded}");
+    }
+
+    #[test]
+    fn live_explore_group_reuses_layout_until_content_or_view_changes() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            ReasoningItem, ResponseOutputItemAddedEvent, ResponseReasoningSummaryTextDeltaEvent,
+            ResponseStreamEvent, SummaryPart, SummaryTextContent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Reasoning(ReasoningItem {
+                    id: Some("reasoning-0".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "cached reasoning".into(),
+                    })],
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                }),
+            },
+        ));
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 1,
+                output_index: 1,
+                item: OutputItem::FunctionCall(tool_call(0, "grep")),
+            },
+        ));
+
+        let area = Rect::new(0, 0, 80, 24);
+        let collapsed = render_text(&mut panel, area);
+        assert_eq!(panel.live_explore_builds, 1);
+        let header_row = collapsed
+            .lines()
+            .position(|line| line.contains("Exploring"))
+            .unwrap() as u16;
+
+        panel.handle_click(2, header_row);
+        let expanded = render_text(&mut panel, area);
+        assert!(expanded.contains("cached reasoning"), "{expanded}");
+        assert_eq!(
+            panel.live_explore_builds, 1,
+            "the expanded form must be generated with the message"
+        );
+        assert_eq!(panel.live_explore_cache_hits, 1);
+
+        let unchanged = render_text(&mut panel, area);
+        assert!(unchanged.contains("cached reasoning"), "{unchanged}");
+        assert_eq!(
+            panel.live_explore_builds, 1,
+            "an unchanged animation/timer frame must reuse the live paragraph"
+        );
+        assert_eq!(panel.live_explore_cache_hits, 2);
+
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseReasoningSummaryTextDelta(
+            ResponseReasoningSummaryTextDeltaEvent {
+                sequence_number: 2,
+                item_id: "reasoning-0".into(),
+                output_index: 0,
+                summary_index: 0,
+                delta: " updated".into(),
+            },
+        ));
+        let updated = render_text(&mut panel, area);
+        assert!(updated.contains("cached reasoning updated"), "{updated}");
+        assert_eq!(panel.live_explore_builds, 2, "new content must invalidate");
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -17,6 +17,7 @@ use crate::response::message_item::MessageItem;
 use crate::ui::components::conversation_panel::conversation_panel::{
     ActivePhase, CachedLiveSlot, CachedParagraph, CachedToolGroup, ConversationPanel,
     LiveGroupHeader, LiveParagraph, LiveRenderCache, MaterializedLiveCache, ToolGroupLayout,
+    ViewportParagraphCache,
 };
 use crate::ui::components::conversation_panel::tool_group::{
     MemberHeader, ToolGroup, ToolGroupMember, build_tool_group_paragraph,
@@ -39,13 +40,12 @@ use async_openai::types::responses::{
     OutputItem, ReasoningItem,
 };
 use ratatui::buffer::Buffer;
-use ratatui::layout::{Rect, Size};
+use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{StatefulWidget, Widget};
+use ratatui::widgets::Widget;
 use ratatui_widgets::paragraph::Paragraph;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 /// Rough height estimate for an item, used to avoid expensive markdown rendering
 /// for items far from the viewport. Returns a u16 line count.
@@ -116,6 +116,117 @@ fn rough_line_count(text: &str, width: usize) -> u16 {
         .map(|l| (l.chars().count().max(1) / width.max(1)).max(1) as u16)
         .sum();
     lines.max(wrapped).max(1)
+}
+
+/// Render one paragraph from virtual conversation coordinates directly into
+/// the viewport. A paragraph crossing the top edge is vertically scrolled;
+/// everything below the viewport is clipped by the destination buffer.
+fn virtual_window(
+    item_top: u16,
+    item_height: u16,
+    viewport_top: u16,
+    viewport: Rect,
+) -> Option<(u16, Rect)> {
+    let visible_top = item_top.max(viewport_top);
+    let visible_bottom = item_top
+        .saturating_add(item_height)
+        .min(viewport_top.saturating_add(viewport.height));
+    if visible_top >= visible_bottom {
+        return None;
+    }
+
+    let source_offset = visible_top.saturating_sub(item_top);
+    let destination_y = viewport
+        .y
+        .saturating_add(visible_top.saturating_sub(viewport_top));
+    let destination = Rect::new(
+        viewport.x,
+        destination_y,
+        viewport.width,
+        visible_bottom.saturating_sub(visible_top),
+    );
+    Some((source_offset, destination))
+}
+
+fn render_virtual_paragraph(
+    paragraph: &Arc<Paragraph<'static>>,
+    item_top: u16,
+    item_height: u16,
+    viewport_top: u16,
+    viewport: Rect,
+    buf: &mut Buffer,
+    clipped: &mut ViewportParagraphCache,
+) {
+    let Some((source_offset, destination)) =
+        virtual_window(item_top, item_height, viewport_top, viewport)
+    else {
+        return;
+    };
+
+    if source_offset == 0 {
+        paragraph.as_ref().render(destination, buf);
+    } else {
+        clipped
+            .scrolled(paragraph, source_offset)
+            .as_ref()
+            .render(destination, buf);
+    }
+}
+
+fn render_virtual_borrowed_paragraph(
+    paragraph: &Paragraph<'_>,
+    item_top: u16,
+    item_height: u16,
+    viewport_top: u16,
+    viewport: Rect,
+    buf: &mut Buffer,
+) {
+    let Some((source_offset, destination)) =
+        virtual_window(item_top, item_height, viewport_top, viewport)
+    else {
+        return;
+    };
+    if source_offset == 0 {
+        paragraph.render(destination, buf);
+    } else {
+        paragraph
+            .clone()
+            .scroll((source_offset, 0))
+            .render(destination, buf);
+    }
+}
+
+/// The welcome card is small and not a paragraph, so clip it through a tiny
+/// temporary buffer when the viewport starts inside it.
+fn render_virtual_welcome(
+    welcome: &WelcomeMessage,
+    height: u16,
+    viewport_top: u16,
+    viewport: Rect,
+    buf: &mut Buffer,
+) {
+    if viewport_top >= height {
+        return;
+    }
+    if viewport_top == 0 {
+        welcome.render(
+            Rect::new(viewport.x, viewport.y, viewport.width, height),
+            buf,
+        );
+        return;
+    }
+
+    let mut card = Buffer::empty(Rect::new(0, 0, viewport.width, height));
+    welcome.render(card.area, &mut card);
+    let rows = height.saturating_sub(viewport_top).min(viewport.height);
+    for row in 0..rows {
+        for column in 0..viewport.width {
+            let source = card[(column, viewport_top + row)].clone();
+            if let Some(target) = buf.cell_mut((viewport.x + column, viewport.y + row)) {
+                *target = source;
+            }
+        }
+    }
 }
 
 fn live_cache_matches(
@@ -691,7 +802,7 @@ impl Widget for &mut ConversationPanel {
             if needs_build {
                 let entry = if hidden {
                     CachedParagraph {
-                        paragraph: Paragraph::new(""),
+                        paragraph: Arc::new(Paragraph::new("")),
                         height: 0,
                         hidden: true,
                         expanded,
@@ -702,7 +813,7 @@ impl Widget for &mut ConversationPanel {
                     }
                 } else if !in_viewport {
                     CachedParagraph {
-                        paragraph: Paragraph::new(""),
+                        paragraph: Arc::new(Paragraph::new("")),
                         height: est_heights[index],
                         hidden: false,
                         expanded,
@@ -766,7 +877,7 @@ impl Widget for &mut ConversationPanel {
                     );
                     let height = paragraph.line_count(content_width) as u16;
                     CachedParagraph {
-                        paragraph,
+                        paragraph: Arc::new(paragraph),
                         height,
                         hidden: false,
                         expanded,
@@ -789,7 +900,7 @@ impl Widget for &mut ConversationPanel {
                     );
                     let height = paragraph.line_count(content_width) as u16;
                     CachedParagraph {
-                        paragraph,
+                        paragraph: Arc::new(paragraph),
                         height,
                         hidden: false,
                         expanded,
@@ -977,7 +1088,7 @@ impl Widget for &mut ConversationPanel {
         let compacting = (self.phase == ActivePhase::Compacting).then(|| {
             let paragraph = CompactingMessage::into_paragraph();
             let height = paragraph.line_count(content_width) as u16;
-            (paragraph, height)
+            (Arc::new(paragraph), height)
         });
         if let Some((_, height)) = &compacting {
             content_height = content_height.saturating_add(*height);
@@ -1005,34 +1116,31 @@ impl Widget for &mut ConversationPanel {
         }
         self.last_content_height = content_height;
 
-        // Follow the bottom while the user hasn't scrolled up. Doing this here
-        // (rather than re-snapping on every incoming chunk) is what lets manual
-        // scrolling stick during streaming.
+        // Clamp the virtual scroll range after content height changes, then
+        // follow the bottom while the user hasn't manually scrolled away.
+        self.scroll_view_state.update(content_height, area.height);
         if stick_to_bottom {
             self.scroll_view_state.scroll_to_bottom();
         }
 
-        // Only the rows in the current scroll window are visible, so skip
-        // rendering paragraphs that fall entirely outside it. `render_widget`
-        // (re)wraps and writes every cell of a paragraph, so culling off-screen
-        // ones turns each frame from O(whole conversation) into O(viewport).
-        //
-        // The offset is clamped exactly as `ScrollView::render` does below, which
-        // also resolves the `u16::MAX` sentinel that `scroll_to_bottom` leaves in
-        // the state (used every frame while auto-following a streaming reply).
-        let max_y_offset = content_height.saturating_sub(area.height);
-        let visible_top = self.scroll_view_state.offset().y.min(max_y_offset);
+        // Paint directly into the viewport. This avoids `ScrollView`'s
+        // width-by-full-content-height backing buffer, which made a large
+        // expanded group expensive on every animation frame.
+        let visible_top = self.scroll_view_state.offset().y;
         let visible_bottom = visible_top.saturating_add(area.height);
         let visible =
             |y: u16, height: u16| y < visible_bottom && y.saturating_add(height) > visible_top;
+        let clipped_paragraphs = &mut self.viewport_paragraph_cache;
+        clipped_paragraphs.begin_frame(visible_top);
 
-        let mut scroll_view = ScrollView::new(Size::new(content_width, content_height))
-            .scrollbars_visibility(ScrollbarVisibility::Never);
         let mut y = 0u16;
         if visible(y, welcome_height) {
-            scroll_view.render_widget(
+            render_virtual_welcome(
                 &welcome_message,
-                Rect::new(0, y, content_width, welcome_height),
+                welcome_height,
+                visible_top,
+                content_area,
+                buf,
             );
         }
         y = y.saturating_add(welcome_height);
@@ -1063,9 +1171,14 @@ impl Widget for &mut ConversationPanel {
                 });
             }
             if visible(y, entry.height) {
-                scroll_view.render_widget(
+                render_virtual_paragraph(
                     &entry.paragraph,
-                    Rect::new(0, y, content_width, entry.height),
+                    y,
+                    entry.height,
+                    visible_top,
+                    content_area,
+                    buf,
+                    clipped_paragraphs,
                 );
             }
             y = y.saturating_add(entry.height);
@@ -1092,14 +1205,29 @@ impl Widget for &mut ConversationPanel {
                 });
             }
             if visible(y, *height) {
-                scroll_view
-                    .render_widget(paragraph.as_ref(), Rect::new(0, y, content_width, *height));
+                render_virtual_paragraph(
+                    paragraph,
+                    y,
+                    *height,
+                    visible_top,
+                    content_area,
+                    buf,
+                    clipped_paragraphs,
+                );
             }
             y = y.saturating_add(*height);
         }
         if let Some((paragraph, height)) = &compacting {
             if visible(y, *height) {
-                scroll_view.render_widget(paragraph, Rect::new(0, y, content_width, *height));
+                render_virtual_paragraph(
+                    paragraph,
+                    y,
+                    *height,
+                    visible_top,
+                    content_area,
+                    buf,
+                    clipped_paragraphs,
+                );
             }
             y = y.saturating_add(*height);
         }
@@ -1107,13 +1235,19 @@ impl Widget for &mut ConversationPanel {
         if let Some((paragraph, height)) = &pending
             && visible(y, *height)
         {
-            scroll_view.render_widget(paragraph, Rect::new(0, y, content_width, *height));
+            render_virtual_borrowed_paragraph(
+                paragraph,
+                y,
+                *height,
+                visible_top,
+                content_area,
+                buf,
+            );
         }
-        scroll_view.render(content_area, buf, &mut self.scroll_view_state);
+        clipped_paragraphs.finish_frame();
         crate::ui::image_preview::render_protocol_images(content_area, buf);
 
-        // The scroll view has now clamped the offset to its real value; store it
-        // and the layout for click hit-testing on the next event.
+        // Store the virtual offset and layout for click hit-testing.
         let offset = self.scroll_view_state.offset().y;
 
         // Draw a minimal custom scrollbar: no background, thin gray thumb. It
@@ -1199,7 +1333,7 @@ impl Widget for &mut ConversationPanel {
 
 #[cfg(test)]
 mod tests {
-    use super::is_hidden_developer_input;
+    use super::{is_hidden_developer_input, render_virtual_paragraph};
     use async_openai::types::responses::{
         FunctionCallOutput, FunctionCallOutputItemParam, FunctionToolCall, InputContent,
         InputMessage, InputRole, InputTextContent, Item, MessageItem as ApiMessageItem, OutputItem,
@@ -1208,10 +1342,12 @@ mod tests {
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
     use ratatui::widgets::Widget;
+    use ratatui_widgets::paragraph::Paragraph;
+    use std::sync::Arc;
 
     use crate::tools::ToolOutput;
     use crate::ui::components::conversation_panel::conversation_panel::{
-        ActivePhase, ConversationPanel,
+        ActivePhase, ConversationPanel, ViewportParagraphCache,
     };
 
     #[test]
@@ -1366,6 +1502,31 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn virtual_paragraph_renders_only_the_requested_window() {
+        let lines = (0..1_000)
+            .map(|line| ratatui::text::Line::from(format!("row {line}")))
+            .collect::<Vec<_>>();
+        let paragraph = Arc::new(Paragraph::new(lines));
+        let area = Rect::new(0, 0, 20, 4);
+        let mut buffer = Buffer::empty(area);
+        let mut cache = ViewportParagraphCache::default();
+        cache.begin_frame(990);
+
+        render_virtual_paragraph(&paragraph, 0, 1_000, 990, area, &mut buffer, &mut cache);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "r");
+        assert!(
+            buffer
+                .content
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<String>()
+                .contains("row 990")
+        );
+        assert_eq!(buffer.area.height, 4);
     }
 
     #[test]

--- a/src/ui/components/messages/assistant/reasoning.rs
+++ b/src/ui/components/messages/assistant/reasoning.rs
@@ -19,6 +19,7 @@ use ratatui_markdown::markdown::MarkdownRenderer;
 
 use crate::ui::markdown_code_block::CodeBlockHooks;
 use crate::ui::markdown_theme::AppTheme;
+use crate::ui::text::truncate_to_width;
 
 use super::muted_style;
 
@@ -28,6 +29,9 @@ const BLOCK_PAD: u16 = 2;
 /// Extra left indent applied to expanded reasoning lines, keeping a visual
 /// nesting relationship under the "✻ Thought" header.
 const INDENT: u16 = 2;
+/// Keep the status row compact. The complete summary remains available in the
+/// expanded Markdown body.
+const SUMMARY_TITLE_WIDTH: usize = 72;
 
 /// Renders the reasoning indicator. Collapsed it's a single line ("Thinking..."
 /// while streaming with animated dots, "Thought" once done); expanded it also
@@ -140,7 +144,7 @@ pub(crate) fn reasoning_summary_title(item: &ReasoningItem) -> Option<String> {
         .collect::<Vec<_>>()
         .join(" ");
 
-    (!title.is_empty()).then_some(title)
+    (!title.is_empty()).then(|| truncate_to_width(&title, SUMMARY_TITLE_WIDTH))
 }
 
 /// The reasoning text, preferring the summary and falling back to the raw
@@ -201,5 +205,17 @@ mod tests {
             text.lines[0].to_string(),
             "▸ ✻ Thinking... · Checking tool grouping"
         );
+    }
+
+    #[test]
+    fn long_summary_is_truncated_only_in_the_title() {
+        let summary = "analysis ".repeat(20);
+        let item = reasoning_with_summary(&summary);
+
+        let title = reasoning_summary_title(&item).unwrap();
+        assert!(title.ends_with('…'));
+        assert!(title.len() < summary.len());
+
+        assert_eq!(reasoning_text(&item), summary);
     }
 }

--- a/src/ui/event.rs
+++ b/src/ui/event.rs
@@ -19,6 +19,8 @@ use async_openai::types::responses::{FunctionToolCall, ResponseStreamEvent};
 use color_eyre::eyre::OptionExt;
 use crossterm::event::Event as CrosstermEvent;
 use futures::{FutureExt, StreamExt};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -297,6 +299,9 @@ pub struct EventHandler {
     pub sender: mpsc::UnboundedSender<Event>,
     /// Event receiver channel.
     receiver: mpsc::UnboundedReceiver<Event>,
+    /// At most one tick may wait in the FIFO, so a slow render cannot bury
+    /// keyboard and mouse events under stale animation work.
+    tick_queued: Arc<AtomicBool>,
     /// The task that reads crossterm events and emits ticks.
     _task: tokio::task::JoinHandle<()>,
 }
@@ -307,6 +312,8 @@ impl EventHandler {
         let tick_rate = tick_interval();
         let (sender, receiver) = mpsc::unbounded_channel();
         let _sender = sender.clone();
+        let tick_queued = Arc::new(AtomicBool::new(false));
+        let producer_tick_queued = tick_queued.clone();
         let _task = tokio::spawn(async move {
             let mut reader = crossterm::event::EventStream::new();
             let mut tick = tokio::time::interval(tick_rate);
@@ -318,7 +325,7 @@ impl EventHandler {
                     break;
                   }
                   _ = tick_delay => {
-                    let _ = _sender.send(Event::Tick);
+                    queue_tick(&_sender, &producer_tick_queued);
                   }
                   Some(Ok(evt)) = crossterm_event => {
                     let _ = _sender.send(Event::Crossterm(evt));
@@ -330,6 +337,7 @@ impl EventHandler {
         Self {
             sender,
             receiver,
+            tick_queued,
             _task,
         }
     }
@@ -339,17 +347,22 @@ impl EventHandler {
     /// This function will block the current thread until an event is received. The event can be a
     /// tick event, a crossterm event, or an application event.
     pub async fn next(&mut self) -> color_eyre::Result<Event> {
-        self.receiver
+        let event = self
+            .receiver
             .recv()
             .await
-            .ok_or_eyre("application event channel closed unexpectedly")
+            .ok_or_eyre("application event channel closed unexpectedly")?;
+        self.mark_received(&event);
+        Ok(event)
     }
 
     /// Attempt to receive an event without blocking.
     ///
     /// This can be used to drain the event queue between frames.
     pub fn try_next(&mut self) -> Option<Event> {
-        self.receiver.try_recv().ok()
+        let event = self.receiver.try_recv().ok()?;
+        self.mark_received(&event);
+        Some(event)
     }
 
     /// Queue an app event to be sent to the event receiver.
@@ -361,6 +374,22 @@ impl EventHandler {
         // reference to it
         let _ = self.sender.send(Event::App(app_event));
     }
+
+    fn mark_received(&self, event: &Event) {
+        if matches!(event, Event::Tick) {
+            self.tick_queued.store(false, Ordering::Release);
+        }
+    }
+}
+
+fn queue_tick(sender: &mpsc::UnboundedSender<Event>, queued: &AtomicBool) {
+    if queued
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+        && sender.send(Event::Tick).is_err()
+    {
+        queued.store(false, Ordering::Release);
+    }
 }
 
 fn tick_interval() -> Duration {
@@ -369,7 +398,9 @@ fn tick_interval() -> Duration {
 
 #[cfg(test)]
 mod tests {
-    use super::tick_interval;
+    use super::{Event, queue_tick, tick_interval};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::mpsc;
 
     #[test]
     fn tick_interval_is_one_over_tick_fps() {
@@ -380,5 +411,20 @@ mod tests {
             (30..=35).contains(&ms),
             "expected ~33ms per tick, got {ms}ms — is the formula 1.0 / TICK_FPS?"
         );
+    }
+
+    #[test]
+    fn queued_ticks_are_coalesced_until_consumed() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let queued = AtomicBool::new(false);
+
+        queue_tick(&sender, &queued);
+        queue_tick(&sender, &queued);
+        assert!(matches!(receiver.try_recv(), Ok(Event::Tick)));
+        assert!(receiver.try_recv().is_err());
+
+        queued.store(false, Ordering::Release);
+        queue_tick(&sender, &queued);
+        assert!(matches!(receiver.try_recv(), Ok(Event::Tick)));
     }
 }


### PR DESCRIPTION
### Programmer v0.2.3

- Cache live Exploring layouts while streaming.
- Virtualize long conversation rendering to keep expanded blocks responsive.
- Coalesce stale animation ticks so keyboard and mouse input stay responsive.
- Keep reasoning summary titles compact while preserving the full expanded summary.
- Improve project onboarding and issue templates.

Validation: 488 tests passed, 1 ignored; clippy passed with warnings denied.