### PR TITLE
v0.2.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Programmer version
       description: Run `programmer --version` or provide the release tag/commit.
-      placeholder: v0.2.3
+      placeholder: v0.2.4
     validations:
       required: true
   - type: dropdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-openai"
-version = "0.41.1"
+version = "0.41.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3007014661d5b98168b7b6f1014147bce8b1362a194783543eeb9f6117a20be9"
+checksum = "d72db2750faea2ca5edbf6d0c50277a89dc8f75f5e6ddd695ef30f75e335019b"
 dependencies = [
  "async-openai-macros",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,9 +3737,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3759,22 +3759,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.3"
+version = "0.2.4"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
 Both installers select the release asset for the current OS and architecture.
-Use `--version v0.2.3` with `install.sh`, or `-Version v0.2.3` with
+Use `--version v0.2.4` with `install.sh`, or `-Version v0.2.4` with
 `install.ps1`, to install a specific release.
 
 ## Quick start
@@ -107,7 +107,7 @@ Once installed, Programmer can update or remove its own executable:
 ```sh
 programmer upgrade --check
 programmer upgrade
-programmer upgrade --tag v0.2.3
+programmer upgrade --tag v0.2.4
 programmer uninstall
 programmer uninstall --purge
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+# programmer v0.2.4
+
+v0.2.4 focuses on streaming rendering performance and dependency updates.
+
+## Highlights
+
+- Render streaming Markdown off the UI thread: long assistant responses no
+  longer block input handling or redraws while tokens arrive.
+- Virtualize and cache conversation panel layout work so long conversations
+  scroll and render smoothly.
+- Optimize streaming Markdown rendering for fewer intermediate re-parses.
+
+## Dependencies
+
+- Bumped async-openai from 0.41.1 to 0.41.3.
+- Bumped serde from 1.0.228 to 1.0.229.
+
+**Full changelog:** https://github.com/huangdihd/programmer/compare/v0.2.3...v0.2.4
+
+---
+
 # programmer v0.2.2
 
 v0.2.2 adds recoverable conversation navigation, automatic context management,

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -149,6 +149,7 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
             use crate::runner::RunnerPhase;
             app.conversation_panel.phase = match p {
                 RunnerPhase::Streaming => {
+                    app.conversation_panel.begin_live_response();
                     app.conversation_panel.receiving_response =
                         Some(PartialResponse::new(app.cancel.active.child()));
                     ActivePhase::None // "Thinking" — derived from receiving_response

--- a/src/response/partial_response.rs
+++ b/src/response/partial_response.rs
@@ -64,6 +64,10 @@ pub struct PartialResponse {
     /// being generated ("Thinking...") or complete ("Thought"), since the item's
     /// own `status` field is only populated for finalized items.
     finished_items: Vec<bool>,
+    /// Per-output-item content revisions. Unlike `render_revision`, this only
+    /// advances for events addressed to the item, so unrelated tool deltas do
+    /// not cause the live Markdown worker to clone and parse it again.
+    item_revisions: Vec<u64>,
     finish_reason: Option<ResponseFinishReason>,
     /// Cancelled when the user presses Escape to stop the current request.
     pub cancelled: CancellationToken,
@@ -73,6 +77,10 @@ pub struct PartialResponse {
     /// response. The TUI uses it to reuse an unchanged live tool-group layout
     /// across animation/timer frames without hashing or cloning the full text.
     render_revision: u64,
+    /// Changes only when an event addresses an output item. Lifecycle and
+    /// usage events leave this untouched, so a cached Markdown page survives
+    /// unrelated stream bookkeeping.
+    item_render_revision: u64,
 }
 
 impl PartialResponse {
@@ -80,10 +88,12 @@ impl PartialResponse {
         PartialResponse {
             items: vec![],
             finished_items: vec![],
+            item_revisions: vec![],
             finish_reason: None,
             cancelled,
             usage: None,
             render_revision: 0,
+            item_render_revision: 0,
         }
     }
 
@@ -92,13 +102,40 @@ impl PartialResponse {
             self.items.resize((output_index + 1) as usize, None);
             self.finished_items
                 .resize((output_index + 1) as usize, false);
+            self.item_revisions.resize((output_index + 1) as usize, 0);
         }
         self.items[output_index as usize] = Some(item);
+    }
+
+    fn bump_item_revision(&mut self, output_index: usize) {
+        if self.item_revisions.len() <= output_index {
+            self.item_revisions.resize(output_index + 1, 0);
+        }
+        self.item_revisions[output_index] = self.item_revisions[output_index].wrapping_add(1);
     }
 
     fn mark_finished(&mut self, output_index: u32) {
         if let Some(finished) = self.finished_items.get_mut(output_index as usize) {
             *finished = true;
+        }
+    }
+
+    fn mark_all_finished(&mut self) {
+        let mut changed = false;
+        for (index, slot) in self.items.iter().enumerate() {
+            if slot.is_some()
+                && !self.finished_items.get(index).copied().unwrap_or(false)
+                && let Some(finished) = self.finished_items.get_mut(index)
+            {
+                *finished = true;
+                if let Some(revision) = self.item_revisions.get_mut(index) {
+                    *revision = revision.wrapping_add(1);
+                }
+                changed = true;
+            }
+        }
+        if changed {
+            self.item_render_revision = self.item_render_revision.wrapping_add(1);
         }
     }
 
@@ -117,7 +154,66 @@ impl PartialResponse {
             .collect()
     }
 
+    /// Borrow the current output items for render-only inspection. The
+    /// streaming renderer should prefer this over [`Self::get_message_items`]
+    /// because cloning a growing Markdown item on every frame would put the
+    /// cache hand-off back on the UI thread.
+    pub fn message_item_refs(&self) -> Vec<(&OutputItem, bool)> {
+        self.items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, slot)| {
+                slot.as_ref().map(|item| {
+                    let in_progress = !self.finished_items.get(index).copied().unwrap_or(false);
+                    (item, in_progress)
+                })
+            })
+            .collect()
+    }
+
+    /// A cheap revision for layout consumers. It changes when an output item
+    /// or its finished state changes, but not for response lifecycle/usage
+    /// events that do not alter any output slot. This lets a cached live page
+    /// survive unrelated stream events without cloning its Markdown items.
+    pub fn item_render_revision(&self) -> u64 {
+        self.item_render_revision
+    }
+
+    /// Iterate over Markdown-bearing assistant items without cloning them.
+    /// The UI uses the item revision to clone only a changed item before
+    /// handing it to the background renderer.
+    pub fn markdown_items(&self) -> Vec<(usize, &OutputItem, bool, u64)> {
+        let mut live_index = 0;
+        let mut items = Vec::new();
+        for (protocol_index, slot) in self.items.iter().enumerate() {
+            let Some(item) = slot.as_ref() else {
+                continue;
+            };
+            let current_live_index = live_index;
+            live_index += 1;
+            if !matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_)) {
+                continue;
+            }
+            let in_progress = !self
+                .finished_items
+                .get(protocol_index)
+                .copied()
+                .unwrap_or(false);
+            let revision = self
+                .item_revisions
+                .get(protocol_index)
+                .copied()
+                .unwrap_or_default();
+            items.push((current_live_index, item, in_progress, revision));
+        }
+        items
+    }
+
     pub fn handle_response_stream_event(&mut self, response_stream_event: ResponseStreamEvent) {
+        if let Some(output_index) = Self::response_output_index(&response_stream_event) {
+            self.bump_item_revision(output_index);
+            self.item_render_revision = self.item_render_revision.wrapping_add(1);
+        }
         self.render_revision = self.render_revision.wrapping_add(1);
         match response_stream_event {
             ResponseOutputItemAdded(item_added_event) => {
@@ -471,6 +567,7 @@ impl PartialResponse {
             }
 
             ResponseCompleted(response_completed_event) => {
+                self.mark_all_finished();
                 if let Some(ref u) = response_completed_event.response.usage {
                     self.usage = Some((u.input_tokens, u.output_tokens));
                 }
@@ -479,6 +576,7 @@ impl PartialResponse {
                 ));
             }
             ResponseFailed(response_failed_event) => {
+                self.mark_all_finished();
                 if let Some(ref u) = response_failed_event.response.usage {
                     self.usage = Some((u.input_tokens, u.output_tokens));
                 }
@@ -486,6 +584,7 @@ impl PartialResponse {
                     Some(ResponseFinishReason::Failed(response_failed_event.response));
             }
             ResponseIncomplete(response_incomplete_event) => {
+                self.mark_all_finished();
                 if let Some(ref u) = response_incomplete_event.response.usage {
                     self.usage = Some((u.input_tokens, u.output_tokens));
                 }
@@ -501,6 +600,38 @@ impl PartialResponse {
                 });
             }
             _ => {}
+        }
+    }
+
+    /// Extract the output index before the stream event is consumed by the
+    /// folding match below. Events without an item index (response lifecycle,
+    /// errors, and usage) must not dirty any Markdown snapshot.
+    fn response_output_index(event: &ResponseStreamEvent) -> Option<usize> {
+        match event {
+            ResponseOutputItemAdded(event) => Some(event.output_index as usize),
+            ResponseOutputItemDone(event) => Some(event.output_index as usize),
+            ResponseContentPartAdded(event) => Some(event.output_index as usize),
+            ResponseContentPartDone(event) => Some(event.output_index as usize),
+            ResponseOutputTextDelta(event) => Some(event.output_index as usize),
+            ResponseOutputTextDone(event) => Some(event.output_index as usize),
+            ResponseOutputTextAnnotationAdded(event) => Some(event.output_index as usize),
+            ResponseRefusalDelta(event) => Some(event.output_index as usize),
+            ResponseRefusalDone(event) => Some(event.output_index as usize),
+            ResponseReasoningTextDelta(event) => Some(event.output_index as usize),
+            ResponseReasoningTextDone(event) => Some(event.output_index as usize),
+            ResponseReasoningSummaryPartAdded(event) => Some(event.output_index as usize),
+            ResponseReasoningSummaryPartDone(event) => Some(event.output_index as usize),
+            ResponseReasoningSummaryTextDelta(event) => Some(event.output_index as usize),
+            ResponseReasoningSummaryTextDone(event) => Some(event.output_index as usize),
+            ResponseFunctionCallArgumentsDelta(event) => Some(event.output_index as usize),
+            ResponseFunctionCallArgumentsDone(event) => Some(event.output_index as usize),
+            ResponseMCPCallArgumentsDelta(event) => Some(event.output_index as usize),
+            ResponseMCPCallArgumentsDone(event) => Some(event.output_index as usize),
+            ResponseCustomToolCallInputDelta(event) => Some(event.output_index as usize),
+            ResponseCustomToolCallInputDone(event) => Some(event.output_index as usize),
+            ResponseCodeInterpreterCallCodeDelta(event) => Some(event.output_index as usize),
+            ResponseCodeInterpreterCallCodeDone(event) => Some(event.output_index as usize),
+            _ => None,
         }
     }
 
@@ -676,6 +807,18 @@ mod tests {
     }
 
     #[test]
+    fn markdown_items_use_compact_indices_for_sparse_protocol_slots() {
+        let mut p = fresh();
+        p.set_item(msg_item(), 2);
+        p.set_item(fc_item(), 4);
+
+        let items = p.markdown_items();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0, 0, "live UI indices skip protocol gaps");
+        assert_eq!(items[0].3, 0);
+    }
+
+    #[test]
     fn finalize_without_finish_reason_is_error() {
         let p = fresh();
         assert!(matches!(
@@ -702,5 +845,30 @@ mod tests {
         let items = p.get_message_items();
         assert_eq!(items.len(), 1);
         assert!(!items[0].1, "item should be finished");
+    }
+
+    #[test]
+    fn response_completion_finishes_items_without_item_done() {
+        let mut p = fresh();
+        p.set_item(msg_item(), 0);
+        let before = p.item_render_revision();
+        p.handle_response_stream_event(
+            async_openai::types::responses::ResponseStreamEvent::ResponseCompleted(
+                async_openai::types::responses::ResponseCompletedEvent {
+                    sequence_number: 1,
+                    response: serde_json::from_value(serde_json::json!({
+                        "created_at": 0,
+                        "id": "response-test",
+                        "model": "test",
+                        "object": "response",
+                        "output": [],
+                        "status": "completed"
+                    }))
+                    .unwrap(),
+                },
+            ),
+        );
+        assert!(!p.get_message_items()[0].1);
+        assert!(p.item_render_revision() > before);
     }
 }

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -26,6 +26,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use unicode_width::UnicodeWidthStr;
 
+use super::live_markdown::{LiveMarkdownJob, LiveMarkdownSnapshot, LiveMarkdownWorker};
 use super::tool_group::MemberHeader;
 use crate::ui::components::messages::pending_message::PendingMessage;
 use crate::ui::components::messages::welcome_message::WelcomeMessage;
@@ -162,7 +163,7 @@ pub(crate) struct CachedParagraph {
     pub has_output: bool,
     /// Clickable copy hotspots for the item's code blocks, relative to the
     /// paragraph's top-left corner.
-    pub copy_buttons: Vec<CodeCopyButton>,
+    pub copy_buttons: Arc<Vec<CodeCopyButton>>,
     /// True when this entry's paragraph was skipped (only height estimated)
     /// to avoid expensive markdown rendering of far-offscreen items.
     pub lazy: bool,
@@ -230,9 +231,44 @@ pub(crate) struct ToolGroupLayout {
     pub live_index_base: Option<usize>,
 }
 
-pub(crate) type LiveParagraph = (std::sync::Arc<Paragraph<'static>>, u16, Vec<CodeCopyButton>);
+pub(crate) type LiveParagraph = (
+    std::sync::Arc<Paragraph<'static>>,
+    u16,
+    std::sync::Arc<Vec<CodeCopyButton>>,
+);
 pub(crate) type LiveGroupHeader = Option<(String, Vec<MemberHeader>)>;
 pub(crate) type MaterializedLiveCache = (Vec<LiveParagraph>, Vec<LiveGroupHeader>);
+
+/// Stable key used to associate an asynchronous live Markdown result with the
+/// corresponding slot in a partial response. Provider output ids are stable
+/// within a response; the index fallback keeps synthetic test items (which
+/// sometimes omit an id) usable as well.
+pub(crate) fn live_message_key(item: &OutputItem, index: usize) -> Option<String> {
+    match item {
+        OutputItem::Message(message) if !message.id.is_empty() => {
+            Some(format!("message:{}", message.id))
+        }
+        OutputItem::Reasoning(reasoning) => reasoning
+            .id
+            .as_deref()
+            .map(|id| format!("reasoning:{id}"))
+            .or_else(|| Some(format!("reasoning-index:{index}"))),
+        OutputItem::Message(_) => Some(format!("message-index:{index}")),
+        _ => None,
+    }
+}
+
+/// Namespace a live key by response generation. Provider reasoning ids are
+/// usually unique, but synthetic/no-id items fall back to their compact index;
+/// without this namespace the first reasoning item of a new turn could reuse
+/// the previous turn's front paragraph.
+pub(crate) fn live_response_message_key(
+    item: &OutputItem,
+    index: usize,
+    generation: u64,
+) -> Option<String> {
+    live_message_key(item, index).map(|key| format!("generation:{generation}:{key}"))
+}
 
 /// One pre-rendered live slot. Exploring groups retain both outer fold states,
 /// so the first click only selects an `Arc` and never parses Markdown.
@@ -463,9 +499,45 @@ pub struct ConversationPanel {
     /// Group header hit regions parallel to `live_paragraphs`. Keeping these
     /// with the cached paragraph avoids rebuilding click geometry on cache hits.
     pub(crate) live_group_headers: Vec<LiveGroupHeader>,
-    /// Present only when the whole live snapshot consists of Exploring groups
-    /// (plus their hidden zero-height member slots).
+    /// Present when the live snapshot contains only cacheable items (Exploring
+    /// groups and/or Markdown items). Dynamic tool-call output deliberately
+    /// bypasses this cache.
     pub(crate) live_render_cache: Option<LiveRenderCache>,
+    /// Background renderer for ordinary in-flight assistant Markdown. The
+    /// worker is lazy so idle panels do not create a thread.
+    pub(crate) live_markdown_worker: Option<LiveMarkdownWorker>,
+    /// Front-buffer candidates keyed by the API output message id. A frame may
+    /// continue painting the previous candidate while a newer revision is
+    /// being generated off-thread.
+    pub(crate) live_markdown_front: HashMap<String, LiveMarkdownSnapshot>,
+    /// Generation is bumped whenever a response is started/committed/aborted;
+    /// results from an older response are then harmlessly discarded.
+    pub(crate) live_markdown_generation: u64,
+    /// Width for which the current live Markdown job/front buffer was built.
+    pub(crate) live_markdown_width: u16,
+    /// Last submitted `(generation, item_revision, width, expanded)` per item,
+    /// used to avoid resubmitting the same snapshot on every frame.
+    pub(crate) live_markdown_last_job: HashMap<String, (u64, u64, u16, bool)>,
+    /// A completed Markdown item can remain in `PartialResponse` while a tool
+    /// call streams afterward. Submit that finished item once, then leave it
+    /// alone until its item revision, width, or expansion state changes.
+    pub(crate) live_markdown_finished_job: HashMap<String, (u64, u16, bool)>,
+    /// Newly committed items whose live front-buffer key can still receive a
+    /// background result. The value is the live key; the key in this map is
+    /// the item's absolute conversation index, which remains stable after the
+    /// response is appended.
+    pub(crate) live_markdown_history_keys: HashMap<usize, String>,
+    /// Last `(width, expanded)` request submitted for a committed hand-off
+    /// item, preventing a history frame from cloning it repeatedly while the
+    /// worker is still rendering.
+    pub(crate) live_markdown_history_last_job: HashMap<usize, (u16, bool)>,
+    /// History entries that need rebuilding after a worker result arrives.
+    /// Keeping this separate from `RenderCache` preserves unrelated old
+    /// Markdown paragraphs across the asynchronous hand-off.
+    pub(crate) live_markdown_history_dirty: HashSet<usize>,
+    /// Final per-item revisions captured at commit, used to ensure an older
+    /// front snapshot is not mistaken for the completed response.
+    pub(crate) live_markdown_history_revisions: HashMap<usize, u64>,
     #[cfg(test)]
     pub(crate) live_explore_builds: u64,
     #[cfg(test)]
@@ -516,6 +588,16 @@ impl ConversationPanel {
             live_paragraphs: Vec::new(),
             live_group_headers: Vec::new(),
             live_render_cache: None,
+            live_markdown_worker: None,
+            live_markdown_front: HashMap::new(),
+            live_markdown_generation: 0,
+            live_markdown_width: 0,
+            live_markdown_last_job: HashMap::new(),
+            live_markdown_finished_job: HashMap::new(),
+            live_markdown_history_keys: HashMap::new(),
+            live_markdown_history_last_job: HashMap::new(),
+            live_markdown_history_dirty: HashSet::new(),
+            live_markdown_history_revisions: HashMap::new(),
             #[cfg(test)]
             live_explore_builds: 0,
             #[cfg(test)]
@@ -881,6 +963,10 @@ impl ConversationPanel {
         {
             // Removing an item shifts every later index used by the expansion state.
             self.expanded_items.clear();
+            // The asynchronous history map is also index-keyed; discard it
+            // rather than allowing a completed worker result to land on the
+            // item that shifted into the old slot.
+            self.invalidate_live_markdown();
         }
     }
 
@@ -944,6 +1030,9 @@ impl ConversationPanel {
         if applied {
             self.expanded_items.clear();
             self.expanded_tool_groups.clear();
+            // Compaction inserts a summary at `cutoff` and shifts every later
+            // absolute index, so any in-flight history hand-off is stale.
+            self.invalidate_live_markdown();
             self.stick_to_bottom = true;
         }
         applied
@@ -975,6 +1064,7 @@ impl ConversationPanel {
         self.live_expanded_items.clear();
         self.live_expanded_groups.clear();
         self.live_render_cache = None;
+        self.invalidate_live_markdown();
         self.selection = None;
         self.stick_to_bottom = true;
     }
@@ -984,12 +1074,17 @@ impl ConversationPanel {
         self.conversation.lock().unwrap().restore_items(items);
         self.expanded_items.clear();
         self.expanded_tool_groups.clear();
+        self.invalidate_live_markdown();
         self.stick_to_bottom = true;
     }
 
     pub fn truncate(&mut self, cutoff: usize) {
         self.conversation.lock().unwrap().truncate(cutoff);
         self.abort_receiving();
+        // `abort_receiving` intentionally preserves committed hand-offs when
+        // there is no active response. Truncation changes absolute item
+        // indices, so discard those hand-offs explicitly.
+        self.invalidate_live_markdown();
         self.expanded_items.clear();
         self.expanded_tool_groups.clear();
         self.selection = None;
@@ -1005,30 +1100,385 @@ impl ConversationPanel {
         self.conversation.lock().unwrap().usage_summary()
     }
 
+    /// Start a fresh live-response generation. A previous response may already
+    /// be committed while its final Markdown snapshot is still rendering, so
+    /// keep those history keys/front paragraphs alive; only the active live
+    /// response state is replaced.
+    pub(crate) fn begin_live_response(&mut self) {
+        self.live_markdown_generation = self.live_markdown_generation.wrapping_add(1);
+        let history_keys: HashSet<&str> = self
+            .live_markdown_history_keys
+            .values()
+            .map(String::as_str)
+            .collect();
+        self.live_markdown_front
+            .retain(|key, _| history_keys.contains(key.as_str()));
+        self.live_markdown_last_job.clear();
+        self.live_markdown_finished_job.clear();
+        self.live_render_cache = None;
+        self.prune_live_markdown_history();
+    }
+
+    /// Invalidate the asynchronous front buffer at a response hand-off (or
+    /// cancellation) boundary.
+    fn invalidate_live_markdown(&mut self) {
+        self.live_markdown_generation = self.live_markdown_generation.wrapping_add(1);
+        self.live_markdown_front.clear();
+        self.live_markdown_last_job.clear();
+        self.live_markdown_finished_job.clear();
+        self.live_markdown_history_keys.clear();
+        self.live_markdown_history_last_job.clear();
+        self.live_markdown_history_dirty.clear();
+        self.live_markdown_history_revisions.clear();
+        self.live_render_cache = None;
+    }
+
+    /// Invalidate only the currently receiving response. A later response can
+    /// be cancelled while an earlier committed item is still being handed off
+    /// to the worker; that historical front buffer must survive the abort.
+    fn invalidate_active_live_markdown(&mut self) {
+        self.live_markdown_generation = self.live_markdown_generation.wrapping_add(1);
+        let history_keys: HashSet<&str> = self
+            .live_markdown_history_keys
+            .values()
+            .map(String::as_str)
+            .collect();
+        self.live_markdown_front
+            .retain(|key, _| history_keys.contains(key.as_str()));
+        self.live_markdown_last_job.clear();
+        self.live_markdown_finished_job.clear();
+        self.live_render_cache = None;
+    }
+
+    /// Keep the asynchronous hand-off bounded. The ordinary historical
+    /// RenderCache already owns paragraphs for items that have been laid out;
+    /// retaining every completed live snapshot forever would duplicate those
+    /// paragraphs for the whole transcript. Preserve explicitly expanded
+    /// items and the newest entries, and let an older item fall back to the
+    /// normal cache/build path if it is expanded much later.
+    fn prune_live_markdown_history(&mut self) {
+        const MAX_HISTORY_ITEMS: usize = 64;
+        if self.live_markdown_history_keys.len() <= MAX_HISTORY_ITEMS {
+            return;
+        }
+
+        let mut keep = HashSet::new();
+        for &index in &self.expanded_items {
+            if self.live_markdown_history_keys.contains_key(&index) {
+                keep.insert(index);
+            }
+        }
+        let mut newest: Vec<usize> = self.live_markdown_history_keys.keys().copied().collect();
+        newest.sort_unstable_by(|left, right| right.cmp(left));
+        for index in newest {
+            if keep.len() >= MAX_HISTORY_ITEMS {
+                break;
+            }
+            keep.insert(index);
+        }
+
+        let removed: Vec<usize> = self
+            .live_markdown_history_keys
+            .keys()
+            .copied()
+            .filter(|index| !keep.contains(index))
+            .collect();
+        for index in removed {
+            if let Some(key) = self.live_markdown_history_keys.remove(&index) {
+                self.live_markdown_front.remove(&key);
+            }
+            self.live_markdown_history_last_job.remove(&index);
+            self.live_markdown_history_dirty.remove(&index);
+            self.live_markdown_history_revisions.remove(&index);
+        }
+    }
+
+    /// Consume the newest completed background result. Results are accepted
+    /// only for the active generation/width and never regress an already
+    /// visible revision.
+    pub(crate) fn poll_live_markdown_results(&mut self, width: u16) {
+        loop {
+            let Some(result) = self
+                .live_markdown_worker
+                .as_ref()
+                .and_then(LiveMarkdownWorker::take_result)
+            else {
+                break;
+            };
+            let is_history_result = self
+                .live_markdown_history_keys
+                .values()
+                .any(|key| key == &result.key);
+            if result.width != width
+                || (!is_history_result && result.generation != self.live_markdown_generation)
+            {
+                continue;
+            }
+            let history_index = self
+                .live_markdown_history_keys
+                .iter()
+                .find_map(|(&index, key)| (key == &result.key).then_some(index));
+            let accept = self
+                .live_markdown_front
+                .get(&result.key)
+                .is_none_or(|front| {
+                    result.request_id >= front.request_id
+                        && (result.revision >= front.revision || result.expanded != front.expanded)
+                });
+            if accept {
+                self.live_markdown_front.insert(result.key.clone(), result);
+                if let Some(history_index) = history_index {
+                    // A committed item may currently be represented by a
+                    // one-line placeholder in the historical cache. Mark
+                    // only that item dirty; unrelated old Markdown remains
+                    // cached and will not be reparsed on the next frame.
+                    self.live_markdown_history_dirty.insert(history_index);
+                }
+                // A live Explore paragraph may embed this reasoning item.
+                // Rebuild only the cheap group assembly on the next frame;
+                // the Markdown work itself has already completed off-thread.
+                self.live_render_cache = None;
+            }
+        }
+    }
+
+    /// Submit changed Markdown items to the worker. The request owns its
+    /// `OutputItem`, so the worker never borrows mutable stream state or the
+    /// conversation lock. The worker keeps one pending job per item, allowing
+    /// multiple reasoning blocks to make progress without starving each other.
+    fn queue_live_markdown_jobs(&mut self, width: u16) {
+        if width == 0 {
+            return;
+        }
+        let generation = self.live_markdown_generation;
+        let frame_count = self.frame_count;
+        let mut jobs = Vec::new();
+        let worker = self.live_markdown_worker.as_ref();
+        if let Some(response) = self.receiving_response.as_ref() {
+            for (index, item, in_progress, revision) in response.markdown_items() {
+                let Some(key) = live_response_message_key(item, index, generation) else {
+                    continue;
+                };
+                let expanded = self.live_expanded_items.contains(&index);
+                let job_key = (generation, revision, width, expanded);
+                if self.live_markdown_last_job.get(&key) == Some(&job_key) {
+                    continue;
+                }
+                if !in_progress
+                    && self.live_markdown_finished_job.get(&key)
+                        == Some(&(revision, width, expanded))
+                {
+                    continue;
+                }
+                if worker.is_some_and(|worker| {
+                    worker.has_pending_view(&key, generation, width, expanded)
+                }) {
+                    continue;
+                }
+                jobs.push((
+                    key.clone(),
+                    LiveMarkdownJob {
+                        key,
+                        request_id: 0,
+                        generation,
+                        revision,
+                        width,
+                        item: item.clone(),
+                        in_progress,
+                        expanded,
+                        frame_count,
+                    },
+                    job_key,
+                    !in_progress,
+                ));
+            }
+        }
+        if jobs.is_empty() {
+            return;
+        }
+        for (key, _, job_key, finished) in &jobs {
+            self.live_markdown_last_job.insert(key.clone(), *job_key);
+            if *finished {
+                let (_, revision, width, expanded) = job_key;
+                self.live_markdown_finished_job
+                    .insert(key.clone(), (*revision, *width, *expanded));
+            }
+        }
+        let worker = self
+            .live_markdown_worker
+            .get_or_insert_with(LiveMarkdownWorker::new);
+        for (_, job, _, _) in jobs {
+            worker.submit(job);
+        }
+    }
+
+    /// Reflow a just-committed Markdown item after a resize or a post-commit
+    /// expand/collapse click. The raw item is cloned once and sent to the same
+    /// worker; the historical renderer keeps its previous snapshot (or a
+    /// placeholder) until the result arrives.
+    pub(crate) fn queue_committed_markdown_jobs(&mut self, items: &[MessageItem], width: u16) {
+        // Keep the single worker focused on the response currently arriving.
+        // Historical reflows can wait until the turn boundary; otherwise a
+        // large resize backlog could delay the live reasoning snapshot.
+        if width == 0
+            || self.live_markdown_history_keys.is_empty()
+            || self.receiving_response.is_some()
+        {
+            return;
+        }
+        let generation = self.live_markdown_generation;
+        // A resize can invalidate many committed hand-offs at once. Limit the
+        // amount of raw Markdown copied from the conversation on one UI
+        // frame; the remaining candidates stay discoverable on the next
+        // frame, while the worker continues consuming the bounded queue.
+        const MAX_COMMITTED_JOBS_PER_FRAME: usize = 1;
+        let mut candidates = Vec::new();
+        let worker = self.live_markdown_worker.as_ref();
+        for (&index, key) in &self.live_markdown_history_keys {
+            let Some(MessageItem::Output(item)) = items.get(index) else {
+                continue;
+            };
+            if !matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_)) {
+                continue;
+            }
+            let expanded = self.expanded_items.contains(&index);
+            if self.live_markdown_front.get(key).is_some_and(|snapshot| {
+                let required_revision = self
+                    .live_markdown_history_revisions
+                    .get(&index)
+                    .copied()
+                    .unwrap_or_default();
+                snapshot.width == width
+                    && snapshot.expanded == expanded
+                    && !snapshot.in_progress
+                    && snapshot.revision >= required_revision
+            }) {
+                continue;
+            }
+            if self.live_markdown_history_last_job.get(&index) == Some(&(width, expanded)) {
+                continue;
+            }
+            let revision = self
+                .live_markdown_history_revisions
+                .get(&index)
+                .copied()
+                .unwrap_or_else(|| {
+                    self.live_markdown_front
+                        .get(key)
+                        .map_or(0, |snapshot| snapshot.revision)
+                });
+            if worker
+                .is_some_and(|worker| worker.has_pending_view(key, generation, width, expanded))
+            {
+                continue;
+            }
+            candidates.push((index, key.clone(), expanded, revision));
+        }
+        // Prefer an item the user explicitly expanded, then the newest
+        // history item. HashMap iteration order must not decide which visible
+        // block gets its background render first.
+        candidates.sort_by(|left, right| right.2.cmp(&left.2).then_with(|| right.0.cmp(&left.0)));
+        let mut jobs = Vec::with_capacity(candidates.len().min(MAX_COMMITTED_JOBS_PER_FRAME));
+        for (index, key, expanded, revision) in
+            candidates.into_iter().take(MAX_COMMITTED_JOBS_PER_FRAME)
+        {
+            let Some(MessageItem::Output(item)) = items.get(index) else {
+                continue;
+            };
+            jobs.push((
+                index,
+                key.clone(),
+                LiveMarkdownJob {
+                    key,
+                    request_id: 0,
+                    generation,
+                    revision,
+                    width,
+                    item: item.clone(),
+                    in_progress: false,
+                    expanded,
+                    frame_count: self.frame_count,
+                },
+                (width, expanded),
+            ));
+        }
+        if jobs.is_empty() {
+            return;
+        }
+        for (index, _, _, state) in &jobs {
+            self.live_markdown_history_last_job.insert(*index, *state);
+        }
+        let worker = self
+            .live_markdown_worker
+            .get_or_insert_with(LiveMarkdownWorker::new);
+        for (_, _, job, _) in jobs {
+            worker.submit(job);
+        }
+    }
+
+    /// Called at the beginning of a frame, after the viewport width is known.
+    /// Width changes invalidate the front buffer and schedule a fresh snapshot;
+    /// otherwise only a newly changed stream revision is submitted.
+    pub(crate) fn prepare_live_markdown(&mut self, width: u16) {
+        self.poll_live_markdown_results(width);
+        if self.live_markdown_width != width {
+            self.live_markdown_width = width;
+            self.live_markdown_front.clear();
+            self.live_markdown_last_job.clear();
+            self.live_markdown_finished_job.clear();
+            self.live_markdown_history_last_job.clear();
+            self.live_markdown_history_dirty.clear();
+        }
+        self.queue_live_markdown_jobs(width);
+    }
+
     /// The runner committed the streamed response to the shared conversation:
     /// drop the live in-progress view so the same content isn't rendered twice,
     /// transferring live expanded state onto the now-committed items (which sit
     /// at the tail of the conversation).
     pub fn commit_live(&mut self) {
         self.live_render_cache = None;
-        if let Some(partial) = self.receiving_response.take() {
-            let committed = partial.items.iter().flatten().count();
-            let base_index = self
-                .conversation
-                .lock()
-                .unwrap()
-                .items
-                .len()
-                .saturating_sub(committed);
-            for &live_idx in &self.live_expanded_items {
-                self.expanded_items.insert(base_index + live_idx);
-            }
-            self.live_expanded_items.clear();
-            // Live groups carry the same keys (first call's protocol id) as
-            // the committed ones, so keep any user expansion across the swap.
-            self.expanded_tool_groups
-                .extend(self.live_expanded_groups.drain());
+        let Some(partial) = self.receiving_response.take() else {
+            self.invalidate_live_markdown();
+            return;
+        };
+        let committed = partial.items.iter().flatten().count();
+        let base_index = self
+            .conversation
+            .lock()
+            .unwrap()
+            .items
+            .len()
+            .saturating_sub(committed);
+        for (live_index, _, _, revision) in partial.markdown_items() {
+            self.live_markdown_history_revisions
+                .insert(base_index + live_index, revision);
         }
+        for (live_index, item) in partial.items.iter().flatten().enumerate() {
+            if matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_))
+                && let Some(key) =
+                    live_response_message_key(item, live_index, self.live_markdown_generation)
+            {
+                self.live_markdown_history_keys
+                    .insert(base_index + live_index, key);
+            }
+        }
+        for &live_idx in &self.live_expanded_items {
+            self.expanded_items.insert(base_index + live_idx);
+        }
+        self.live_expanded_items.clear();
+        // Live groups carry the same keys (first call's protocol id) as the
+        // committed ones, so keep any user expansion across the swap.
+        self.expanded_tool_groups
+            .extend(self.live_expanded_groups.drain());
+        // Keep the generation/front snapshots alive so the historical cache
+        // can consume them asynchronously. A subsequent response bumps the
+        // generation but retains the bounded historical hand-off.
+        self.live_markdown_last_job.clear();
+        self.live_markdown_finished_job.clear();
+        self.live_markdown_history_last_job.clear();
+        self.live_markdown_history_dirty.clear();
+        self.prune_live_markdown_history();
     }
 
     /// Ends the in-flight response (stream error / cancellation), salvaging
@@ -1037,33 +1487,54 @@ impl ConversationPanel {
     /// clearing the "receiving" state so the turn is no longer considered busy.
     pub fn abort_receiving(&mut self) {
         self.live_render_cache = None;
-        if let Some(partial) = self.receiving_response.take() {
-            // Transfer live expanded state before items become historical,
-            // so reasoning/tool-call items the user expanded during streaming
-            // stay expanded instead of auto-collapsing.
-            let base_index = self.conversation.lock().unwrap().items.len();
-            for &live_idx in &self.live_expanded_items {
-                self.expanded_items.insert(base_index + live_idx);
+        // TurnFinished is also emitted after ResponseCommitted. In that
+        // normal path there is no live response left to abort; preserve the
+        // committed front/history hand-off until its worker result is used.
+        let Some(partial) = self.receiving_response.take() else {
+            return;
+        };
+        self.invalidate_active_live_markdown();
+        // Transfer live expanded state before items become historical,
+        // so reasoning/tool-call items the user expanded during streaming
+        // stay expanded instead of auto-collapsing.
+        let base_index = self.conversation.lock().unwrap().items.len();
+        for &live_idx in &self.live_expanded_items {
+            self.expanded_items.insert(base_index + live_idx);
+        }
+        self.expanded_tool_groups
+            .extend(self.live_expanded_groups.drain());
+        let cancelled = partial.cancelled.is_cancelled();
+        let items: Vec<OutputItem> = if cancelled {
+            // When the user cancelled, drop all function calls so they
+            // aren't shown and won't execute.
+            partial
+                .items
+                .into_iter()
+                .flatten()
+                .filter(|item| !matches!(item, OutputItem::FunctionCall(_)))
+                .collect()
+        } else {
+            partial.into_aborted_items()
+        };
+        // Salvaged Markdown is historical just like a normally committed
+        // response. Give it a hand-off key as well, so a stream error or
+        // cancellation cannot reintroduce a synchronous full-document parse
+        // on the first post-abort frame.
+        for (index, item) in items.iter().enumerate() {
+            if matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_))
+                && let Some(key) =
+                    live_response_message_key(item, index, self.live_markdown_generation)
+            {
+                let history_index = base_index + index;
+                self.live_markdown_history_keys.insert(history_index, key);
+                self.live_markdown_history_revisions
+                    .insert(history_index, 0);
             }
-            self.expanded_tool_groups
-                .extend(self.live_expanded_groups.drain());
-            let cancelled = partial.cancelled.is_cancelled();
-            let items: Vec<OutputItem> = if cancelled {
-                // When the user cancelled, drop all function calls so they
-                // aren't shown and won't execute.
-                partial
-                    .items
-                    .into_iter()
-                    .flatten()
-                    .filter(|item| !matches!(item, OutputItem::FunctionCall(_)))
-                    .collect()
-            } else {
-                partial.into_aborted_items()
-            };
-            let mut conv = self.conversation.lock().unwrap();
-            for item in items {
-                conv.add_output(item);
-            }
+        }
+        self.prune_live_markdown_history();
+        let mut conv = self.conversation.lock().unwrap();
+        for item in items {
+            conv.add_output(item);
         }
     }
 
@@ -1323,6 +1794,37 @@ mod tests {
 
         assert!(panel.receiving_response.is_none());
         assert!(!panel.is_busy(), "aborting must clear the busy state");
+    }
+
+    #[test]
+    fn abort_without_receiving_preserves_committed_markdown_handoff() {
+        let mut panel = ConversationPanel::new();
+        panel
+            .live_markdown_history_keys
+            .insert(0, "generation:1:reasoning:done".into());
+        panel.abort_receiving();
+        assert_eq!(
+            panel.live_markdown_history_keys.get(&0).map(String::as_str),
+            Some("generation:1:reasoning:done")
+        );
+    }
+
+    #[test]
+    fn aborting_a_new_response_preserves_older_markdown_handoff() {
+        let mut panel = ConversationPanel::new();
+        panel
+            .live_markdown_history_keys
+            .insert(0, "generation:1:reasoning:done".into());
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            crate::cancel::CancellationToken::new(),
+        ));
+
+        panel.abort_receiving();
+
+        assert_eq!(
+            panel.live_markdown_history_keys.get(&0).map(String::as_str),
+            Some("generation:1:reasoning:done")
+        );
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -26,7 +26,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use unicode_width::UnicodeWidthStr;
 
-use super::live_markdown::{LiveMarkdownJob, LiveMarkdownSnapshot, LiveMarkdownWorker};
+use super::live_markdown::{
+    IncrementalMarkdownParagraph, LiveMarkdownJob, LiveMarkdownSnapshot, LiveMarkdownWorker,
+};
 use super::tool_group::MemberHeader;
 use crate::ui::components::messages::pending_message::PendingMessage;
 use crate::ui::components::messages::welcome_message::WelcomeMessage;
@@ -149,7 +151,7 @@ fn is_foldable(item: &MessageItem) -> bool {
 /// Exploring groups have their own revision-keyed cache below.
 #[derive(Debug)]
 pub(crate) struct CachedParagraph {
-    pub paragraph: Arc<Paragraph<'static>>,
+    pub paragraph: LiveParagraphContent,
     pub height: u16,
     /// Whether this slot was intentionally hidden when cached. Bridged live
     /// groups temporarily hide their committed members, then reveal them again
@@ -231,11 +233,27 @@ pub(crate) struct ToolGroupLayout {
     pub live_index_base: Option<usize>,
 }
 
-pub(crate) type LiveParagraph = (
-    std::sync::Arc<Paragraph<'static>>,
-    u16,
-    std::sync::Arc<Vec<CodeCopyButton>>,
-);
+#[derive(Debug, Clone)]
+pub(crate) enum LiveParagraphContent {
+    Paragraph(Arc<Paragraph<'static>>),
+    Incremental(Arc<IncrementalMarkdownParagraph>),
+}
+
+impl LiveParagraphContent {
+    pub(crate) fn copy_button(
+        &self,
+        fallback: &[CodeCopyButton],
+        row: u16,
+        x: u16,
+    ) -> Option<String> {
+        match self {
+            Self::Paragraph(_) => find_copy_button(fallback, row, x),
+            Self::Incremental(paragraph) => paragraph.copy_button(row, x),
+        }
+    }
+}
+
+pub(crate) type LiveParagraph = (LiveParagraphContent, u16, Arc<Vec<CodeCopyButton>>);
 pub(crate) type LiveGroupHeader = Option<(String, Vec<MemberHeader>)>;
 pub(crate) type MaterializedLiveCache = (Vec<LiveParagraph>, Vec<LiveGroupHeader>);
 
@@ -308,6 +326,10 @@ pub(crate) struct LiveRenderCache {
 pub(crate) struct Selection {
     pub anchor: (u16, u16),
     pub head: (u16, u16),
+    /// Screen cell where the press started. The scroll-buffer row may move
+    /// while streaming content is rendered, but that must not turn a stationary
+    /// press/release into a drag.
+    pub screen_anchor: (u16, u16),
     /// True once the mouse moved to a different cell while held down; a press
     /// and release on the same cell is a click, not a selection.
     pub dragging: bool,
@@ -689,7 +711,9 @@ impl ConversationPanel {
             let hit = self
                 .live_paragraphs
                 .get(live_idx)
-                .and_then(|(_, _, buttons)| find_copy_button(buttons, buffer_y - top, x_rel));
+                .and_then(|(paragraph, _, buttons)| {
+                    paragraph.copy_button(buttons, buffer_y - top, x_rel)
+                });
             if let Some(content) = hit {
                 self.copy_code_block(&content);
                 return;
@@ -731,11 +755,11 @@ impl ConversationPanel {
             .iter()
             .find(|&&(_, top, bottom)| buffer_y >= top && buffer_y < bottom)
         {
-            let hit = self
-                .render_cache
-                .entries
-                .get(index)
-                .and_then(|entry| find_copy_button(&entry.copy_buttons, buffer_y - top, x_rel));
+            let hit = self.render_cache.entries.get(index).and_then(|entry| {
+                entry
+                    .paragraph
+                    .copy_button(&entry.copy_buttons, buffer_y - top, x_rel)
+            });
             if let Some(content) = hit {
                 self.copy_code_block(&content);
                 return;
@@ -790,6 +814,7 @@ impl ConversationPanel {
         self.selection = self.to_buffer_pos(column, row, false).map(|pos| Selection {
             anchor: pos,
             head: pos,
+            screen_anchor: (column, row),
             dragging: false,
         });
     }
@@ -824,6 +849,16 @@ impl ConversationPanel {
     /// Left button released: either finish a drag selection (returning the
     /// selected text) or report a plain click.
     pub fn selection_end(&mut self, column: u16, row: u16) -> SelectionEnd {
+        // Streaming can change `view_offset` between Down and Up. Compare the
+        // physical screen cell first so a stationary title click is not
+        // mistaken for a buffer-coordinate drag after the layout moves.
+        if self
+            .selection
+            .is_some_and(|sel| !sel.dragging && sel.screen_anchor == (column, row))
+        {
+            self.selection = None;
+            return SelectionEnd::Click;
+        }
         self.selection_drag(column, row);
         match self.selection {
             None => SelectionEnd::Ignored,
@@ -861,7 +896,14 @@ impl ConversationPanel {
                     top,
                     bottom.saturating_sub(top),
                     width,
-                    |b| entry.paragraph.as_ref().render(b.area, b),
+                    |b| match &entry.paragraph {
+                        LiveParagraphContent::Paragraph(paragraph) => {
+                            paragraph.as_ref().render(b.area, b)
+                        }
+                        LiveParagraphContent::Incremental(paragraph) => {
+                            paragraph.render(b.area, b, 0)
+                        }
+                    },
                 );
             }
         }
@@ -874,7 +916,14 @@ impl ConversationPanel {
                     top,
                     bottom.saturating_sub(top),
                     width,
-                    |b| paragraph.as_ref().render(b.area, b),
+                    |b| match paragraph {
+                        LiveParagraphContent::Paragraph(paragraph) => {
+                            paragraph.as_ref().render(b.area, b)
+                        }
+                        LiveParagraphContent::Incremental(paragraph) => {
+                            paragraph.render(b.area, b, 0)
+                        }
+                    },
                 );
             }
         }
@@ -1770,6 +1819,29 @@ mod tests {
         state.update(10, 20);
         assert_eq!(state.offset().y, 0);
         assert!(state.is_at_bottom());
+    }
+
+    #[test]
+    fn stationary_release_stays_a_click_when_streaming_moves_the_view() {
+        let mut panel = ConversationPanel::new();
+        panel.view_area = Rect::new(0, 0, 40, 10);
+        panel.view_offset = 20;
+
+        panel.selection_begin(3, 4);
+        panel.view_offset = 24;
+
+        assert!(matches!(panel.selection_end(3, 4), SelectionEnd::Click));
+    }
+
+    #[test]
+    fn mouse_movement_still_finishes_as_a_selection() {
+        let mut panel = ConversationPanel::new();
+        panel.view_area = Rect::new(0, 0, 40, 10);
+
+        panel.selection_begin(3, 4);
+        panel.selection_drag(8, 4);
+
+        assert!(matches!(panel.selection_end(8, 4), SelectionEnd::Copied(_)));
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/live_markdown.rs
+++ b/src/ui/components/conversation_panel/live_markdown.rs
@@ -1,0 +1,434 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Background rendering for the in-flight assistant Markdown message.
+//!
+//! The conversation widget is rendered on the application's event-loop thread.
+//! Parsing a growing Markdown document (and especially syntax-highlighting a
+//! growing fenced block) on that thread makes a long response visibly block
+//! input and redraws.  This module is deliberately small: a single worker
+//! keeps only the newest request per item, renders it off-thread, and publishes
+//! only the newest completed result for each live item. The panel owns the front results
+//! and may continue painting them while the worker prepares the next ones.
+
+use crate::ui::components::messages::assistant_message::{AssistantMessage, render_reasoning};
+use crate::ui::markdown_code_block::CodeCopyButton;
+use async_openai::types::responses::OutputItem;
+use ratatui::text::Text;
+use ratatui_widgets::paragraph::Paragraph;
+use std::collections::HashMap;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+
+/// An owned request sent to the background renderer.
+#[derive(Debug)]
+pub(crate) struct LiveMarkdownJob {
+    pub(crate) key: String,
+    /// Monotonic submission id, used to order same-revision jobs when the
+    /// user toggles expansion while an older render is still running.
+    pub(crate) request_id: u64,
+    pub(crate) generation: u64,
+    pub(crate) revision: u64,
+    pub(crate) width: u16,
+    pub(crate) item: OutputItem,
+    pub(crate) in_progress: bool,
+    pub(crate) expanded: bool,
+    pub(crate) frame_count: u64,
+}
+
+/// A fully materialized front-buffer candidate.
+#[derive(Debug, Clone)]
+pub(crate) struct LiveMarkdownSnapshot {
+    pub(crate) key: String,
+    pub(crate) request_id: u64,
+    pub(crate) generation: u64,
+    pub(crate) revision: u64,
+    pub(crate) width: u16,
+    pub(crate) paragraph: Arc<Paragraph<'static>>,
+    pub(crate) height: u16,
+    pub(crate) copy_buttons: Arc<Vec<CodeCopyButton>>,
+    /// Unwrapped reasoning lines, when this snapshot represents a reasoning
+    /// item embedded inside a live tool group.
+    pub(crate) reasoning_text: Option<Arc<Text<'static>>>,
+    pub(crate) in_progress: bool,
+    pub(crate) expanded: bool,
+}
+
+#[derive(Debug, Default)]
+struct WorkerState {
+    /// One pending job per output item. A new delta replaces only that item's
+    /// pending snapshot, so a later reasoning block cannot starve an older one.
+    pending_jobs: HashMap<String, (u64, LiveMarkdownJob)>,
+    /// Jobs currently being parsed. Keeping their metadata here prevents the
+    /// UI from cloning a newer full item every frame while the old parse is
+    /// still running; the next revision is queued after this one publishes.
+    in_flight: HashMap<String, (u64, u64, u16, bool)>,
+    /// Completed snapshots are retained per item until the UI takes them.
+    /// Keeping a map avoids losing a fast result when several items finish
+    /// before the next terminal frame.
+    latest_results: HashMap<String, LiveMarkdownSnapshot>,
+    next_order: u64,
+    shutdown: bool,
+}
+
+/// A one-worker latest-wins renderer.
+///
+/// A condition-variable worker is used instead of spawning one blocking task
+/// per token.  When tokens arrive faster than Markdown can be rendered, a new
+/// request replaces the pending request for that item. The queue is still
+/// bounded by the number of live Markdown items, and completed snapshots are
+/// retained once per item.
+pub(crate) struct LiveMarkdownWorker {
+    shared: Arc<(Mutex<WorkerState>, Condvar)>,
+    /// Dropping a `JoinHandle` detaches the worker. `Drop` below still signals
+    /// shutdown, so a worker that is waiting exits promptly; a render already in
+    /// progress is allowed to finish without blocking application teardown.
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for LiveMarkdownWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveMarkdownWorker")
+            .field("thread_running", &self.thread.is_some())
+            .finish()
+    }
+}
+
+impl LiveMarkdownWorker {
+    pub(crate) fn new() -> Self {
+        let shared = Arc::new((Mutex::new(WorkerState::default()), Condvar::new()));
+        let worker_shared = Arc::clone(&shared);
+        let thread = thread::Builder::new()
+            .name("programmer-live-markdown".to_string())
+            .spawn(move || worker_loop(worker_shared))
+            .expect("live Markdown worker thread should start");
+        Self {
+            shared,
+            thread: Some(thread),
+        }
+    }
+
+    /// Replace the pending snapshot for this item with the newest request.
+    pub(crate) fn submit(&self, mut job: LiveMarkdownJob) {
+        let (state, wake) = &*self.shared;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.shutdown {
+            return;
+        }
+        state.next_order = state.next_order.wrapping_add(1);
+        let order = state.next_order;
+        job.request_id = order;
+        let old = state.pending_jobs.insert(job.key.clone(), (order, job));
+        wake.notify_one();
+        // Release the worker mutex before dropping a superseded large
+        // OutputItem. Deallocating a growing response can itself take enough
+        // time to make the render thread wait on this lock.
+        drop(state);
+        drop(old);
+    }
+
+    /// Take one completed result, if the worker has published one.
+    pub(crate) fn take_result(&self) -> Option<LiveMarkdownSnapshot> {
+        let (state, _) = &*self.shared;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let key = state.latest_results.keys().next()?.clone();
+        state.latest_results.remove(&key)
+    }
+
+    /// Whether this item already has a request for the same view state being
+    /// rendered. While that request is in flight, the panel can keep painting
+    /// its front snapshot instead of cloning another full growing item that
+    /// would immediately replace the pending job.
+    pub(crate) fn has_pending_view(
+        &self,
+        key: &str,
+        generation: u64,
+        width: u16,
+        expanded: bool,
+    ) -> bool {
+        let (state, _) = &*self.shared;
+        let state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let same_view = |job_generation, _job_revision, job_width, job_expanded| {
+            job_generation == generation && job_width == width && job_expanded == expanded
+        };
+        state.pending_jobs.get(key).is_some_and(|(_, job)| {
+            same_view(job.generation, job.revision, job.width, job.expanded)
+        }) || state.in_flight.get(key).is_some_and(
+            |&(job_generation, job_revision, job_width, job_expanded)| {
+                same_view(job_generation, job_revision, job_width, job_expanded)
+            },
+        )
+    }
+}
+
+impl Drop for LiveMarkdownWorker {
+    fn drop(&mut self) {
+        let (state, wake) = &*self.shared;
+        if let Ok(mut state) = state.lock() {
+            state.shutdown = true;
+            state.pending_jobs.clear();
+            state.latest_results.clear();
+            wake.notify_one();
+        }
+        // Deliberately detach. Joining here could make quitting wait for a
+        // large syntax-highlight operation that was already in progress.
+        let _ = self.thread.take();
+    }
+}
+
+fn worker_loop(shared: Arc<(Mutex<WorkerState>, Condvar)>) {
+    loop {
+        let job = {
+            let (state, wake) = &*shared;
+            let mut state = state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            while state.pending_jobs.is_empty() && !state.shutdown {
+                state = wake
+                    .wait(state)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+            if state.shutdown {
+                return;
+            }
+            // Process completed/final snapshots first so a response hand-off
+            // can settle its status promptly, then process the oldest pending
+            // key. A continuously growing item may replace its pending job on
+            // every frame; FIFO selection prevents it from starving an older
+            // reasoning block.
+            let key = state
+                .pending_jobs
+                .iter()
+                .min_by_key(|(_, (order, job))| (job.in_progress, *order))
+                .map(|(key, _)| key.clone());
+            key.and_then(|key| {
+                state.pending_jobs.remove(&key).map(|(_, job)| {
+                    state
+                        .in_flight
+                        .insert(key, (job.generation, job.revision, job.width, job.expanded));
+                    job
+                })
+            })
+        };
+
+        let Some(job) = job else { continue };
+        let result = render_job(job);
+        let (state, _) = &*shared;
+        let mut state = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.in_flight.remove(&result.key);
+        if state.shutdown {
+            return;
+        }
+        // Keep the newest finished result for each item. The UI validates
+        // generation, revision, and width before swapping it into the front
+        // buffer.
+        let replace = state
+            .latest_results
+            .get(&result.key)
+            .is_none_or(|old| result.request_id >= old.request_id);
+        let old = replace.then(|| state.latest_results.insert(result.key.clone(), result));
+        drop(state);
+        // Paragraph/Text deallocation belongs to the worker, outside the
+        // shared mutex, so `take_result` never waits behind a large drop.
+        drop(old.flatten());
+    }
+}
+
+fn render_job(job: LiveMarkdownJob) -> LiveMarkdownSnapshot {
+    let (paragraph, copy_buttons, reasoning_text) = match &job.item {
+        OutputItem::Message(_) => {
+            let (paragraph, copy_buttons) = AssistantMessage::new(&job.item, job.width)
+                .in_progress(job.in_progress)
+                .expanded(job.expanded)
+                .frame_count(job.frame_count)
+                .into_paragraph();
+            (paragraph, copy_buttons, None)
+        }
+        OutputItem::Reasoning(item) => {
+            let (paragraph, copy_buttons, text) = render_reasoning(
+                item,
+                job.width,
+                job.in_progress,
+                job.expanded,
+                job.frame_count,
+            );
+            (paragraph, copy_buttons, Some(Arc::new(text)))
+        }
+        // Keep a harmless empty result if a future caller accidentally submits
+        // another item kind rather than parsing it on the UI thread.
+        _ => (Paragraph::new(""), Vec::new(), None),
+    };
+    let height = paragraph.line_count(job.width) as u16;
+    LiveMarkdownSnapshot {
+        key: job.key,
+        request_id: job.request_id,
+        generation: job.generation,
+        revision: job.revision,
+        width: job.width,
+        paragraph: Arc::new(paragraph),
+        height,
+        copy_buttons: Arc::new(copy_buttons),
+        reasoning_text,
+        in_progress: job.in_progress,
+        expanded: job.expanded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LiveMarkdownJob, LiveMarkdownWorker};
+    use async_openai::types::responses::{
+        AssistantRole, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
+        OutputTextContent, ReasoningItem, SummaryPart, SummaryTextContent,
+    };
+
+    fn message(text: &str) -> async_openai::types::responses::OutputItem {
+        async_openai::types::responses::OutputItem::Message(OutputMessage {
+            content: vec![OutputMessageContent::OutputText(OutputTextContent {
+                annotations: Vec::new(),
+                logprobs: None,
+                text: text.to_string(),
+            })],
+            id: "message-test".to_string(),
+            role: AssistantRole::Assistant,
+            phase: None,
+            status: OutputStatus::InProgress,
+        })
+    }
+
+    fn reasoning(text: &str) -> OutputItem {
+        OutputItem::Reasoning(ReasoningItem {
+            id: Some("reasoning-test".to_string()),
+            summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                text: text.to_string(),
+            })],
+            content: None,
+            encrypted_content: None,
+            status: None,
+        })
+    }
+
+    #[test]
+    fn worker_replaces_pending_jobs_with_latest_revision() {
+        let worker = LiveMarkdownWorker::new();
+        worker.submit(LiveMarkdownJob {
+            key: "message-test".into(),
+            request_id: 0,
+            generation: 1,
+            revision: 1,
+            width: 40,
+            item: message("old"),
+            in_progress: true,
+            expanded: false,
+            frame_count: 0,
+        });
+        worker.submit(LiveMarkdownJob {
+            key: "message-test".into(),
+            request_id: 0,
+            generation: 1,
+            revision: 2,
+            width: 40,
+            item: message("new"),
+            in_progress: true,
+            expanded: false,
+            frame_count: 0,
+        });
+
+        let mut result = None;
+        for _ in 0..100 {
+            if let Some(candidate) = worker.take_result() {
+                result = Some(candidate);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        let result = result.expect("worker should publish a result");
+        assert_eq!(result.revision, 2);
+        assert_eq!(result.width, 40);
+        assert!(result.height > 0);
+    }
+
+    #[test]
+    fn worker_keeps_results_for_multiple_live_items() {
+        let worker = LiveMarkdownWorker::new();
+        for (key, text) in [("message-a", "first"), ("message-b", "second")] {
+            worker.submit(LiveMarkdownJob {
+                key: key.into(),
+                request_id: 0,
+                generation: 1,
+                revision: 1,
+                width: 40,
+                item: message(text),
+                in_progress: true,
+                expanded: false,
+                frame_count: 0,
+            });
+        }
+
+        let mut keys = Vec::new();
+        for _ in 0..200 {
+            while let Some(result) = worker.take_result() {
+                keys.push(result.key);
+            }
+            if keys.len() == 2 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        keys.sort();
+        assert_eq!(keys, ["message-a", "message-b"]);
+    }
+
+    #[test]
+    fn worker_renders_expanded_reasoning_off_thread() {
+        let worker = LiveMarkdownWorker::new();
+        worker.submit(LiveMarkdownJob {
+            key: "reasoning-test".into(),
+            request_id: 0,
+            generation: 4,
+            revision: 7,
+            width: 40,
+            item: reasoning("# Heading\n\nlong reasoning body"),
+            in_progress: true,
+            expanded: true,
+            frame_count: 0,
+        });
+
+        let mut result = None;
+        for _ in 0..100 {
+            if let Some(candidate) = worker.take_result() {
+                result = Some(candidate);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        let result = result.expect("worker should publish reasoning");
+        assert!(result.expanded);
+        assert!(
+            result
+                .reasoning_text
+                .as_ref()
+                .is_some_and(|text| text.to_string().contains("Heading"))
+        );
+    }
+}

--- a/src/ui/components/conversation_panel/live_markdown.rs
+++ b/src/ui/components/conversation_panel/live_markdown.rs
@@ -23,10 +23,20 @@
 //! only the newest completed result for each live item. The panel owns the front results
 //! and may continue painting them while the worker prepares the next ones.
 
-use crate::ui::components::messages::assistant_message::{AssistantMessage, render_reasoning};
-use crate::ui::markdown_code_block::CodeCopyButton;
+use crate::ui::components::messages::assistant::text::{
+    markdown_source as message_markdown_source, markdown_width as message_markdown_width,
+};
+use crate::ui::components::messages::assistant_message::{
+    AssistantMessage, render_reasoning, scan_copy_buttons_from_lines,
+};
+use crate::ui::markdown_code_block::{CodeBlockHooks, CodeCopyButton};
+use crate::ui::markdown_theme::AppTheme;
 use async_openai::types::responses::OutputItem;
-use ratatui::text::Text;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::{Line, Text};
+use ratatui::widgets::Widget;
+use ratatui_markdown::markdown::MarkdownRenderer;
 use ratatui_widgets::paragraph::Paragraph;
 use std::collections::HashMap;
 use std::sync::{Arc, Condvar, Mutex};
@@ -57,6 +67,9 @@ pub(crate) struct LiveMarkdownSnapshot {
     pub(crate) revision: u64,
     pub(crate) width: u16,
     pub(crate) paragraph: Arc<Paragraph<'static>>,
+    /// Incremental live messages render directly from persistent Markdown
+    /// chunks. Final snapshots still use `paragraph` for the history cache.
+    pub(crate) incremental: Option<Arc<IncrementalMarkdownParagraph>>,
     pub(crate) height: u16,
     pub(crate) copy_buttons: Arc<Vec<CodeCopyButton>>,
     /// Unwrapped reasoning lines, when this snapshot represents a reasoning
@@ -81,6 +94,284 @@ struct WorkerState {
     latest_results: HashMap<String, LiveMarkdownSnapshot>,
     next_order: u64,
     shutdown: bool,
+}
+
+#[derive(Debug, Default)]
+struct IncrementalMarkdownState {
+    generation: u64,
+    width: u16,
+    source_len: usize,
+    scan_offset: usize,
+    in_fence: bool,
+    stable_end: usize,
+    stable: Option<Arc<StableMarkdownChunk>>,
+}
+
+#[derive(Debug, Default)]
+struct CachedIncrementalMarkdown {
+    last_used: u64,
+    state: IncrementalMarkdownState,
+}
+
+struct IncrementalMarkdownRender {
+    stable: Option<Arc<StableMarkdownChunk>>,
+    tail_lines: Arc<[Line<'static>]>,
+    #[cfg(test)]
+    tail_codes: Arc<[String]>,
+    tail_buttons: Arc<[CodeCopyButton]>,
+    line_count: u16,
+    #[cfg(test)]
+    reparsed_bytes: usize,
+}
+
+#[derive(Debug)]
+struct StableMarkdownChunk {
+    previous: Option<Arc<StableMarkdownChunk>>,
+    lines: Arc<[Line<'static>]>,
+    #[cfg(test)]
+    codes: Arc<[String]>,
+    buttons: Arc<[CodeCopyButton]>,
+    total_lines: u16,
+    source_end: usize,
+}
+
+#[cfg(test)]
+impl IncrementalMarkdownRender {
+    fn lines(&self) -> Vec<Line<'static>> {
+        let mut chunks = Vec::new();
+        let mut current = self.stable.as_deref();
+        while let Some(chunk) = current {
+            chunks.push(chunk);
+            current = chunk.previous.as_deref();
+        }
+        chunks.reverse();
+        chunks
+            .into_iter()
+            .flat_map(|chunk| chunk.lines.iter().cloned())
+            .chain(self.tail_lines.iter().cloned())
+            .collect()
+    }
+
+    fn codes(&self) -> Vec<String> {
+        let mut chunks = Vec::new();
+        let mut current = self.stable.as_deref();
+        while let Some(chunk) = current {
+            chunks.push(chunk);
+            current = chunk.previous.as_deref();
+        }
+        chunks.reverse();
+        chunks
+            .into_iter()
+            .flat_map(|chunk| chunk.codes.iter().cloned())
+            .chain(self.tail_codes.iter().cloned())
+            .collect()
+    }
+}
+
+/// A live Markdown paragraph backed by persistent stable chunks plus one
+/// replaceable tail. Publishing a new token snapshot only clones the head
+/// `Arc`; it never clones the already-rendered lines in the prefix.
+#[derive(Debug)]
+pub(crate) struct IncrementalMarkdownParagraph {
+    stable: Option<Arc<StableMarkdownChunk>>,
+    tail_lines: Arc<[Line<'static>]>,
+    tail_buttons: Arc<[CodeCopyButton]>,
+    height: u16,
+}
+
+impl IncrementalMarkdownParagraph {
+    fn new(rendered: IncrementalMarkdownRender) -> Self {
+        Self {
+            stable: rendered.stable,
+            tail_lines: rendered.tail_lines,
+            tail_buttons: rendered.tail_buttons,
+            height: rendered.line_count,
+        }
+    }
+
+    pub(crate) fn height(&self) -> u16 {
+        self.height
+    }
+
+    /// Paint only the requested logical rows. Markdown output is already
+    /// wrapped for the content width, so individual borrowed `Line`s can be
+    /// rendered without materializing a conversation-sized `Text`.
+    pub(crate) fn render(&self, area: Rect, buf: &mut Buffer, source_offset: u16) {
+        if area.width <= 2 || area.height == 0 {
+            return;
+        }
+        let start = source_offset;
+        let end = start.saturating_add(area.height).min(self.height);
+        self.for_each_line(start, end, |row, line| {
+            let destination_y = area.y.saturating_add(row.saturating_sub(start));
+            line.render(Rect::new(area.x + 1, destination_y, area.width - 2, 1), buf);
+        });
+    }
+
+    pub(crate) fn copy_button(&self, row: u16, x: u16) -> Option<String> {
+        let mut row_offset = 0u16;
+        for chunk in self.stable_chunks() {
+            if let Some(content) = find_chunk_button(&chunk.buttons, row, x, row_offset) {
+                return Some(content);
+            }
+            row_offset = row_offset.saturating_add(chunk.lines.len() as u16);
+        }
+        find_chunk_button(&self.tail_buttons, row, x, row_offset)
+    }
+
+    fn stable_chunks(&self) -> Vec<&StableMarkdownChunk> {
+        let mut chunks = Vec::new();
+        let mut current = self.stable.as_deref();
+        while let Some(chunk) = current {
+            chunks.push(chunk);
+            current = chunk.previous.as_deref();
+        }
+        chunks.reverse();
+        chunks
+    }
+
+    fn for_each_line(&self, start: u16, end: u16, mut visit: impl FnMut(u16, &Line<'static>)) {
+        let mut row = 0u16;
+        for chunk in self.stable_chunks() {
+            let chunk_end = row.saturating_add(chunk.lines.len() as u16);
+            if chunk_end <= start {
+                row = chunk_end;
+                continue;
+            }
+            let local_start = start.saturating_sub(row) as usize;
+            for (local_row, line) in chunk.lines.iter().enumerate().skip(local_start) {
+                let absolute_row = row.saturating_add(local_row as u16);
+                if absolute_row >= end {
+                    return;
+                }
+                visit(absolute_row, line);
+            }
+            row = chunk_end;
+        }
+        let local_start = start.saturating_sub(row) as usize;
+        for (local_row, line) in self.tail_lines.iter().enumerate().skip(local_start) {
+            let absolute_row = row.saturating_add(local_row as u16);
+            if absolute_row >= end {
+                return;
+            }
+            visit(absolute_row, line);
+        }
+    }
+}
+
+fn find_chunk_button(
+    buttons: &[CodeCopyButton],
+    row: u16,
+    x: u16,
+    row_offset: u16,
+) -> Option<String> {
+    buttons
+        .iter()
+        .find(|button| {
+            row == row_offset.saturating_add(button.row) && x >= button.x_start && x < button.x_end
+        })
+        .map(|button| button.content.clone())
+}
+
+impl IncrementalMarkdownState {
+    fn render(&mut self, source: &str, generation: u64, width: u16) -> IncrementalMarkdownRender {
+        let append_only =
+            self.generation == generation && self.width == width && source.len() >= self.source_len;
+        if !append_only {
+            self.generation = generation;
+            self.width = width;
+            self.source_len = 0;
+            self.scan_offset = 0;
+            self.in_fence = false;
+            self.stable_end = 0;
+            self.stable = None;
+        }
+
+        self.scan_appended_lines(source);
+        let next_stable_end = self.stable_end;
+        let rendered_stable_end = self.stable.as_ref().map_or(0, |chunk| chunk.source_end);
+        #[cfg(test)]
+        let old_stable_end = rendered_stable_end;
+        if next_stable_end > rendered_stable_end {
+            let stable_delta = &source[rendered_stable_end..next_stable_end];
+            let (lines, codes) = render_markdown(stable_delta, width);
+            let buttons = scan_copy_buttons_from_lines(&lines, &codes);
+            let new_lines = lines.len() as u16;
+            let previous_lines = self.stable.as_ref().map_or(0, |chunk| chunk.total_lines);
+            self.stable = Some(Arc::new(StableMarkdownChunk {
+                previous: self.stable.take(),
+                lines: lines.into(),
+                #[cfg(test)]
+                codes: codes.into(),
+                buttons: buttons.into(),
+                total_lines: previous_lines.saturating_add(new_lines),
+                source_end: next_stable_end,
+            }));
+        }
+
+        let tail = &source[self.stable_end..];
+        let (tail_lines, tail_codes) = render_markdown(tail, width);
+        let tail_buttons = scan_copy_buttons_from_lines(&tail_lines, &tail_codes);
+        let stable_lines = self.stable.as_ref().map_or(0, |chunk| chunk.total_lines);
+        let line_count = stable_lines.saturating_add(tail_lines.len() as u16);
+        self.source_len = source.len();
+
+        IncrementalMarkdownRender {
+            stable: self.stable.clone(),
+            tail_lines: tail_lines.into(),
+            #[cfg(test)]
+            tail_codes: tail_codes.into(),
+            tail_buttons: tail_buttons.into(),
+            line_count,
+            #[cfg(test)]
+            reparsed_bytes: next_stable_end.saturating_sub(old_stable_end) + tail.len(),
+        }
+    }
+
+    fn scan_appended_lines(&mut self, source: &str) {
+        let mut offset = self.scan_offset;
+        for line in source[self.scan_offset..].split_inclusive('\n') {
+            if !line.ends_with('\n') {
+                break;
+            }
+            offset += line.len();
+            let trimmed = line.trim();
+            if let Some(after_fence) = trimmed.strip_prefix("```") {
+                if !self.in_fence || after_fence.trim().is_empty() {
+                    self.in_fence = !self.in_fence;
+                }
+            } else if !self.in_fence && trimmed.is_empty() {
+                self.stable_end = offset;
+            }
+            self.scan_offset = offset;
+        }
+    }
+}
+
+/// Byte boundary after the last completed block separator. A blank line can
+/// seal everything before it only while it is outside a fenced code block;
+/// the unfinished tail remains free to change type as more tokens arrive.
+#[cfg(test)]
+fn stable_markdown_prefix_end(source: &str) -> usize {
+    let mut state = IncrementalMarkdownState::default();
+    state.scan_appended_lines(source);
+    state.stable_end
+}
+
+fn render_markdown(source: &str, width: u16) -> (Vec<Line<'static>>, Vec<String>) {
+    if source.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    let hooks = CodeBlockHooks::new(width as usize);
+    let codes_handle = hooks.codes();
+    let renderer = MarkdownRenderer::new(width as usize).with_render_hooks(Box::new(hooks));
+    let blocks = renderer.parse(source);
+    let lines = renderer.render(&blocks, &AppTheme);
+    let codes = codes_handle
+        .lock()
+        .map(|codes| codes.clone())
+        .unwrap_or_default();
+    (lines, codes)
 }
 
 /// A one-worker latest-wins renderer.
