### PR TITLE
v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.5"
+version = "0.2.6"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/src/app/events/mouse.rs
+++ b/src/app/events/mouse.rs
@@ -95,7 +95,9 @@ pub(crate) fn handle_mouse(app: &mut App<'_>, mouse: MouseEvent) {
                 .conversation_panel
                 .selection_end(mouse.column, mouse.row)
             {
-                SelectionEnd::Click => app.conversation_panel.handle_click(mouse.column, mouse.row),
+                SelectionEnd::Click { column, row } => {
+                    app.conversation_panel.handle_buffer_click(column, row)
+                }
                 SelectionEnd::Copied(text) => {
                     if !crate::clipboard::copy(&text) {
                         app.conversation_panel

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -99,23 +99,41 @@ pub(crate) async fn run_with_security_scope(
     // Normalize CRLF → LF so old_string matching works across platforms.
     let contents = contents.replace("\r\n", "\n");
     let old_normalized = args.old_string.replace("\r\n", "\n");
-    let matches_count = if let Some(offset) = args.offset {
+    let region = if let Some(offset) = args.offset {
         let limit = args.limit.unwrap_or(1);
-        let lines: Vec<&str> = contents.lines().collect();
-        let start = offset.saturating_sub(1); // 1-based → 0-based
-        let end = (start + limit).min(lines.len());
-        if start >= lines.len() {
+        let line_count = contents.lines().count();
+        let start_line = offset.saturating_sub(1); // 1-based → 0-based
+        if start_line >= line_count {
             return Err(format!(
-                "error: offset {offset} is past end of {} ({} lines)",
-                args.path,
-                lines.len()
+                "error: offset {offset} is past end of {} ({line_count} lines)",
+                args.path
             ));
         }
-        let region = lines[start..end].join("\n");
-        region.matches(&old_normalized).count()
+        let end_line = start_line.saturating_add(limit).min(line_count);
+        let mut starts = std::iter::once(0)
+            .chain(
+                contents
+                    .match_indices('\n')
+                    .map(|(index, _)| index + 1)
+                    .filter(|&index| index < contents.len()),
+            )
+            .skip(start_line);
+        let start = starts.next().unwrap();
+        let end = if end_line == start_line {
+            start
+        } else {
+            starts
+                .nth(end_line - start_line - 1)
+                .unwrap_or(contents.len())
+        };
+        Some(start..end)
     } else {
-        contents.matches(&old_normalized).count()
+        None
     };
+    let matches_count = region.as_ref().map_or_else(
+        || contents.matches(&old_normalized).count(),
+        |range| contents[range.clone()].matches(&old_normalized).count(),
+    );
 
     if matches_count == 0 {
         return Err(if let Some(offset) = args.offset {
@@ -143,7 +161,17 @@ pub(crate) async fn run_with_security_scope(
         ));
     }
 
-    let updated = contents.replacen(&old_normalized, &args.new_string, 1);
+    let updated = if let Some(range) = region {
+        let updated_region = contents[range.clone()].replacen(&old_normalized, &args.new_string, 1);
+        format!(
+            "{}{}{}",
+            &contents[..range.start],
+            updated_region,
+            &contents[range.end..]
+        )
+    } else {
+        contents.replacen(&old_normalized, &args.new_string, 1)
+    };
     match tokio::fs::write(&path, &updated).await {
         Ok(()) => {
             security.record_read_scoped(scope, &path, updated.as_bytes());

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -363,8 +363,8 @@ impl Selection {
 pub enum SelectionEnd {
     /// The press started outside the panel; nothing to do.
     Ignored,
-    /// Press and release on the same cell: treat as a click.
-    Click,
+    /// A click at the scroll-buffer position captured on mouse-down.
+    Click { column: u16, row: u16 },
     /// A drag selection finished; contains the selected text.
     Copied(String),
 }
@@ -650,20 +650,15 @@ impl ConversationPanel {
     /// Handles a left click at the given screen coordinates: if it lands on a
     /// foldable item (finished or live), toggle that item's expanded state.
     pub fn handle_click(&mut self, column: u16, row: u16) {
-        let area = self.view_area;
-        let inside = area.width > 0
-            && area.height > 0
-            && column >= area.x
-            && column < area.x + area.width
-            && row >= area.y
-            && row < area.y + area.height;
-        if !inside {
-            return;
+        if let Some((x_rel, buffer_y)) = self.to_buffer_pos(column, row, false) {
+            self.handle_buffer_click(x_rel, buffer_y);
         }
+    }
 
-        let buffer_y = (row - area.y).saturating_add(self.view_offset);
-        let x_rel = column - area.x;
-
+    /// Handles a click already mapped into scroll-buffer coordinates. Mouse
+    /// releases use the position captured on button-down so a render between
+    /// down and up cannot redirect the click to a different item.
+    pub fn handle_buffer_click(&mut self, x_rel: u16, buffer_y: u16) {
         // Live groups sit after finished content in the scroll buffer; check
         // their member hit regions before the flat live-item layout so a click
         // on the header row toggles the group and a click on a member row
@@ -852,19 +847,25 @@ impl ConversationPanel {
         // Streaming can change `view_offset` between Down and Up. Compare the
         // physical screen cell first so a stationary title click is not
         // mistaken for a buffer-coordinate drag after the layout moves.
-        if self
+        if let Some(sel) = self
             .selection
-            .is_some_and(|sel| !sel.dragging && sel.screen_anchor == (column, row))
+            .filter(|sel| !sel.dragging && sel.screen_anchor == (column, row))
         {
             self.selection = None;
-            return SelectionEnd::Click;
+            return SelectionEnd::Click {
+                column: sel.anchor.0,
+                row: sel.anchor.1,
+            };
         }
         self.selection_drag(column, row);
         match self.selection {
             None => SelectionEnd::Ignored,
             Some(sel) if !sel.dragging || sel.anchor == sel.head => {
                 self.selection = None;
-                SelectionEnd::Click
+                SelectionEnd::Click {
+                    column: sel.anchor.0,
+                    row: sel.anchor.1,
+                }
             }
             // Keep the selection so the highlight stays visible.
             Some(sel) => SelectionEnd::Copied(self.extract_selection_text(sel)),
@@ -1822,15 +1823,39 @@ mod tests {
     }
 
     #[test]
-    fn stationary_release_stays_a_click_when_streaming_moves_the_view() {
+    fn stationary_release_uses_mouse_down_position_when_streaming_moves_the_view() {
         let mut panel = ConversationPanel::new();
         panel.view_area = Rect::new(0, 0, 40, 10);
         panel.view_offset = 20;
+        panel.tool_group_layout.push(ToolGroupLayout {
+            key: "group".into(),
+            top: 23,
+            bottom: 30,
+            member_headers: vec![
+                MemberHeader {
+                    index: 7,
+                    top: 24,
+                    bottom: 25,
+                },
+                MemberHeader {
+                    index: 9,
+                    top: 28,
+                    bottom: 29,
+                },
+            ],
+            live_index_base: None,
+        });
 
         panel.selection_begin(3, 4);
         panel.view_offset = 24;
 
-        assert!(matches!(panel.selection_end(3, 4), SelectionEnd::Click));
+        let SelectionEnd::Click { column, row } = panel.selection_end(3, 4) else {
+            panic!("stationary release should remain a click");
+        };
+        assert_eq!((column, row), (3, 24));
+        panel.handle_buffer_click(column, row);
+        assert!(panel.expanded_items.contains(&7));
+        assert!(!panel.expanded_items.contains(&9));
     }
 
     #[test]


### PR DESCRIPTION
### Programmer v0.2.6

- Restrict `edit_file` replacements to the requested `offset`/`limit` line range.
- Keep grouped tool-item clicks anchored across streaming redraws.
- Add regression coverage for click targeting when the viewport moves.

### Verification

- 508 tests passed before the version-only bump.
- Interactive TUI verification completed with grouped and nested tool expansion.
- Clean CI is required before merge because the local post-bump relink ran out of disk space.