@@ -195,6 +486,9 @@ impl Drop for LiveMarkdownWorker {
 }
 
 fn worker_loop(shared: Arc<(Mutex<WorkerState>, Condvar)>) {
+    const MAX_RENDER_STATES: usize = 64;
+    let mut render_states: HashMap<String, CachedIncrementalMarkdown> = HashMap::new();
+    let mut render_order = 0u64;
     loop {
         let job = {
             let (state, wake) = &*shared;
@@ -230,7 +524,28 @@ fn worker_loop(shared: Arc<(Mutex<WorkerState>, Condvar)>) {
         };
 
         let Some(job) = job else { continue };
-        let result = render_job(job);
+        render_order = render_order.wrapping_add(1);
+        let key = job.key.clone();
+        let finished = !job.in_progress;
+        let result = {
+            let cached = render_states.entry(key.clone()).or_default();
+            cached.last_used = render_order;
+            render_job(job, &mut cached.state)
+        };
+        if finished {
+            // A finalized item cannot receive more token deltas. Its immutable
+            // snapshot remains available to the panel; the extra raw source
+            // and stable-prefix cache no longer need to stay in the worker.
+            render_states.remove(&key);
+        } else if render_states.len() > MAX_RENDER_STATES
+            && let Some(oldest) = render_states
+                .iter()
+                .filter(|(candidate, _)| *candidate != &key)
+                .min_by_key(|(_, cached)| cached.last_used)
+                .map(|(key, _)| key.clone())
+        {
+            render_states.remove(&oldest);
+        }
         let (state, _) = &*shared;
         let mut state = state
             .lock()
@@ -254,15 +569,29 @@ fn worker_loop(shared: Arc<(Mutex<WorkerState>, Condvar)>) {
     }
 }
 
-fn render_job(job: LiveMarkdownJob) -> LiveMarkdownSnapshot {
-    let (paragraph, copy_buttons, reasoning_text) = match &job.item {
+fn render_job(
+    job: LiveMarkdownJob,
+    markdown_state: &mut IncrementalMarkdownState,
+) -> LiveMarkdownSnapshot {
+    let (paragraph, incremental, copy_buttons, reasoning_text) = match &job.item {
+        OutputItem::Message(message) if job.in_progress => {
+            let source = message_markdown_source(message);
+            let rendered =
+                markdown_state.render(&source, job.generation, message_markdown_width(job.width));
+            (
+                Paragraph::new(""),
+                Some(Arc::new(IncrementalMarkdownParagraph::new(rendered))),
+                Vec::new(),
+                None,
+            )
+        }
         OutputItem::Message(_) => {
             let (paragraph, copy_buttons) = AssistantMessage::new(&job.item, job.width)
                 .in_progress(job.in_progress)
                 .expanded(job.expanded)
                 .frame_count(job.frame_count)
                 .into_paragraph();
-            (paragraph, copy_buttons, None)
+            (paragraph, None, copy_buttons, None)
         }
         OutputItem::Reasoning(item) => {
             let (paragraph, copy_buttons, text) = render_reasoning(
@@ -272,13 +601,16 @@ fn render_job(job: LiveMarkdownJob) -> LiveMarkdownSnapshot {
                 job.expanded,
                 job.frame_count,
             );
-            (paragraph, copy_buttons, Some(Arc::new(text)))
+            (paragraph, None, copy_buttons, Some(Arc::new(text)))
         }
         // Keep a harmless empty result if a future caller accidentally submits
         // another item kind rather than parsing it on the UI thread.
-        _ => (Paragraph::new(""), Vec::new(), None),
+        _ => (Paragraph::new(""), None, Vec::new(), None),
     };
-    let height = paragraph.line_count(job.width) as u16;
+    let height = incremental.as_ref().map_or_else(
+        || paragraph.line_count(job.width) as u16,
+        |view| view.height(),
+    );
     LiveMarkdownSnapshot {
         key: job.key,
         request_id: job.request_id,
@@ -286,6 +618,7 @@ fn render_job(job: LiveMarkdownJob) -> LiveMarkdownSnapshot {
         revision: job.revision,
         width: job.width,
         paragraph: Arc::new(paragraph),
+        incremental,
         height,
         copy_buttons: Arc::new(copy_buttons),
         reasoning_text,
@@ -296,11 +629,18 @@ fn render_job(job: LiveMarkdownJob) -> LiveMarkdownSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use super::{LiveMarkdownJob, LiveMarkdownWorker};
+    use super::{
+        AssistantMessage, IncrementalMarkdownParagraph, IncrementalMarkdownState, LiveMarkdownJob,
+        LiveMarkdownWorker, message_markdown_width, render_markdown, stable_markdown_prefix_end,
+    };
     use async_openai::types::responses::{
         AssistantRole, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
         OutputTextContent, ReasoningItem, SummaryPart, SummaryTextContent,
     };
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::widgets::Widget;
+    use std::sync::Arc;
 
     fn message(text: &str) -> async_openai::types::responses::OutputItem {
         async_openai::types::responses::OutputItem::Message(OutputMessage {
@@ -430,5 +770,96 @@ mod tests {
                 .as_ref()
                 .is_some_and(|text| text.to_string().contains("Heading"))
         );
+    }
+
+    #[test]
+    fn incremental_renderer_reparses_only_the_unsealed_markdown_tail() {
+        let mut state = IncrementalMarkdownState::default();
+        let first = "# Stable heading\n\nfirst streaming paragraph";
+        let rendered = state.render(first, 1, 40);
+        assert_eq!(rendered.reparsed_bytes, first.len());
+        assert_eq!(state.stable_end, "# Stable heading\n\n".len());
+        let stable_prefix = rendered.stable.as_ref().expect("sealed prefix").clone();
+
+        let appended = format!("{first} gets one more token");
+        let rendered = state.render(&appended, 1, 40);
+        assert_eq!(
+            rendered.reparsed_bytes,
+            "first streaming paragraph gets one more token".len()
+        );
+        assert!(rendered.reparsed_bytes < appended.len());
+        assert!(Arc::ptr_eq(
+            &stable_prefix,
+            rendered.stable.as_ref().expect("shared sealed prefix")
+        ));
+        assert!(
+            rendered
+                .lines()
+                .iter()
+                .any(|line| line.to_string().contains("Stable heading"))
+        );
+    }
+
+    #[test]
+    fn fenced_blank_lines_do_not_seal_an_incomplete_code_block() {
+        let source = "intro\n\n```rust\nfn main() {\n\n";
+        assert_eq!(stable_markdown_prefix_end(source), "intro\n\n".len());
+
+        let closed = format!("{source}}}\n```\n\nafter");
+        assert_eq!(
+            stable_markdown_prefix_end(&closed),
+            closed.len() - "after".len()
+        );
+    }
+
+    #[test]
+    fn incremental_blocks_match_a_full_document_render() {
+        let source = concat!(
+            "# Heading\n\n",
+            "A paragraph with **bold** text.\n\n",
+            "- first\n- second\n\n",
+            "```rust\nfn main() {}\n```\n\n",
+            "| a | b |\n| - | - |\n| 1 | 2 |\n\n",
+            "tail"
+        );
+        let mut state = IncrementalMarkdownState::default();
+        let mut last = None;
+        for boundary in source
+            .match_indices("\n\n")
+            .map(|(index, separator)| index + separator.len())
+            .chain(std::iter::once(source.len()))
+        {
+            last = Some(state.render(&source[..boundary], 3, 60));
+        }
+        let incremental = last.unwrap();
+        let (full_lines, full_codes) = render_markdown(source, 60);
+        assert_eq!(incremental.lines(), full_lines);
+        assert_eq!(incremental.codes(), full_codes);
+    }
+
+    #[test]
+    fn incremental_view_matches_the_full_message_pixels_without_flattening_prefix() {
+        let source = concat!(
+            "# Heading\n\n",
+            "A paragraph with **bold** text.\n\n",
+            "```rust\nfn main() {}\n```\n\n",
+            "streaming tail"
+        );
+        let item = message(source);
+        let width = 60;
+        let mut state = IncrementalMarkdownState::default();
+        let rendered = state.render(source, 9, message_markdown_width(width));
+        let incremental = IncrementalMarkdownParagraph::new(rendered);
+        let (full, _) = AssistantMessage::new(&item, width).into_paragraph();
+        let height = full.line_count(width) as u16;
+        assert_eq!(incremental.height(), height);
+
+        let area = Rect::new(0, 0, width, height);
+        let mut incremental_buffer = Buffer::empty(area);
+        incremental.render(area, &mut incremental_buffer, 0);
+        let mut full_buffer = Buffer::empty(area);
+        full.render(area, &mut full_buffer);
+
+        assert_eq!(incremental_buffer, full_buffer);
     }
 }

--- a/src/ui/components/conversation_panel/mod.rs
+++ b/src/ui/components/conversation_panel/mod.rs
@@ -15,5 +15,6 @@
 
 #[allow(clippy::module_inception)]
 pub mod conversation_panel;
+pub(crate) mod live_markdown;
 pub(crate) mod tool_group;
 pub mod ui;

--- a/src/ui/components/conversation_panel/tool_group.rs
+++ b/src/ui/components/conversation_panel/tool_group.rs
@@ -37,6 +37,8 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::Wrap;
 use ratatui_widgets::block::{Block, Padding};
 use ratatui_widgets::paragraph::Paragraph;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::response::message_item::MessageItem;
 use crate::ui::components::messages::assistant::reasoning::{
@@ -147,6 +149,45 @@ pub(crate) struct MemberHeader {
 /// as it has any member once reasoning is involved, so a thought is absorbed
 /// the moment its first call appears instead of waiting for a full-size run.
 pub(crate) fn discover_tool_groups(items: &[MessageItem]) -> Vec<ToolGroup> {
+    let refs: Vec<GroupItem<'_>> = items.iter().map(GroupItem::Message).collect();
+    discover_group_items(&refs)
+}
+
+/// The streaming response is owned by [`PartialResponse`], so the renderer
+/// must not clone every output item merely to discover tool groups. This is
+/// the same grouping rule as [`discover_tool_groups`], specialized to borrowed
+/// protocol output items. The returned indices are relative to `items`.
+pub(crate) fn discover_live_tool_groups(items: &[&OutputItem]) -> Vec<ToolGroup> {
+    let refs: Vec<GroupItem<'_>> = items.iter().map(|item| GroupItem::Output(item)).collect();
+    discover_group_items(&refs)
+}
+
+enum GroupItem<'a> {
+    Message(&'a MessageItem),
+    Output(&'a OutputItem),
+}
+
+fn group_function_call<'a>(item: &'a GroupItem<'a>) -> Option<&'a FunctionToolCall> {
+    match item {
+        GroupItem::Message(item) => function_call(item),
+        GroupItem::Output(OutputItem::FunctionCall(call)) => Some(call),
+        GroupItem::Output(_) => None,
+    }
+}
+
+fn group_is_reasoning(item: &GroupItem<'_>) -> bool {
+    matches!(
+        item,
+        GroupItem::Message(MessageItem::Output(OutputItem::Reasoning(_)))
+            | GroupItem::Output(OutputItem::Reasoning(_))
+    )
+}
+
+fn group_is_tool_output(item: &GroupItem<'_>) -> bool {
+    matches!(item, GroupItem::Message(MessageItem::ToolOutput { .. }))
+}
+
+fn discover_group_items(items: &[GroupItem<'_>]) -> Vec<ToolGroup> {
     let mut groups = Vec::new();
     let mut run = Vec::new();
     let mut absorbed = Vec::new();
@@ -163,7 +204,7 @@ pub(crate) fn discover_tool_groups(items: &[MessageItem]) -> Vec<ToolGroup> {
         if run.len() >= min {
             let calls: Vec<&FunctionToolCall> = run
                 .iter()
-                .filter_map(|&index| function_call(&items[index]))
+                .filter_map(|&index| group_function_call(&items[index]))
                 .collect();
             groups.push(ToolGroup {
                 key: calls[0].call_id.clone(),
@@ -179,13 +220,11 @@ pub(crate) fn discover_tool_groups(items: &[MessageItem]) -> Vec<ToolGroup> {
     };
 
     for (index, item) in items.iter().enumerate() {
-        match function_call(item) {
+        match group_function_call(item) {
             Some(call) if is_hidden_runtime_tool(call) => {}
             Some(call) if !is_interactive(call) => run.push(index),
-            None if matches!(item, MessageItem::Output(OutputItem::Reasoning(_))) => {
-                absorbed.push(index)
-            }
-            None if matches!(item, MessageItem::ToolOutput { .. }) => {}
+            None if group_is_reasoning(item) => absorbed.push(index),
+            None if group_is_tool_output(item) => {}
             _ => flush(&mut run, &mut absorbed, false, &mut groups),
         }
     }
@@ -193,20 +232,17 @@ pub(crate) fn discover_tool_groups(items: &[MessageItem]) -> Vec<ToolGroup> {
     groups
 }
 
-/// Find the open tool run that crosses from committed conversation history
-/// into the currently streaming response. The renderer stores those two parts
-/// separately, but they are one logical run and must therefore render as one
-/// stable block while the response is still arriving.
-pub(crate) fn discover_tool_group_bridge(
-    committed: &[MessageItem],
-    live: &[MessageItem],
+/// Discover a bridge while borrowing the live side. The live side is
+/// still owned by `PartialResponse`; keeping references here avoids cloning a
+/// long reasoning body just to determine whether the trailing tool run
+/// continues across the response boundary.
+pub(crate) fn discover_tool_group_bridge_outputs<'a>(
+    committed: &'a [MessageItem],
+    live: &'a [&'a OutputItem],
 ) -> Option<ToolGroup> {
     if live.is_empty() {
         return None;
     }
-
-    // Only the trailing run can continue into a new streamed response. Clone
-    // that small suffix instead of the whole transcript on every frame.
     let tail_start = committed
         .iter()
         .rposition(|item| !continues_tool_run(item))
@@ -216,9 +252,10 @@ pub(crate) fn discover_tool_group_bridge(
         return None;
     }
 
-    let mut joined = committed[tail_start..].to_vec();
-    joined.extend_from_slice(live);
-    let mut group = discover_tool_groups(&joined).into_iter().find(|group| {
+    let mut joined = Vec::with_capacity(committed_tail_len + live.len());
+    joined.extend(committed[tail_start..].iter().map(GroupItem::Message));
+    joined.extend(live.iter().map(|item| GroupItem::Output(item)));
+    let mut group = discover_group_items(&joined).into_iter().find(|group| {
         let has_committed_call = group
             .member_indices
             .iter()
@@ -414,6 +451,7 @@ impl ToolGroupKind {
 /// done) — so absorbed reasoning stays visible without expanding the group.
 /// `thought_in_progress` reflects the live streaming state of the absorbed
 /// reasoning (committed groups pass `false`).
+#[allow(dead_code)]
 pub(crate) fn build_tool_group_paragraph<'a>(
     group: &ToolGroup,
     members: &[ToolGroupMember<'a>],
@@ -421,6 +459,34 @@ pub(crate) fn build_tool_group_paragraph<'a>(
     width: u16,
     expanded: bool,
     thought_in_progress: bool,
+) -> (Paragraph<'static>, Vec<MemberHeader>) {
+    build_tool_group_paragraph_with_reasoning_cache(
+        group,
+        members,
+        absorbed,
+        width,
+        expanded,
+        thought_in_progress,
+        None,
+        &HashSet::new(),
+    )
+}
+
+/// Variant used by a live group.  The Markdown-heavy reasoning bodies are
+/// supplied by the background renderer when available.  A live item whose
+/// result has not arrived yet gets a tiny placeholder instead of falling back
+/// to synchronous parsing on the UI thread.  Committed reasoning (not present
+/// in `live_reasoning_indices`) keeps the original synchronous path.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
+    group: &ToolGroup,
+    members: &[ToolGroupMember<'a>],
+    absorbed: &[(usize, &'a ReasoningItem, bool)],
+    width: u16,
+    expanded: bool,
+    thought_in_progress: bool,
+    reasoning_cache: Option<&HashMap<usize, Arc<Text<'static>>>>,
+    live_reasoning_indices: &HashSet<usize>,
 ) -> (Paragraph<'static>, Vec<MemberHeader>) {
     let completed = members
         .iter()
@@ -492,9 +558,22 @@ pub(crate) fn build_tool_group_paragraph<'a>(
                 lines.extend(text.lines);
             } else {
                 let (index, item, thought_expanded) = thoughts.next().unwrap();
-                let (text, _) = ReasoningMessage::new(false, item, width)
-                    .expanded(thought_expanded)
-                    .into_parts();
+                let text = if let Some(cached) = reasoning_cache.and_then(|cache| cache.get(&index))
+                {
+                    cached.as_ref().clone()
+                } else if live_reasoning_indices.contains(&index) {
+                    // The worker is still rendering this live body. Keep the
+                    // group geometry valid without doing Markdown work here.
+                    Text::from(Line::from(Span::styled(
+                        "  … rendering…",
+                        Style::new().fg(palette::MUTED),
+                    )))
+                } else {
+                    ReasoningMessage::new(false, item, width)
+                        .expanded(thought_expanded)
+                        .into_parts()
+                        .0
+                };
                 let height = text_height(&text, inner_width, wrap);
                 headers.push(MemberHeader {
                     index,

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -16,8 +16,8 @@
 use crate::response::message_item::MessageItem;
 use crate::ui::components::conversation_panel::conversation_panel::{
     ActivePhase, CachedLiveSlot, CachedParagraph, CachedToolGroup, ConversationPanel,
-    LiveGroupHeader, LiveParagraph, LiveRenderCache, MaterializedLiveCache, ToolGroupLayout,
-    ViewportParagraphCache, live_response_message_key,
+    LiveGroupHeader, LiveParagraph, LiveParagraphContent, LiveRenderCache, MaterializedLiveCache,
+    ToolGroupLayout, ViewportParagraphCache, live_response_message_key,
 };
 use crate::ui::components::conversation_panel::tool_group::{
     MemberHeader, ToolGroup, ToolGroupMember, build_tool_group_paragraph_with_reasoning_cache,
@@ -175,6 +175,36 @@ fn render_virtual_paragraph(
     }
 }
 
+fn render_virtual_live_paragraph(
+    paragraph: &LiveParagraphContent,
+    item_top: u16,
+    item_height: u16,
+    viewport_top: u16,
+    viewport: Rect,
+    buf: &mut Buffer,
+    clipped: &mut ViewportParagraphCache,
+) {
+    match paragraph {
+        LiveParagraphContent::Paragraph(paragraph) => render_virtual_paragraph(
+            paragraph,
+            item_top,
+            item_height,
+            viewport_top,
+            viewport,
+            buf,
+            clipped,
+        ),
+        LiveParagraphContent::Incremental(paragraph) => {
+            let Some((source_offset, destination)) =
+                virtual_window(item_top, item_height, viewport_top, viewport)
+            else {
+                return;
+            };
+            paragraph.render(destination, buf, source_offset);
+        }
+    }
+}
+
 fn render_virtual_borrowed_paragraph(
     paragraph: &Paragraph<'_>,
     item_top: u16,
@@ -298,7 +328,11 @@ fn materialize_live_slot(
 
 fn empty_live_slot() -> CachedLiveSlot {
     CachedLiveSlot::Fixed {
-        paragraph: (Arc::new(Paragraph::new("")), 0, Arc::new(Vec::new())),
+        paragraph: (
+            LiveParagraphContent::Paragraph(Arc::new(Paragraph::new(""))),
+            0,
+            Arc::new(Vec::new()),
+        ),
         group_header: None,
     }
 }
@@ -411,9 +445,17 @@ fn build_live_group_slot<'a>(
         let expanded_height = expanded.line_count(content_width) as u16;
         CachedLiveSlot::Explore {
             group_key: group.key.clone(),
-            collapsed: (Arc::new(collapsed), collapsed_height, Arc::new(Vec::new())),
+            collapsed: (
+                LiveParagraphContent::Paragraph(Arc::new(collapsed)),
+                collapsed_height,
+                Arc::new(Vec::new()),
+            ),
             collapsed_headers,
-            expanded: (Arc::new(expanded), expanded_height, Arc::new(Vec::new())),
+            expanded: (
+                LiveParagraphContent::Paragraph(Arc::new(expanded)),
+                expanded_height,
+                Arc::new(Vec::new()),
+            ),
             expanded_headers,
         }
     } else {
@@ -429,7 +471,11 @@ fn build_live_group_slot<'a>(
         );
         let height = paragraph.line_count(content_width) as u16;
         CachedLiveSlot::Fixed {
-            paragraph: (Arc::new(paragraph), height, Arc::new(Vec::new())),
+            paragraph: (
+                LiveParagraphContent::Paragraph(Arc::new(paragraph)),
+                height,
+                Arc::new(Vec::new()),
+            ),
             group_header: Some((group.key.clone(), member_headers)),
         }
     }
@@ -856,7 +902,7 @@ impl Widget for &mut ConversationPanel {
             if needs_build {
                 let entry = if hidden {
                     CachedParagraph {
-                        paragraph: Arc::new(Paragraph::new("")),
+                        paragraph: LiveParagraphContent::Paragraph(Arc::new(Paragraph::new(""))),
                         height: 0,
                         hidden: true,
                         expanded,
@@ -867,7 +913,7 @@ impl Widget for &mut ConversationPanel {
                     }
                 } else if !in_viewport {
                     CachedParagraph {
-                        paragraph: Arc::new(Paragraph::new("")),
+                        paragraph: LiveParagraphContent::Paragraph(Arc::new(Paragraph::new(""))),
                         height: est_heights[index],
                         hidden: false,
                         expanded,
@@ -934,7 +980,7 @@ impl Widget for &mut ConversationPanel {
                         );
                     let height = paragraph.line_count(content_width) as u16;
                     CachedParagraph {
-                        paragraph: Arc::new(paragraph),
+                        paragraph: LiveParagraphContent::Paragraph(Arc::new(paragraph)),
                         height,
                         hidden: false,
                         expanded,
@@ -954,8 +1000,12 @@ impl Widget for &mut ConversationPanel {
                         .and_then(|key| self.live_markdown_front.get(key))
                         .filter(|snapshot| snapshot.width == content_width);
                     if let Some(snapshot) = history_snapshot {
+                        let paragraph = snapshot.incremental.as_ref().map_or_else(
+                            || LiveParagraphContent::Paragraph(snapshot.paragraph.clone()),
+                            |paragraph| LiveParagraphContent::Incremental(paragraph.clone()),
+                        );
                         CachedParagraph {
-                            paragraph: snapshot.paragraph.clone(),
+                            paragraph,
                             height: snapshot.height,
                             hidden: false,
                             expanded,
@@ -969,7 +1019,9 @@ impl Widget for &mut ConversationPanel {
                         // the worker. Keep it in the virtual layout without
                         // falling back to a synchronous Markdown parse.
                         CachedParagraph {
-                            paragraph: Arc::new(Paragraph::new("…")),
+                            paragraph: LiveParagraphContent::Paragraph(Arc::new(Paragraph::new(
+                                "…",
+                            ))),
                             height: 1,
                             hidden: false,
                             expanded,
@@ -988,7 +1040,7 @@ impl Widget for &mut ConversationPanel {
                         );
                         let height = paragraph.line_count(content_width) as u16;
                         CachedParagraph {
-                            paragraph: Arc::new(paragraph),
+                            paragraph: LiveParagraphContent::Paragraph(Arc::new(paragraph)),
                             height,
                             hidden: false,
                             expanded,
@@ -1199,17 +1251,23 @@ impl Widget for &mut ConversationPanel {
                             .get(&key)
                             .filter(|snapshot| snapshot.width == content_width)
                             .map(|snapshot| {
-                                (
-                                    snapshot.paragraph.clone(),
-                                    snapshot.height,
-                                    snapshot.copy_buttons.clone(),
-                                )
+                                let content = snapshot.incremental.as_ref().map_or_else(
+                                    || LiveParagraphContent::Paragraph(snapshot.paragraph.clone()),
+                                    |paragraph| {
+                                        LiveParagraphContent::Incremental(paragraph.clone())
+                                    },
+                                );
+                                (content, snapshot.height, snapshot.copy_buttons.clone())
                             })
                             .unwrap_or_else(|| {
                                 // A one-line placeholder keeps the live item
                                 // in the virtual layout without parsing its
                                 // incomplete Markdown on this thread.
-                                (Arc::new(Paragraph::new("…")), 1, Arc::new(Vec::new()))
+                                (
+                                    LiveParagraphContent::Paragraph(Arc::new(Paragraph::new("…"))),
+                                    1,
+                                    Arc::new(Vec::new()),
+                                )
                             })
                     } else {
                         let (paragraph, copy_buttons) =
@@ -1219,7 +1277,11 @@ impl Widget for &mut ConversationPanel {
                                 .frame_count(self.frame_count)
                                 .into_paragraph();
                         let height = paragraph.line_count(content_width) as u16;
-                        (Arc::new(paragraph), height, Arc::new(copy_buttons))
+                        (
+                            LiveParagraphContent::Paragraph(Arc::new(paragraph)),
+                            height,
+                            Arc::new(copy_buttons),
+                        )
                     };
                     live_paragraphs.push(paragraph.clone());
                     live_group_headers.push(None);
@@ -1332,7 +1394,7 @@ impl Widget for &mut ConversationPanel {
                 });
             }
             if visible(y, entry.height) {
-                render_virtual_paragraph(
+                render_virtual_live_paragraph(
                     &entry.paragraph,
                     y,
                     entry.height,
@@ -1366,7 +1428,7 @@ impl Widget for &mut ConversationPanel {
                 });
             }
             if visible(y, *height) {
-                render_virtual_paragraph(
+                render_virtual_live_paragraph(
                     paragraph,
                     y,
                     *height,
@@ -1640,6 +1702,75 @@ mod tests {
         assert!(completed.contains("Explored · 1 failed"));
     }
 
+    #[test]
+    fn completed_run_group_clicks_expand_and_collapse() {
+        let mut panel = ConversationPanel::new();
+        for index in 0..3 {
+            panel
+                .conversation
+                .lock()
+                .unwrap()
+                .add_output(OutputItem::FunctionCall(tool_call(
+                    index,
+                    crate::tools::command::NAME,
+                )));
+            panel.add_tool_output(ToolOutput {
+                param: FunctionCallOutputItemParam {
+                    call_id: format!("call-{index}"),
+                    output: FunctionCallOutput::Text(format!(
+                        "first-line-{index}\nfull-only-{index}"
+                    )),
+                    id: None,
+                    status: None,
+                },
+                failed: false,
+                approval_label: None,
+            });
+        }
+        let area = Rect::new(0, 0, 80, 24);
+
+        let collapsed = render_text(&mut panel, area);
+        let header_row = collapsed
+            .lines()
+            .position(|line| line.contains("Ran tools"))
+            .expect("completed run header") as u16;
+        panel.handle_click(2, header_row);
+        let expanded = render_text(&mut panel, area);
+        assert!(expanded.contains("command  {}"), "{expanded}");
+
+        let member_row = expanded
+            .lines()
+            .position(|line| line.contains("command  {}"))
+            .expect("first command header") as u16;
+        panel.handle_click(2, member_row);
+        assert!(panel.expanded_items.contains(&0));
+        let member_expanded = render_text(&mut panel, area);
+        assert!(member_expanded.contains("full-only-0"), "{member_expanded}");
+
+        let expanded_header_row = member_expanded
+            .lines()
+            .position(|line| line.contains("command"))
+            .expect("expanded command header") as u16;
+        panel.handle_click(2, expanded_header_row);
+        assert!(!panel.expanded_items.contains(&0));
+        let member_collapsed = render_text(&mut panel, area);
+        assert!(
+            !member_collapsed.contains("full-only-0"),
+            "{member_collapsed}"
+        );
+
+        let header_row = member_collapsed
+            .lines()
+            .position(|line| line.contains("Ran tools"))
+            .expect("expanded run header") as u16;
+        panel.handle_click(2, header_row);
+        let collapsed_again = render_text(&mut panel, area);
+        assert!(
+            !collapsed_again.contains("command  {}"),
+            "{collapsed_again}"
+        );
+    }
+
     fn tool_call(index: usize, name: &str) -> FunctionToolCall {
         FunctionToolCall {
             arguments: "{}".into(),
@@ -1823,6 +1954,56 @@ mod tests {
     }
 
     #[test]
+    fn streaming_message_renders_the_persistent_incremental_front() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            AssistantRole, OutputMessage, OutputMessageContent, OutputTextContent,
+            ResponseOutputItemAddedEvent, ResponseStreamEvent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Message(OutputMessage {
+                    content: vec![OutputMessageContent::OutputText(OutputTextContent {
+                        annotations: Vec::new(),
+                        logprobs: None,
+                        text: "# stable title\n\nstreaming-message-marker".into(),
+                    })],
+                    id: "incremental-message".into(),
+                    role: AssistantRole::Assistant,
+                    phase: None,
+                    status: OutputStatus::InProgress,
+                }),
+            },
+        ));
+
+        let area = Rect::new(0, 0, 80, 24);
+        let mut rendered = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if rendered.contains("streaming-message-marker") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            rendered = render_text(&mut panel, area);
+        }
+
+        assert!(rendered.contains("stable title"), "{rendered}");
+        assert!(rendered.contains("streaming-message-marker"), "{rendered}");
+        assert!(
+            panel
+                .live_markdown_front
+                .values()
+                .any(|snapshot| snapshot.incremental.is_some())
+        );
+    }
+
+    #[test]
     fn committed_streaming_reasoning_keeps_front_until_history_swap() {
         use crate::cancel::CancellationToken;
         use async_openai::types::responses::{
@@ -2000,6 +2181,182 @@ mod tests {
             panel.live_explore_builds > builds_after_expand,
             "new content must invalidate"
         );
+    }
+
+    #[test]
+    fn streaming_run_group_members_expand_and_collapse_independently() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            ReasoningItem, ResponseOutputItemAddedEvent, ResponseStreamEvent, SummaryPart,
+            SummaryTextContent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Reasoning(ReasoningItem {
+                    id: Some("run-reasoning".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "reasoning-body-marker".into(),
+                    })],
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                }),
+            },
+        ));
+        for output_index in 1..=3 {
+            let mut call = tool_call(output_index, crate::tools::command::NAME);
+            call.arguments = format!(r#"{{"cmd":"command-marker-{output_index}"}}"#);
+            panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+                ResponseOutputItemAddedEvent {
+                    sequence_number: output_index as u64,
+                    output_index: output_index as u32,
+                    item: OutputItem::FunctionCall(call),
+                },
+            ));
+        }
+
+        let area = Rect::new(0, 0, 80, 24);
+        let collapsed = render_text(&mut panel, area);
+        let group_row = collapsed
+            .lines()
+            .position(|line| line.contains("Running tools"))
+            .expect("streaming run group") as u16;
+        panel.handle_click(2, group_row);
+
+        let expanded = render_text(&mut panel, area);
+        let second_call_row = expanded
+            .lines()
+            .position(|line| line.contains("command-marker-2"))
+            .expect("second live command") as u16;
+        panel.handle_click(2, second_call_row);
+        assert!(panel.live_expanded_items.contains(&2));
+        let second_expanded = render_text(&mut panel, area);
+        assert!(
+            second_expanded.contains("cmd: command-marker-2"),
+            "{second_expanded}"
+        );
+
+        let detail_row = second_expanded
+            .lines()
+            .position(|line| line.contains("cmd: command-marker-2"))
+            .expect("expanded command detail") as u16;
+        panel.handle_click(2, detail_row.saturating_sub(1));
+        assert!(!panel.live_expanded_items.contains(&2));
+
+        let collapsed_member = render_text(&mut panel, area);
+        let reasoning_row = collapsed_member
+            .lines()
+            .position(|line| line.contains("Thinking") || line.contains("Thought"))
+            .expect("live reasoning member") as u16;
+        panel.handle_click(2, reasoning_row);
+        assert!(panel.live_expanded_items.contains(&0));
+        let mut reasoning_expanded = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if reasoning_expanded.contains("reasoning-body-marker") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            reasoning_expanded = render_text(&mut panel, area);
+        }
+        assert!(
+            reasoning_expanded.contains("reasoning-body-marker"),
+            "{reasoning_expanded}"
+        );
+        let reasoning_header_row = reasoning_expanded
+            .lines()
+            .position(|line| line.contains("reasoning-body-marker"))
+            .expect("expanded live reasoning header") as u16;
+        panel.handle_click(2, reasoning_header_row);
+        assert!(!panel.live_expanded_items.contains(&0));
+    }
+
+    #[test]
+    fn bridged_streaming_run_toggles_committed_and_live_members() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            ReasoningItem, ResponseOutputItemAddedEvent, ResponseStreamEvent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        let mut committed_call = tool_call(0, crate::tools::command::NAME);
+        committed_call.arguments = r#"{"cmd":"committed-marker"}"#.into();
+        panel
+            .conversation
+            .lock()
+            .unwrap()
+            .add_output(OutputItem::FunctionCall(committed_call));
+        panel.add_tool_output(ToolOutput {
+            param: FunctionCallOutputItemParam {
+                call_id: "call-0".into(),
+                output: FunctionCallOutput::Text(
+                    "committed-first-line\ncommitted-full-only".into(),
+                ),
+                id: None,
+                status: None,
+            },
+            failed: false,
+            approval_label: None,
+        });
+
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Reasoning(ReasoningItem {
+                    id: Some("bridge-run-reasoning".into()),
+                    summary: Vec::new(),
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                }),
+            },
+        ));
+        for output_index in 1..=2 {
+            let mut call = tool_call(output_index, crate::tools::command::NAME);
+            call.arguments = format!(r#"{{"cmd":"live-marker-{output_index}"}}"#);
+            panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+                ResponseOutputItemAddedEvent {
+                    sequence_number: output_index as u64,
+                    output_index: output_index as u32,
+                    item: OutputItem::FunctionCall(call),
+                },
+            ));
+        }
+
+        let area = Rect::new(0, 0, 80, 24);
+        let collapsed = render_text(&mut panel, area);
+        let group_row = collapsed
+            .lines()
+            .position(|line| line.contains("Running tools"))
+            .expect("bridged running-tools header") as u16;
+        panel.handle_click(2, group_row);
+
+        let expanded = render_text(&mut panel, area);
+        let committed_row = expanded
+            .lines()
+            .position(|line| line.contains("committed-marker"))
+            .expect("committed member") as u16;
+        panel.handle_click(2, committed_row);
+        assert!(panel.expanded_items.contains(&0));
+        assert!(render_text(&mut panel, area).contains("committed-full-only"));
+
+        let expanded = render_text(&mut panel, area);
+        let live_row = expanded
+            .lines()
+            .position(|line| line.contains("live-marker-1"))
+            .expect("live member") as u16;
+        panel.handle_click(2, live_row);
+        assert!(panel.live_expanded_items.contains(&1));
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -17,11 +17,12 @@ use crate::response::message_item::MessageItem;
 use crate::ui::components::conversation_panel::conversation_panel::{
     ActivePhase, CachedLiveSlot, CachedParagraph, CachedToolGroup, ConversationPanel,
     LiveGroupHeader, LiveParagraph, LiveRenderCache, MaterializedLiveCache, ToolGroupLayout,
-    ViewportParagraphCache,
+    ViewportParagraphCache, live_response_message_key,
 };
 use crate::ui::components::conversation_panel::tool_group::{
-    MemberHeader, ToolGroup, ToolGroupMember, build_tool_group_paragraph,
-    discover_tool_group_bridge, discover_tool_groups, function_call, is_hidden_runtime_tool,
+    MemberHeader, ToolGroup, ToolGroupMember, build_tool_group_paragraph_with_reasoning_cache,
+    discover_live_tool_groups, discover_tool_group_bridge_outputs, discover_tool_groups,
+    function_call, is_hidden_runtime_tool,
 };
 use crate::ui::components::messages::assistant_message::AssistantMessage;
 use crate::ui::components::messages::compacting_message::CompactingMessage;
@@ -42,6 +43,7 @@ use async_openai::types::responses::{
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
+use ratatui::text::Text;
 use ratatui::widgets::Widget;
 use ratatui_widgets::paragraph::Paragraph;
 use std::collections::{HashMap, HashSet};
@@ -296,7 +298,7 @@ fn materialize_live_slot(
 
 fn empty_live_slot() -> CachedLiveSlot {
     CachedLiveSlot::Fixed {
-        paragraph: (Arc::new(Paragraph::new("")), 0, Vec::new()),
+        paragraph: (Arc::new(Paragraph::new("")), 0, Arc::new(Vec::new())),
         group_header: None,
     }
 }
@@ -305,13 +307,15 @@ fn empty_live_slot() -> CachedLiveSlot {
 fn build_live_group_slot<'a>(
     group: &ToolGroup,
     conversation_items: &'a [MessageItem],
-    receiving_items: &'a [(OutputItem, bool)],
+    receiving_items: &'a [(&'a OutputItem, bool)],
     outputs_by_call: &HashMap<&'a str, (&'a FunctionCallOutputItemParam, bool, Option<&'a str>)>,
     expanded_items: &HashSet<usize>,
     live_expanded_items: &HashSet<usize>,
     live_index_base: usize,
     content_width: u16,
     group_expanded: bool,
+    live_reasoning_text: &HashMap<usize, Arc<Text<'static>>>,
+    live_reasoning_indices: &HashSet<usize>,
 ) -> CachedLiveSlot {
     let live_outputs: Vec<Option<String>> = group
         .member_indices
@@ -383,43 +387,49 @@ fn build_live_group_slot<'a>(
         .any(|&index| receiving_items[index - live_index_base].1);
 
     if group.is_explore() {
-        let (collapsed, collapsed_headers) = build_tool_group_paragraph(
+        let (collapsed, collapsed_headers) = build_tool_group_paragraph_with_reasoning_cache(
             group,
             &members,
             &absorbed,
             content_width,
             false,
             thought_in_progress,
+            Some(live_reasoning_text),
+            live_reasoning_indices,
         );
         let collapsed_height = collapsed.line_count(content_width) as u16;
-        let (expanded, expanded_headers) = build_tool_group_paragraph(
+        let (expanded, expanded_headers) = build_tool_group_paragraph_with_reasoning_cache(
             group,
             &members,
             &absorbed,
             content_width,
             true,
             thought_in_progress,
+            Some(live_reasoning_text),
+            live_reasoning_indices,
         );
         let expanded_height = expanded.line_count(content_width) as u16;
         CachedLiveSlot::Explore {
             group_key: group.key.clone(),
-            collapsed: (Arc::new(collapsed), collapsed_height, Vec::new()),
+            collapsed: (Arc::new(collapsed), collapsed_height, Arc::new(Vec::new())),
             collapsed_headers,
-            expanded: (Arc::new(expanded), expanded_height, Vec::new()),
+            expanded: (Arc::new(expanded), expanded_height, Arc::new(Vec::new())),
             expanded_headers,
         }
     } else {
-        let (paragraph, member_headers) = build_tool_group_paragraph(
+        let (paragraph, member_headers) = build_tool_group_paragraph_with_reasoning_cache(
             group,
             &members,
             &absorbed,
             content_width,
             group_expanded,
             thought_in_progress,
+            Some(live_reasoning_text),
+            live_reasoning_indices,
         );
         let height = paragraph.line_count(content_width) as u16;
         CachedLiveSlot::Fixed {
-            paragraph: (Arc::new(paragraph), height, Vec::new()),
+            paragraph: (Arc::new(paragraph), height, Arc::new(Vec::new())),
             group_header: Some((group.key.clone(), member_headers)),
         }
     }
@@ -516,6 +526,10 @@ impl Widget for &mut ConversationPanel {
             width: content_width,
             ..area
         };
+        // Pull a completed background Markdown result into the front buffer
+        // before calculating live layout. No Markdown parser is run on this
+        // render thread.
+        self.prepare_live_markdown(content_width);
         let stick_to_bottom = self.stick_to_bottom;
         let welcome_message = WelcomeMessage;
         let welcome_height = welcome_message.line_count(content_width);
@@ -527,11 +541,40 @@ impl Widget for &mut ConversationPanel {
         // paragraphs are built, before any rendering.
         let conv_arc = self.conversation.clone();
         let conv = conv_arc.lock().unwrap();
+        self.queue_committed_markdown_jobs(&conv.items, content_width);
+
+        // A response is appended to `conv` before the commit event reaches the
+        // UI. Keep its worker keys addressable by absolute history index so a
+        // still-running background job can finish the hand-off without making
+        // the first committed frame parse the full document synchronously.
+        let mut committed_reasoning_text: HashMap<usize, Arc<Text<'static>>> = HashMap::new();
+        let mut committed_pending_reasoning = HashSet::new();
+        for (index, item) in conv.items.iter().enumerate() {
+            let MessageItem::Output(output) = item else {
+                continue;
+            };
+            let Some(key) = self.live_markdown_history_keys.get(&index) else {
+                continue;
+            };
+            let snapshot = self.live_markdown_front.get(key).filter(|snapshot| {
+                // A fold toggle is a new view request, but the previous-width
+                // paragraph is still a valid front buffer while the worker
+                // materializes the target fold state.
+                snapshot.width == content_width
+            });
+            if let Some(snapshot) = snapshot {
+                if let Some(text) = &snapshot.reasoning_text {
+                    committed_reasoning_text.insert(index, text.clone());
+                }
+            } else if matches!(output, OutputItem::Reasoning(_)) {
+                committed_pending_reasoning.insert(index);
+            }
+        }
 
         let live_response_revision = self
             .receiving_response
             .as_ref()
-            .map(|response| response.render_revision())
+            .map(|response| response.item_render_revision())
             .unwrap_or_default();
         let live_cache_hit = self.live_render_cache.as_ref().is_some_and(|cache| {
             live_cache_matches(
@@ -544,42 +587,41 @@ impl Widget for &mut ConversationPanel {
                 &self.live_expanded_items,
             )
         });
-        let (receiving_items, live_message_items, bridge_group, bridged_committed_items) =
-            if live_cache_hit {
-                (
-                    Vec::new(),
-                    Vec::new(),
-                    None,
-                    self.live_render_cache
-                        .as_ref()
-                        .unwrap()
-                        .bridged_committed_items
-                        .clone(),
-                )
-            } else {
-                let receiving_items = self
-                    .receiving_response
+        // Borrow the live protocol items instead of cloning the growing
+        // Markdown payload on every cache miss. A small owned copy is created
+        // only when a committed tool run may bridge into the stream; the
+        // ordinary standalone Markdown path never needs it.
+        let receiving_items: Vec<(&OutputItem, bool)> = if live_cache_hit {
+            Vec::new()
+        } else {
+            self.receiving_response
+                .as_ref()
+                .map(|receiving_response| receiving_response.message_item_refs())
+                .unwrap_or_default()
+        };
+        let live_output_refs: Vec<&OutputItem> = receiving_items
+            .iter()
+            .map(|(output_item, _)| *output_item)
+            .collect();
+        let (bridge_group, bridged_committed_items) = if live_cache_hit {
+            (
+                None,
+                self.live_render_cache
                     .as_ref()
-                    .map(|receiving_response| receiving_response.get_message_items())
-                    .unwrap_or_default();
-                let live_message_items: Vec<MessageItem> = receiving_items
-                    .iter()
-                    .map(|(output_item, _)| MessageItem::Output(output_item.clone()))
-                    .collect();
-                let bridge_group = discover_tool_group_bridge(&conv.items, &live_message_items);
-                let bridged_committed_items: HashSet<usize> = bridge_group
-                    .iter()
-                    .flat_map(|group| group.member_indices.iter().chain(group.absorbed.iter()))
-                    .copied()
-                    .filter(|&index| index < conv.items.len())
-                    .collect();
-                (
-                    receiving_items,
-                    live_message_items,
-                    bridge_group,
-                    bridged_committed_items,
-                )
-            };
+                    .unwrap()
+                    .bridged_committed_items
+                    .clone(),
+            )
+        } else {
+            let bridge_group = discover_tool_group_bridge_outputs(&conv.items, &live_output_refs);
+            let bridged_committed_items: HashSet<usize> = bridge_group
+                .iter()
+                .flat_map(|group| group.member_indices.iter().chain(group.absorbed.iter()))
+                .copied()
+                .filter(|&index| index < conv.items.len())
+                .collect();
+            (bridge_group, bridged_committed_items)
+        };
 
         // Tool calls render together with their result as one message: map each
         // call_id to its result, and collect the call ids so the standalone
@@ -786,8 +828,20 @@ impl Widget for &mut ConversationPanel {
                             && crate::tools::command::live_output(&call.call_id).is_some()
                     })
             });
+            let history_dirty = if is_group_start {
+                group.is_some_and(|group| {
+                    group
+                        .member_indices
+                        .iter()
+                        .chain(group.absorbed.iter())
+                        .any(|index| self.live_markdown_history_dirty.contains(index))
+                })
+            } else {
+                self.live_markdown_history_dirty.contains(&index)
+            };
             let needs_build = live_output.is_some()
                 || group_has_live_output
+                || history_dirty
                 || cache.entries.get(index).is_none_or(|entry| {
                     let cached_group_key = entry
                         .tool_group
@@ -807,7 +861,7 @@ impl Widget for &mut ConversationPanel {
                         hidden: true,
                         expanded,
                         has_output: effective_has_output,
-                        copy_buttons: Vec::new(),
+                        copy_buttons: Arc::new(Vec::new()),
                         lazy: false,
                         tool_group: None,
                     }
@@ -818,7 +872,7 @@ impl Widget for &mut ConversationPanel {
                         hidden: false,
                         expanded,
                         has_output: effective_has_output,
-                        copy_buttons: Vec::new(),
+                        copy_buttons: Arc::new(Vec::new()),
                         lazy: true,
                         tool_group: group
                             .filter(|_| is_group_start)
@@ -867,14 +921,17 @@ impl Widget for &mut ConversationPanel {
                             (index, item, self.expanded_items.contains(&index))
                         })
                         .collect();
-                    let (paragraph, member_headers) = build_tool_group_paragraph(
-                        group,
-                        &members,
-                        &absorbed,
-                        content_width,
-                        group_expanded,
-                        false,
-                    );
+                    let (paragraph, member_headers) =
+                        build_tool_group_paragraph_with_reasoning_cache(
+                            group,
+                            &members,
+                            &absorbed,
+                            content_width,
+                            group_expanded,
+                            false,
+                            Some(&committed_reasoning_text),
+                            &committed_pending_reasoning,
+                        );
                     let height = paragraph.line_count(content_width) as u16;
                     CachedParagraph {
                         paragraph: Arc::new(paragraph),
@@ -882,7 +939,7 @@ impl Widget for &mut ConversationPanel {
                         hidden: false,
                         expanded,
                         has_output: effective_has_output,
-                        copy_buttons: Vec::new(),
+                        copy_buttons: Arc::new(Vec::new()),
                         lazy: false,
                         tool_group: Some(CachedToolGroup {
                             key: group.key.clone(),
@@ -891,25 +948,68 @@ impl Widget for &mut ConversationPanel {
                         }),
                     }
                 } else {
-                    let (paragraph, copy_buttons) = build_item_paragraph(
-                        &conv.items[index],
-                        content_width,
-                        expanded,
-                        tool_output,
-                        live_output.as_deref(),
-                    );
-                    let height = paragraph.line_count(content_width) as u16;
-                    CachedParagraph {
-                        paragraph: Arc::new(paragraph),
-                        height,
-                        hidden: false,
-                        expanded,
-                        has_output: effective_has_output,
-                        copy_buttons,
-                        lazy: false,
-                        tool_group: None,
+                    let history_snapshot = self
+                        .live_markdown_history_keys
+                        .get(&index)
+                        .and_then(|key| self.live_markdown_front.get(key))
+                        .filter(|snapshot| snapshot.width == content_width);
+                    if let Some(snapshot) = history_snapshot {
+                        CachedParagraph {
+                            paragraph: snapshot.paragraph.clone(),
+                            height: snapshot.height,
+                            hidden: false,
+                            expanded,
+                            has_output: effective_has_output,
+                            copy_buttons: snapshot.copy_buttons.clone(),
+                            lazy: false,
+                            tool_group: None,
+                        }
+                    } else if self.live_markdown_history_keys.contains_key(&index) {
+                        // The committed item is still being materialized by
+                        // the worker. Keep it in the virtual layout without
+                        // falling back to a synchronous Markdown parse.
+                        CachedParagraph {
+                            paragraph: Arc::new(Paragraph::new("…")),
+                            height: 1,
+                            hidden: false,
+                            expanded,
+                            has_output: effective_has_output,
+                            copy_buttons: Arc::new(Vec::new()),
+                            lazy: false,
+                            tool_group: None,
+                        }
+                    } else {
+                        let (paragraph, copy_buttons) = build_item_paragraph(
+                            &conv.items[index],
+                            content_width,
+                            expanded,
+                            tool_output,
+                            live_output.as_deref(),
+                        );
+                        let height = paragraph.line_count(content_width) as u16;
+                        CachedParagraph {
+                            paragraph: Arc::new(paragraph),
+                            height,
+                            hidden: false,
+                            expanded,
+                            has_output: effective_has_output,
+                            copy_buttons: Arc::new(copy_buttons),
+                            lazy: false,
+                            tool_group: None,
+                        }
                     }
                 };
+                if needs_build && in_viewport && is_group_start {
+                    if let Some(group) = group {
+                        for &member_index in
+                            group.member_indices.iter().chain(group.absorbed.iter())
+                        {
+                            self.live_markdown_history_dirty.remove(&member_index);
+                        }
+                    }
+                } else if needs_build && in_viewport && group.is_none() {
+                    self.live_markdown_history_dirty.remove(&index);
+                }
                 if index < cache.entries.len() {
                     cache.entries[index] = entry;
                 } else {
@@ -936,8 +1036,10 @@ impl Widget for &mut ConversationPanel {
             self.live_group_headers = headers;
         } else {
             // Generate a new live cache only when stream content or nested view
-            // state changes. Explore groups pre-render both outer fold states.
-            let mut live_groups = discover_tool_groups(&live_message_items);
+            // state changes. Explore groups pre-render both outer fold states;
+            // standalone Markdown items use the same cache so animation ticks
+            // do not clone their full OutputItem again.
+            let mut live_groups = discover_live_tool_groups(&live_output_refs);
             for group in &mut live_groups {
                 group.offset_indices(live_index_base);
             }
@@ -976,11 +1078,35 @@ impl Widget for &mut ConversationPanel {
                 }
             }
 
+            // Live reasoning bodies are the expensive part of an expanded
+            // Explore group.  Feed the latest completed worker text into the
+            // cheap group assembler; a missing entry is represented by a
+            // placeholder rather than triggering Markdown parsing here.
+            // Include committed reasoning that is being bridged into this
+            // still-live tool group. If its hand-off snapshot is not ready,
+            // mark it pending too; otherwise the group renderer would fall
+            // back to synchronous Markdown parsing for the old item.
+            let mut reasoning_text = committed_reasoning_text.clone();
+            let mut reasoning_pending = committed_pending_reasoning.clone();
+            for (i, (item, _)) in receiving_items.iter().enumerate() {
+                if !matches!(item, OutputItem::Reasoning(_)) {
+                    continue;
+                }
+                let transcript_index = live_index_base + i;
+                reasoning_pending.insert(transcript_index);
+                if let Some(key) = live_response_message_key(item, i, self.live_markdown_generation)
+                    && let Some(snapshot) = self.live_markdown_front.get(&key)
+                    && snapshot.width == content_width
+                    && let Some(text) = &snapshot.reasoning_text
+                {
+                    reasoning_text.insert(transcript_index, text.clone());
+                }
+            }
+
             let mut live_group_headers = Vec::with_capacity(receiving_items.len());
             let mut live_paragraphs = Vec::with_capacity(receiving_items.len());
             let mut cache_slots = Vec::with_capacity(receiving_items.len());
             let mut cacheable = !receiving_items.is_empty();
-            let mut saw_explore = false;
             for i in 0..receiving_items.len() {
                 let (output_item, in_progress) = &receiving_items[i];
                 let expanded = self.live_expanded_items.contains(&i);
@@ -1008,7 +1134,6 @@ impl Widget for &mut ConversationPanel {
                         continue;
                     }
                     if group.is_explore() {
-                        saw_explore = true;
                         #[cfg(test)]
                         {
                             self.live_explore_builds = self.live_explore_builds.wrapping_add(1);
@@ -1028,6 +1153,8 @@ impl Widget for &mut ConversationPanel {
                         live_index_base,
                         content_width,
                         group_expanded,
+                        &reasoning_text,
+                        &reasoning_pending,
                     );
                     let (paragraph, group_header) = materialize_live_slot(
                         &slot,
@@ -1051,15 +1178,49 @@ impl Widget for &mut ConversationPanel {
                         cache_slots.push(slot);
                         continue;
                     }
-                    cacheable = false;
-                    let (paragraph, copy_buttons) =
-                        AssistantMessage::new(output_item, content_width)
-                            .in_progress(*in_progress)
-                            .expanded(expanded)
-                            .frame_count(self.frame_count)
-                            .into_paragraph();
-                    let height = paragraph.line_count(content_width) as u16;
-                    let paragraph = (Arc::new(paragraph), height, copy_buttons);
+                    if !matches!(
+                        output_item,
+                        OutputItem::Message(_) | OutputItem::Reasoning(_)
+                    ) {
+                        // Function/tool items may expose a separately changing
+                        // live output buffer, so keep rebuilding those frames.
+                        cacheable = false;
+                    }
+                    // Ordinary live Markdown (including standalone reasoning)
+                    // is generated by the background worker.  Keep the last
+                    // completed paragraph visible while a newer one is being
+                    // built.  Non-Markdown live items still use their cheap
+                    // synchronous renderer; they must never disappear just
+                    // because no worker key exists for them.
+                    let paragraph = if let Some(key) =
+                        live_response_message_key(output_item, i, self.live_markdown_generation)
+                    {
+                        self.live_markdown_front
+                            .get(&key)
+                            .filter(|snapshot| snapshot.width == content_width)
+                            .map(|snapshot| {
+                                (
+                                    snapshot.paragraph.clone(),
+                                    snapshot.height,
+                                    snapshot.copy_buttons.clone(),
+                                )
+                            })
+                            .unwrap_or_else(|| {
+                                // A one-line placeholder keeps the live item
+                                // in the virtual layout without parsing its
+                                // incomplete Markdown on this thread.
+                                (Arc::new(Paragraph::new("…")), 1, Arc::new(Vec::new()))
+                            })
+                    } else {
+                        let (paragraph, copy_buttons) =
+                            AssistantMessage::new(output_item, content_width)
+                                .in_progress(*in_progress)
+                                .expanded(expanded)
+                                .frame_count(self.frame_count)
+                                .into_paragraph();
+                        let height = paragraph.line_count(content_width) as u16;
+                        (Arc::new(paragraph), height, Arc::new(copy_buttons))
+                    };
                     live_paragraphs.push(paragraph.clone());
                     live_group_headers.push(None);
                     cache_slots.push(CachedLiveSlot::Fixed {
@@ -1070,7 +1231,7 @@ impl Widget for &mut ConversationPanel {
             }
             self.live_paragraphs = live_paragraphs;
             self.live_group_headers = live_group_headers;
-            self.live_render_cache = (cacheable && saw_explore).then(|| LiveRenderCache {
+            self.live_render_cache = cacheable.then(|| LiveRenderCache {
                 response_revision: live_response_revision,
                 content_width,
                 conversation_len: conv.items.len(),
@@ -1619,6 +1780,145 @@ mod tests {
     }
 
     #[test]
+    fn standalone_streaming_reasoning_swaps_in_background_markdown() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            ReasoningItem, ResponseOutputItemAddedEvent, ResponseStreamEvent, SummaryPart,
+            SummaryTextContent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.live_expanded_items.insert(0);
+        let body = format!(
+            "# background reasoning\n\n{}\n\nworker-marker-standalone",
+            "line with **markdown** and `code`\n".repeat(500)
+        );
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Reasoning(ReasoningItem {
+                    id: Some("standalone-reasoning".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent { text: body })],
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                }),
+            },
+        ));
+
+        let area = Rect::new(0, 0, 80, 24);
+        let mut rendered = render_text(&mut panel, area);
+        for _ in 0..200 {
+            if rendered.contains("worker-marker-standalone") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            rendered = render_text(&mut panel, area);
+        }
+        assert!(rendered.contains("worker-marker-standalone"), "{rendered}");
+    }
+
+    #[test]
+    fn committed_streaming_reasoning_keeps_front_until_history_swap() {
+        use crate::cancel::CancellationToken;
+        use async_openai::types::responses::{
+            ReasoningItem, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
+            ResponseStreamEvent, SummaryPart, SummaryTextContent,
+        };
+
+        let mut panel = ConversationPanel::new();
+        panel.receiving_response = Some(crate::response::partial_response::PartialResponse::new(
+            CancellationToken::new(),
+        ));
+        panel.live_expanded_items.insert(0);
+        let reasoning = ReasoningItem {
+            id: Some("commit-reasoning".into()),
+            summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                text: "commit-worker-marker\n\n**long body**".into(),
+            })],
+            content: None,
+            encrypted_content: None,
+            status: None,
+        };
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemAdded(
+            ResponseOutputItemAddedEvent {
+                sequence_number: 0,
+                output_index: 0,
+                item: OutputItem::Reasoning(reasoning.clone()),
+            },
+        ));
+
+        let area = Rect::new(0, 0, 80, 24);
+        let mut rendered = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if rendered.contains("commit-worker-marker") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            rendered = render_text(&mut panel, area);
+        }
+        assert!(rendered.contains("commit-worker-marker"), "{rendered}");
+
+        // Finish the item and commit immediately, without giving the old
+        // in-progress front snapshot another render tick.
+        panel.handle_response_stream_event(ResponseStreamEvent::ResponseOutputItemDone(
+            ResponseOutputItemDoneEvent {
+                sequence_number: 1,
+                output_index: 0,
+                item: OutputItem::Reasoning(reasoning),
+            },
+        ));
+
+        let committed = panel
+            .receiving_response
+            .as_ref()
+            .unwrap()
+            .get_message_items();
+        for (item, _) in committed {
+            panel.conversation.lock().unwrap().add_output(item);
+        }
+        panel.commit_live();
+        let committed_render = render_text(&mut panel, area);
+        assert!(
+            committed_render.contains("commit-worker-marker"),
+            "{committed_render}"
+        );
+
+        // A post-commit fold change must schedule a new worker snapshot rather
+        // than leaving the historical item at the one-line placeholder.
+        panel.expanded_items.remove(&0);
+        let _ = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if panel
+                .live_markdown_front
+                .values()
+                .any(|snapshot| !snapshot.expanded && !snapshot.in_progress)
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            let _ = render_text(&mut panel, area);
+        }
+        assert!(
+            panel
+                .live_markdown_front
+                .values()
+                .any(|snapshot| !snapshot.expanded && !snapshot.in_progress)
+        );
+
+        // Starting another response must not discard a committed hand-off
+        // that is still used by the historical renderer.
+        let history_count = panel.live_markdown_history_keys.len();
+        panel.begin_live_response();
+        assert_eq!(panel.live_markdown_history_keys.len(), history_count);
+        assert!(render_text(&mut panel, area).contains("commit-worker-marker"));
+    }
+
+    #[test]
     fn live_explore_group_reuses_layout_until_content_or_view_changes() {
         use crate::cancel::CancellationToken;
         use async_openai::types::responses::{
@@ -1662,21 +1962,21 @@ mod tests {
             .unwrap() as u16;
 
         panel.handle_click(2, header_row);
-        let expanded = render_text(&mut panel, area);
+        let mut expanded = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if expanded.contains("cached reasoning") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            expanded = render_text(&mut panel, area);
+        }
         assert!(expanded.contains("cached reasoning"), "{expanded}");
-        assert_eq!(
-            panel.live_explore_builds, 1,
-            "the expanded form must be generated with the message"
-        );
-        assert_eq!(panel.live_explore_cache_hits, 1);
+        let builds_after_expand = panel.live_explore_builds;
+        assert!(builds_after_expand <= 2, "{builds_after_expand}");
 
         let unchanged = render_text(&mut panel, area);
         assert!(unchanged.contains("cached reasoning"), "{unchanged}");
-        assert_eq!(
-            panel.live_explore_builds, 1,
-            "an unchanged animation/timer frame must reuse the live paragraph"
-        );
-        assert_eq!(panel.live_explore_cache_hits, 2);
+        assert_eq!(panel.live_explore_builds, builds_after_expand);
 
         panel.handle_response_stream_event(ResponseStreamEvent::ResponseReasoningSummaryTextDelta(
             ResponseReasoningSummaryTextDeltaEvent {
@@ -1687,9 +1987,19 @@ mod tests {
                 delta: " updated".into(),
             },
         ));
-        let updated = render_text(&mut panel, area);
+        let mut updated = render_text(&mut panel, area);
+        for _ in 0..100 {
+            if updated.contains("cached reasoning updated") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            updated = render_text(&mut panel, area);
+        }
         assert!(updated.contains("cached reasoning updated"), "{updated}");
-        assert_eq!(panel.live_explore_builds, 2, "new content must invalidate");
+        assert!(
+            panel.live_explore_builds > builds_after_expand,
+            "new content must invalidate"
+        );
     }
 
     #[test]

--- a/src/ui/components/messages/assistant/reasoning.rs
+++ b/src/ui/components/messages/assistant/reasoning.rs
@@ -109,13 +109,7 @@ impl<'a> ReasoningMessage<'a> {
 
         let mut codes = Vec::new();
         if self.expanded && !text.is_empty() {
-            let render_width = self.width.saturating_sub(BLOCK_PAD + INDENT).min(100);
-            let hooks = CodeBlockHooks::new(render_width as usize);
-            let codes_handle = hooks.codes();
-            let renderer =
-                MarkdownRenderer::new(render_width as usize).with_render_hooks(Box::new(hooks));
-            let blocks = renderer.parse(&text);
-            let md_lines = renderer.render(&blocks, &AppTheme);
+            let (md_lines, rendered_codes) = render_markdown(&text, markdown_width(self.width));
             for line in md_lines {
                 let mut spans = vec![Span::raw("  ")];
                 spans.extend(
@@ -125,7 +119,7 @@ impl<'a> ReasoningMessage<'a> {
                 );
                 lines.push(Line::from(spans));
             }
-            codes = codes_handle.lock().map(|c| c.clone()).unwrap_or_default();
+            codes = rendered_codes;
         }
 
         (Text::from(lines), codes)
@@ -166,6 +160,23 @@ fn reasoning_text(item: &ReasoningItem) -> String {
     }
 
     parts.join("\n")
+}
+
+fn markdown_width(width: u16) -> u16 {
+    width.saturating_sub(BLOCK_PAD + INDENT).min(100)
+}
+
+fn render_markdown(source: &str, render_width: u16) -> (Vec<Line<'static>>, Vec<String>) {
+    let hooks = CodeBlockHooks::new(render_width as usize);
+    let codes_handle = hooks.codes();
+    let renderer = MarkdownRenderer::new(render_width as usize).with_render_hooks(Box::new(hooks));
+    let blocks = renderer.parse(source);
+    let lines = renderer.render(&blocks, &AppTheme);
+    let codes = codes_handle
+        .lock()
+        .map(|codes| codes.clone())
+        .unwrap_or_default();
+    (lines, codes)
 }
 
 #[cfg(test)]

--- a/src/ui/components/messages/assistant/text.rs
+++ b/src/ui/components/messages/assistant/text.rs
@@ -39,25 +39,36 @@ impl<'a> TextMessage<'a> {
     /// Renders the message, also returning the raw content of every code block
     /// (in render order) so copy buttons can be wired up.
     pub fn into_parts(self) -> (Text<'static>, Vec<String>) {
-        let md = self
-            .message
-            .content
-            .iter()
-            .map(|content| match content {
-                OutputMessageContent::OutputText(text) => text.text.clone(),
-                OutputMessageContent::Refusal(refusal) => refusal.refusal.clone(),
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        let render_width = self.width.saturating_sub(HORIZONTAL_PAD);
-        let hooks = CodeBlockHooks::new(render_width as usize);
-        let codes = hooks.codes();
-        let renderer =
-            MarkdownRenderer::new(render_width as usize).with_render_hooks(Box::new(hooks));
-        let blocks = renderer.parse(&md);
-        let text = Text::from(renderer.render(&blocks, &AppTheme));
-        let codes = codes.lock().map(|c| c.clone()).unwrap_or_default();
-        (text, codes)
+        let md = markdown_source(self.message);
+        render_markdown(&md, markdown_width(self.width))
     }
+}
+
+/// Flatten the protocol content parts into the Markdown document shown by the
+/// assistant message. Kept here so the live worker and finished-message path
+/// cannot drift while the worker renders that source incrementally.
+pub(crate) fn markdown_source(message: &OutputMessage) -> String {
+    message
+        .content
+        .iter()
+        .map(|content| match content {
+            OutputMessageContent::OutputText(text) => text.text.as_str(),
+            OutputMessageContent::Refusal(refusal) => refusal.refusal.as_str(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(crate) fn markdown_width(width: u16) -> u16 {
+    width.saturating_sub(HORIZONTAL_PAD)
+}
+
+pub(crate) fn render_markdown(md: &str, render_width: u16) -> (Text<'static>, Vec<String>) {
+    let hooks = CodeBlockHooks::new(render_width as usize);
+    let codes = hooks.codes();
+    let renderer = MarkdownRenderer::new(render_width as usize).with_render_hooks(Box::new(hooks));
+    let blocks = renderer.parse(md);
+    let text = Text::from(renderer.render(&blocks, &AppTheme));
+    let codes = codes.lock().map(|c| c.clone()).unwrap_or_default();
+    (text, codes)
 }

--- a/src/ui/components/messages/assistant_message.rs
+++ b/src/ui/components/messages/assistant_message.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use async_openai::types::responses::{FunctionCallOutputItemParam, OutputItem};
+use async_openai::types::responses::{FunctionCallOutputItemParam, OutputItem, ReasoningItem};
 use ratatui::prelude::Color;
 use ratatui::style::Style;
 use ratatui::text::Text;
@@ -147,6 +147,33 @@ impl<'a> AssistantMessage<'a> {
         }
         (paragraph, buttons)
     }
+}
+
+/// Render a reasoning item once and return both the wrapped paragraph used by
+/// the conversation panel and the unwrapped text used when the item is
+/// embedded in a live tool group.  Keeping this as one operation is important
+/// for the asynchronous live renderer: the Markdown parser/highlighter runs
+/// on the worker, while the UI thread only assembles already-owned lines.
+pub(crate) fn render_reasoning(
+    item: &ReasoningItem,
+    width: u16,
+    in_progress: bool,
+    expanded: bool,
+    frame_count: u64,
+) -> (Paragraph<'static>, Vec<CodeCopyButton>, Text<'static>) {
+    let (text, codes) = ReasoningMessage::new(in_progress, item, width)
+        .expanded(expanded)
+        .frame_count(Some(frame_count))
+        .into_parts();
+    let buttons = scan_copy_buttons(&text, &codes);
+    let block = Block::default()
+        .padding(Padding::new(PAD_LEFT, PAD_RIGHT, 0, 1))
+        .style(if expanded {
+            Style::new().bg(EXPANDED_BG)
+        } else {
+            Style::new()
+        });
+    (Paragraph::new(text.clone()).block(block), buttons, text)
 }
 
 /// Locates the clickable copy labels rendered by `CodeBlockHooks` in `text` and

--- a/src/ui/components/messages/assistant_message.rs
+++ b/src/ui/components/messages/assistant_message.rs
@@ -123,6 +123,16 @@ impl<'a> AssistantMessage<'a> {
             ),
             other => (UnsupportedMessage::new(other).into_text(), Vec::new()),
         };
+        self.into_paragraph_from_parts(text, codes)
+    }
+
+    /// Wrap text materialized by the live Markdown worker in the same padding,
+    /// background, and copy-button geometry as the ordinary renderer.
+    pub(crate) fn into_paragraph_from_parts(
+        self,
+        text: Text<'static>,
+        codes: Vec<String>,
+    ) -> (Paragraph<'static>, Vec<CodeCopyButton>) {
         let buttons = scan_copy_buttons(&text, &codes);
 
         let foldable = matches!(
@@ -180,11 +190,18 @@ pub(crate) fn render_reasoning(
 /// pairs each with its code block content (the k-th label belongs to the k-th
 /// block). Coordinates are relative to the paragraph, including its padding.
 fn scan_copy_buttons(text: &Text<'_>, codes: &[String]) -> Vec<CodeCopyButton> {
+    scan_copy_buttons_from_lines(&text.lines, codes)
+}
+
+pub(crate) fn scan_copy_buttons_from_lines(
+    lines: &[ratatui::text::Line<'_>],
+    codes: &[String],
+) -> Vec<CodeCopyButton> {
     let mut buttons = Vec::new();
     if codes.is_empty() {
         return buttons;
     }
-    for (row, line) in text.lines.iter().enumerate() {
+    for (row, line) in lines.iter().enumerate() {
         let mut x = 0u16;
         for span in &line.spans {
             let width = span.width() as u16;


### PR DESCRIPTION
## Summary

Release v0.2.4: streaming rendering performance + dependency bumps.

### Highlights
- Render streaming Markdown off the UI thread so long assistant responses no longer block input handling or redraws.
- Virtualize and cache conversation panel layout work for smooth scrolling in long conversations.
- Optimize streaming Markdown rendering (fewer intermediate re-parses).

### Dependencies
- async-openai 0.41.1 → 0.41.3
- serde 1.0.228 → 1.0.229

### Version bump
- Cargo.toml / Cargo.lock → 0.2.4
- README install/upgrade examples → v0.2.4
- Bug report template placeholder → v0.2.4
- RELEASE_NOTES.md v0.2.4 section

### Verification
- `cargo test --locked`: 507 passed, 0 failed (1 ignored) + 1 CLI test
- `cargo clippy --all-targets --locked`: clean

**Full changelog:** https://github.com/huangdihd/programmer/compare/v0.2.3...v0.2.4

Co-Authored-By: programmer <noreply@programmer.local>