### PR TITLE
v0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.6"
+version = "0.2.7"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/PROGRAMMER.md
+++ b/PROGRAMMER.md
@@ -6,7 +6,7 @@
 connects to OpenAI-compatible APIs (Responses API), streams responses, and
 gives the model local tools including `command`, `read_file`, `write_file`,
 `edit_file`, `grep`, `blob`, `ask_user`, `configure_diagnostics`, `fetch`,
-`task`, `todo`, and `agent`,
+`task`, `todo`, `memory`, and `agent`,
 plus MCP-bridged external tools. The TUI is built with Ratatui and crossterm.
 The binary is a single crate at the repo root.
 
@@ -14,7 +14,8 @@ Key features beyond the chat loop:
 - **Multi-provider**: add/edit/delete/switch API backends at runtime.
 - **Multi-session**: UUID-keyed JSON persistence in `~/.config/programmer/sessions/`.
 - **Rewind checkpoints**: prompt-level conversation checkpoints plus content-addressed snapshots for built-in file edits.
-- **Context compaction**: manual and provider-usage-triggered background summaries with session overrides.
+- **Context compaction**: manual and provider-usage-triggered background summaries with session overrides and a parsed structured working-state snapshot.
+- **Persistent memory**: explicit-only bounded lexical recall over inspectable global/project JSON stores, with no automatic request injection, explicit memory management, and credential rejection.
 - **Auto-mode classifier**: per-mode LLM classifier that approves/denies/defers tool calls.
 - **MCP (Model Context Protocol)**: connect to external MCP servers (stdio + HTTP);
   their tools are advertised to the model as `mcp__<server>__<tool>`.
@@ -113,6 +114,9 @@ src/
 │   ├── runner.rs             #   Run checkers, collect diagnostics
 │   └── lsp.rs                #   LSP-based checker (spawn + query over stdio)
 │
+├── memory/                   # Layered persistent memory store, retrieval, and L1 session state
+│   └── mod.rs
+│
 ├── mcp/                      # Model Context Protocol integration
 │   ├── mod.rs                #   McpManager: connect, discover tools, route calls
 │   ├── types.rs              #   JSON-RPC types, McpTool, McpServerConfig, tool annotations
@@ -156,6 +160,7 @@ src/
 │   ├── fetch.rs              #   HTTP fetch (html2text conversion)
 │   ├── task.rs               #   Background task management (create/list/output/write/wait/kill)
 │   ├── agent.rs              #   Sub-agent spawn/list/result/wait/cancel lifecycle
+│   ├── memory.rs             #   Persistent memory remember/recall/list/update/forget tool
 │   ├── todo.rs               #   Todo list management (add/list/update/delete)
 │   └── mcp_bridge.rs         #   Internal: route MCP-prefixed calls to McpManager
 │

--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ auto_update_check = true
 # "" to disable. (GitHub organizations can't be commit co-authors.)
 git_coauthor = "programmer <noreply@programmer.local>"
 
+[memory]
+# Durable memory is local JSON outside the repository. It is recalled only
+# through the explicit memory tool or /memory command; requests are not
+# automatically modified with retrieved context.
+enabled = true
+global_enabled = true
+project_enabled = true
+max_global_results = 3
+max_project_results = 8
+
 [security]
 enabled = true
 protect_file_changes = true
@@ -230,6 +240,9 @@ api_key = "sk-your-key-here"
 | `compact_model` | (chat model) | `provider/model` used for manual and automatic context compaction. |
 | `auto_compact_tokens` | `100000` | Provider-reported input-token threshold for seamless background compaction. `0` disables it. Providers that do not report usage do not trigger it. |
 | `compact_keep_recent_turns` | `2` | Number of recent complete turns kept verbatim when context is compacted. |
+| `memory.enabled` | `true` | Advertise the persistent-memory tool. Memory is recalled explicitly and is never injected automatically. |
+| `memory.global_enabled` / `project_enabled` | `true` | Include cross-project preferences and current-project memories in explicit recall. |
+| `memory.max_global_results` / `max_project_results` | `3` / `8` | Per-scope explicit recall limits. |
 | `allow_yolo` | `false` | Whether `/mode yolo` and `Ctrl+T` can reach YOLO mode. |
 | `auto_update_check` | `true` | Check GitHub Releases at startup and show a non-blocking update notice. |
 | `git_coauthor` | `programmer <noreply@programmer.local>` | `Co-Authored-By:` trailer added to the agent's git commits. Use a GitHub-linked email for an avatar; `""` disables. |
@@ -428,6 +441,12 @@ programmer
 | `/select [on\|off]` | Toggle native terminal text selection and copying |
 | `/permission` `/sandbox` | Show sandbox, file protection, and permission status |
 | `/todo` `/t` | Open this session's todo list |
+| `/memory list [global\|project]` | List active persistent memories |
+| `/memory recall <query>` | Search relevant memories |
+| `/memory remember <global\|project> <kind> <content>` | Store an explicit stable preference, fact, or decision |
+| `/memory update <id> <content>` | Correct an existing memory |
+| `/memory forget <id>` | Permanently remove a memory |
+| `/memory <on\|off>` | Enable or disable memory for this run |
 | `/skill <name\|list\|off>` | Activate, list, or clear skills |
 | `/skill manage` | Open the skills management panel |
 | `/mcp show` | List MCP server status |
@@ -443,6 +462,12 @@ programmer
 | `/clear` `/c` | Delete the current session and reset its chat, todos, images, and diagnostics |
 | `/quit` `/q` | Exit the application |
 | `/help` `/?` | Show all commands |
+
+Memory files are versioned JSON under the platform config directory at
+`programmer/memory/global.json` and `programmer/memory/projects/<workspace-id>.json`.
+They are not written into the repository. Credential-like content is rejected.
+Stored entries are never injected into model requests automatically; the agent
+or user must explicitly call `memory recall` or `/memory recall`.
 
 ### Provider management panel
 
@@ -642,7 +667,7 @@ Terminal emulators generally reserve `Cmd+V` for text paste, so image paste uses
 
 | Flag / command | Action |
 |---|---|
-| `programmer --resume` | Interactive picker to choose a saved session |
+| `programmer --resume` | Interactive picker, filtered to the current working directory by default; press `f` to show all sessions |
 | `programmer --resume <uuid>` | Resume a specific session |
 | `/new` `/n` | Save current session and start fresh |
 | `/session` `/s` | Show current session UUID |

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -369,6 +369,7 @@ pub(crate) struct AgentRuntime {
     pub(crate) coauthor: Option<String>,
     pub(crate) vision_enabled: bool,
     pub(crate) thinking_level: crate::thinking::ThinkingLevel,
+    pub(crate) memory_config: crate::config::programmer_config::MemoryConfig,
     pub(crate) skill_registry: crate::skills::SkillRegistry,
     pub(crate) skill_prompt: Option<String>,
     pub(crate) approval_label: String,
@@ -415,7 +416,8 @@ impl AgentRuntime {
                     self.security.clone(),
                     file_scope,
                 )
-                .with_checkpoint(self.checkpoint.clone()),
+                .with_checkpoint(self.checkpoint.clone())
+                .with_memory_enabled(self.memory_config.enabled),
             ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -751,6 +751,60 @@ pub(super) fn open_terminal(app: &mut App<'_>, arg: &str) {
 // Slash-command dispatch
 // ---------------------------------------------------------------------------
 
+async fn memory_command(app: &mut App<'_>, argument: &str) -> command_handlers::CommandOutcome {
+    app.input_panel.clear();
+    let mut parts = argument.trim().splitn(4, char::is_whitespace);
+    let action = parts
+        .next()
+        .filter(|part| !part.is_empty())
+        .unwrap_or("list");
+
+    if matches!(action, "on" | "off") {
+        app.config.memory.enabled = action == "on";
+        app.conversation_panel
+            .add_info_string(format!("Persistent memory {} for this run.", action));
+        return command_handlers::CommandOutcome::handled(false);
+    }
+
+    let arguments = match action {
+        "list" => serde_json::json!({
+            "action": "list",
+            "scope": parts.next().filter(|part| !part.is_empty()),
+        }),
+        "recall" => serde_json::json!({
+            "action": "recall",
+            "query": parts.collect::<Vec<_>>().join(" "),
+        }),
+        "remember" => serde_json::json!({
+            "action": "remember",
+            "scope": parts.next(),
+            "kind": parts.next(),
+            "content": parts.next(),
+        }),
+        "update" => serde_json::json!({
+            "action": "update",
+            "id": parts.next(),
+            "content": parts.next(),
+        }),
+        "forget" => serde_json::json!({
+            "action": "forget",
+            "id": parts.next(),
+        }),
+        _ => {
+            app.conversation_panel.add_warning_string(
+                "usage: /memory [list [global|project] | recall <query> | remember <global|project> <kind> <content> | update <id> <content> | forget <id> | on | off]",
+            );
+            return command_handlers::CommandOutcome::handled(false);
+        }
+    };
+
+    match crate::tools::memory::run(&arguments.to_string()).await {
+        Ok(output) => app.conversation_panel.add_info_string(output),
+        Err(error) => app.conversation_panel.add_warning_string(error),
+    }
+    command_handlers::CommandOutcome::handled(false)
+}
+
 /// Parse and execute a slash command. If the command is unknown, fall back
 /// to sending it to the AI model.
 pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
@@ -782,6 +836,7 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
         | Command::Skill(_)
         | Command::Mcp(_)
         | Command::Diagnostics(_)) => command_handlers::integrations::execute(app, command),
+        Command::Memory(arg) => memory_command(app, &arg).await,
         command @ (Command::Init | Command::Compact(_) | Command::Plan(_)) => {
             command_handlers::workflow::execute(app, command).await
         }
@@ -862,6 +917,11 @@ mod tests {
             ),
             ("init", "/init", ExpectedCommandEffect::AppendedMessage),
             ("todo", "/todo", ExpectedCommandEffect::TodoPanel),
+            (
+                "memory",
+                "/memory off",
+                ExpectedCommandEffect::AppendedMessage,
+            ),
             ("skill", "/skill manage", ExpectedCommandEffect::SkillsPanel),
             ("mcp", "/mcp manage", ExpectedCommandEffect::McpPanel),
             (

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -650,7 +650,8 @@ impl App<'_> {
         let mut base_providers: Vec<Arc<dyn ToolProvider>> = vec![
             Arc::new(
                 LocalToolProvider::new(self.todo_store.clone(), self.security.clone())
-                    .with_checkpoint(self.checkpoint_recorder()),
+                    .with_checkpoint(self.checkpoint_recorder())
+                    .with_memory_enabled(self.config.memory.enabled),
             ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];
@@ -696,6 +697,7 @@ impl App<'_> {
             coauthor: self.config.git_coauthor.clone(),
             vision_enabled: self.vision_enabled,
             thinking_level: self.thinking_level,
+            memory_config: self.config.memory.clone(),
             skill_registry: self.skill_registry.clone(),
             skill_prompt: self.skill_registry.catalog_prompt(),
             approval_label: format!(

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -86,6 +86,10 @@ fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
     {
         session.first_message = crate::session::truncate_first_line(&text, 80);
     }
+    session.session_memory = items.iter().rev().find_map(|item| match item {
+        MessageItem::Compacted { summary } => crate::memory::SessionMemory::from_summary(summary),
+        _ => None,
+    });
     SessionManager::set_items(&mut session, items);
     session.history = app.input_panel.history.clone();
     session.work_mode = Some(app.work_mode);

--- a/src/classifier/mod.rs
+++ b/src/classifier/mod.rs
@@ -74,6 +74,9 @@ fn is_mutating(tool_name: &str, arguments: &str) -> bool {
     if tool_name == crate::tools::task::NAME {
         return crate::tools::task::action_is_mutating(arguments);
     }
+    if tool_name == crate::tools::memory::NAME {
+        return crate::tools::memory::action_is_mutating(arguments);
+    }
     DANGEROUS_TOOLS.contains(&tool_name)
 }
 
@@ -323,6 +326,9 @@ mod tests {
         assert!(!needs_review("read_file", "{}"));
         assert!(!needs_review("grep", "{}"));
         assert!(!needs_review("todo", "{}"));
+        assert!(!needs_review("memory", r#"{"action":"recall"}"#));
+        assert!(needs_review("memory", r#"{"action":"remember"}"#));
+        assert!(needs_review("memory", r#"{"action":"forget"}"#));
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,6 +46,8 @@ pub enum Command {
     Usage,
     Rewind,
     Todo,
+    /// `/memory` — inspect or manage persistent global/project memories.
+    Memory(String),
     /// `/skill <name|list|off>` — activate, list, or clear skills.
     Skill(String),
     /// `/mcp <show|manage>` — list or manage MCP servers.
@@ -87,6 +89,7 @@ enum CommandKind {
     Usage,
     Rewind,
     Todo,
+    Memory,
     Skill,
     Mcp,
     Diagnostics,
@@ -162,6 +165,7 @@ impl CommandKind {
             Self::Usage => Command::Usage,
             Self::Rewind => Command::Rewind,
             Self::Todo => Command::Todo,
+            Self::Memory => Command::Memory(args),
             Self::Skill => Command::Skill(args),
             Self::Mcp => Command::Mcp(args),
             Self::Diagnostics => Command::Diagnostics(args),
@@ -303,6 +307,19 @@ const COMMAND_SPECS: &[CommandSpec] = &[
             order: 21,
             usage: "/todo | /t",
             description: "Open the todo list panel",
+        }],
+    },
+    CommandSpec {
+        kind: CommandKind::Memory,
+        name: "memory",
+        aliases: &[],
+        completion: CompletionKind::Fixed(&[
+            "list", "recall", "remember", "update", "forget", "on", "off",
+        ]),
+        help: &[HelpEntry {
+            order: 32,
+            usage: "/memory <list|recall|remember|update|forget|on|off>",
+            description: "Inspect or manage persistent memory",
         }],
     },
     CommandSpec {
@@ -1648,6 +1665,7 @@ mod tests {
             "classifier",
             "init",
             "todo",
+            "memory",
             "skill",
             "mcp",
             "diagnostics",
@@ -1779,6 +1797,10 @@ mod tests {
             ),
             ("/quit | /q", "Exit the application"),
             ("/help | /?", "Show this help"),
+            (
+                "/memory <list|recall|remember|update|forget|on|off>",
+                "Inspect or manage persistent memory",
+            ),
         ];
         assert_eq!(Command::descriptions(), expected);
     }

--- a/src/config/programmer_config.rs
+++ b/src/config/programmer_config.rs
@@ -34,6 +34,33 @@ pub(crate) fn validate_security_profile_name(name: &str) -> Result<(), String> {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
+pub struct MemoryConfig {
+    /// Enable the persistent memory tool.
+    pub enabled: bool,
+    /// Include cross-project user preferences in explicit recall results.
+    pub global_enabled: bool,
+    /// Include current-project memories in explicit recall results.
+    pub project_enabled: bool,
+    /// Maximum number of global memories returned by one recall.
+    pub max_global_results: usize,
+    /// Maximum number of project memories returned by one recall.
+    pub max_project_results: usize,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            global_enabled: true,
+            project_enabled: true,
+            max_global_results: 3,
+            max_project_results: 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct ProgrammerConfig {
     /// The provider to use when none is specified in the model string.
     pub default_provider: String,
@@ -62,6 +89,9 @@ pub struct ProgrammerConfig {
     /// Number of complete recent turns kept verbatim after a compaction.
     #[serde(default = "default_compact_keep_recent_turns")]
     pub compact_keep_recent_turns: usize,
+    /// Layered persistent-memory settings.
+    #[serde(default)]
+    pub memory: MemoryConfig,
     /// YOLO mode (run every tool call unchecked) is gated behind this flag so
     /// it can't be reached by the normal Ctrl+T cycle or a bare `/mode yolo`.
     #[serde(default)]
@@ -182,6 +212,7 @@ impl Default for ProgrammerConfig {
             compact_model: None,
             auto_compact_tokens: default_auto_compact_tokens(),
             compact_keep_recent_turns: default_compact_keep_recent_turns(),
+            memory: MemoryConfig::default(),
             allow_yolo: false,
             security,
             // Kept empty until normalization so deserialization can distinguish

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -178,7 +178,10 @@ impl HeadlessAgent {
                 color_eyre::eyre::eyre!("built-in initialize-project skill is unavailable")
             })?;
         let mut base_providers: Vec<Arc<dyn ToolProvider>> = vec![
-            Arc::new(LocalToolProvider::new(todo_store.clone(), security.clone())),
+            Arc::new(
+                LocalToolProvider::new(todo_store.clone(), security.clone())
+                    .with_memory_enabled(config.memory.enabled),
+            ),
             Arc::new(SkillToolProvider::new(skill_registry.clone())),
         ];
 
@@ -238,6 +241,7 @@ impl HeadlessAgent {
             coauthor: config.git_coauthor.clone(),
             vision_enabled: false,
             thinking_level: args.thinking,
+            memory_config: config.memory.clone(),
             skill_registry,
             skill_prompt: skill_prompt.clone(),
             approval_label: format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod conversation;
 mod diagnostics;
 mod headless;
 mod mcp;
+mod memory;
 mod prompts;
 mod providers;
 mod response;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,0 +1,704 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Local, inspectable long-term memory shared across sessions.
+//!
+//! Memories are split into a user-global file and a project file keyed by the
+//! canonical repository root. Storage is deliberately plain versioned JSON:
+//! the expected data set is small, atomic writes match session persistence, and
+//! users can inspect or remove everything without a database-specific tool.
+
+use crate::config::programmer_config::MemoryConfig;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Structured L1 working state persisted alongside a compacted conversation.
+/// The original summary remains the fallback when an older or model-produced
+/// summary cannot be parsed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SessionMemory {
+    pub(crate) schema_version: u32,
+    pub(crate) intent: String,
+    pub(crate) state: String,
+    pub(crate) in_flight: String,
+    pub(crate) next: String,
+}
+
+impl SessionMemory {
+    pub(crate) fn from_summary(summary: &str) -> Option<Self> {
+        let mut sections = [String::new(), String::new(), String::new(), String::new()];
+        let mut current = None;
+        for line in summary.lines() {
+            let heading = line
+                .trim()
+                .trim_start_matches('#')
+                .trim()
+                .trim_start_matches(|character: char| {
+                    character.is_ascii_digit() || character == '.'
+                })
+                .trim()
+                .trim_matches('*')
+                .trim_end_matches(':')
+                .trim()
+                .to_ascii_uppercase();
+            let section = match heading.as_str() {
+                "INTENT" => Some(0),
+                "STATE" => Some(1),
+                "IN FLIGHT" | "IN_FLIGHT" => Some(2),
+                "NEXT" => Some(3),
+                _ => None,
+            };
+            if let Some(index) = section {
+                current = Some(index);
+                continue;
+            }
+            if let Some(index) = current {
+                if !sections[index].is_empty() {
+                    sections[index].push('\n');
+                }
+                sections[index].push_str(line);
+            }
+        }
+        if sections.iter().all(|section| section.trim().is_empty()) {
+            return None;
+        }
+        Some(Self {
+            schema_version: SCHEMA_VERSION,
+            intent: sections[0].trim().to_string(),
+            state: sections[1].trim().to_string(),
+            in_flight: sections[2].trim().to_string(),
+            next: sections[3].trim().to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryScope {
+    Global,
+    Project,
+}
+
+impl MemoryScope {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "global" | "user" => Some(Self::Global),
+            "project" | "workspace" => Some(Self::Project),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Project => "project",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryKind {
+    Preference,
+    ProjectFact,
+    Decision,
+    Convention,
+    Workflow,
+    Constraint,
+    KnownIssue,
+}
+
+impl MemoryKind {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+            "preference" => Some(Self::Preference),
+            "project_fact" | "fact" => Some(Self::ProjectFact),
+            "decision" => Some(Self::Decision),
+            "convention" => Some(Self::Convention),
+            "workflow" => Some(Self::Workflow),
+            "constraint" => Some(Self::Constraint),
+            "known_issue" | "issue" => Some(Self::KnownIssue),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Preference => "preference",
+            Self::ProjectFact => "project_fact",
+            Self::Decision => "decision",
+            Self::Convention => "convention",
+            Self::Workflow => "workflow",
+            Self::Constraint => "constraint",
+            Self::KnownIssue => "known_issue",
+        }
+    }
+
+    fn priority(self) -> f32 {
+        match self {
+            Self::Constraint | Self::Preference => 2.0,
+            Self::Decision | Self::Convention => 1.5,
+            Self::KnownIssue | Self::Workflow => 1.0,
+            Self::ProjectFact => 0.5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemorySource {
+    ExplicitUser,
+    AgentTool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryConfidence {
+    Explicit,
+    Confirmed,
+    Inferred,
+}
+
+impl MemoryConfidence {
+    fn score(self) -> f32 {
+        match self {
+            Self::Explicit => 1.0,
+            Self::Confirmed => 0.7,
+            Self::Inferred => 0.2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MemoryStatus {
+    #[default]
+    Active,
+    Superseded,
+    Archived,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MemoryEntry {
+    pub(crate) id: String,
+    pub(crate) scope: MemoryScope,
+    pub(crate) kind: MemoryKind,
+    pub(crate) content: String,
+    #[serde(default)]
+    pub(crate) tags: Vec<String>,
+    pub(crate) created_at: u64,
+    pub(crate) updated_at: u64,
+    #[serde(default)]
+    pub(crate) last_used_at: Option<u64>,
+    #[serde(default)]
+    pub(crate) use_count: u32,
+    pub(crate) source: MemorySource,
+    pub(crate) confidence: MemoryConfidence,
+    #[serde(default)]
+    pub(crate) status: MemoryStatus,
+    #[serde(default)]
+    pub(crate) supersedes: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MemoryFile {
+    schema_version: u32,
+    #[serde(default)]
+    workspace_path: Option<String>,
+    #[serde(default)]
+    entries: Vec<MemoryEntry>,
+}
+
+impl MemoryFile {
+    fn empty(workspace_path: Option<String>) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            workspace_path,
+            entries: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MemoryManager {
+    global_path: PathBuf,
+    project_path: PathBuf,
+    workspace_root: PathBuf,
+}
+
+impl MemoryManager {
+    pub(crate) fn for_current_dir() -> Result<Self, String> {
+        let cwd = std::env::current_dir().map_err(|error| format!("current directory: {error}"))?;
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| "cannot locate the platform config directory".to_string())?;
+        Ok(Self::new(config_dir.join("programmer"), cwd))
+    }
+
+    fn new(config_root: PathBuf, working_dir: PathBuf) -> Self {
+        let workspace_root = workspace_root(&working_dir);
+        let identity = workspace_root.to_string_lossy().replace('\\', "/");
+        let workspace_id = blake3::hash(identity.as_bytes()).to_hex().to_string();
+        let memory_dir = config_root.join("memory");
+        Self {
+            global_path: memory_dir.join("global.json"),
+            project_path: memory_dir
+                .join("projects")
+                .join(format!("{workspace_id}.json")),
+            workspace_root,
+        }
+    }
+
+    pub(crate) fn list(&self, scope: Option<MemoryScope>) -> Result<Vec<MemoryEntry>, String> {
+        let mut entries = Vec::new();
+        if scope.is_none() || scope == Some(MemoryScope::Global) {
+            entries.extend(self.load(MemoryScope::Global)?.entries);
+        }
+        if scope.is_none() || scope == Some(MemoryScope::Project) {
+            entries.extend(self.load(MemoryScope::Project)?.entries);
+        }
+        entries.retain(|entry| entry.status == MemoryStatus::Active);
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.updated_at));
+        Ok(entries)
+    }
+
+    pub(crate) fn remember(
+        &self,
+        scope: MemoryScope,
+        kind: MemoryKind,
+        content: String,
+        tags: Vec<String>,
+    ) -> Result<MemoryEntry, String> {
+        validate_content(&content)?;
+        let content = content.trim().to_string();
+        let mut file = self.load(scope)?;
+        if let Some(existing) = file.entries.iter().find(|entry| {
+            entry.status == MemoryStatus::Active
+                && entry.kind == kind
+                && entry.content.eq_ignore_ascii_case(&content)
+        }) {
+            return Ok(existing.clone());
+        }
+        let now = now_secs();
+        let entry = MemoryEntry {
+            id: format!("mem_{}", uuid::Uuid::new_v4().simple()),
+            scope,
+            kind,
+            content,
+            tags: normalize_tags(tags),
+            created_at: now,
+            updated_at: now,
+            last_used_at: None,
+            use_count: 0,
+            source: MemorySource::AgentTool,
+            confidence: MemoryConfidence::Explicit,
+            status: MemoryStatus::Active,
+            supersedes: None,
+        };
+        file.entries.push(entry.clone());
+        self.save(scope, &file)?;
+        Ok(entry)
+    }
+
+    pub(crate) fn update(
+        &self,
+        id: &str,
+        content: Option<String>,
+        kind: Option<MemoryKind>,
+        tags: Option<Vec<String>>,
+    ) -> Result<MemoryEntry, String> {
+        for scope in [MemoryScope::Global, MemoryScope::Project] {
+            let mut file = self.load(scope)?;
+            if let Some(entry) = file
+                .entries
+                .iter_mut()
+                .find(|entry| entry.id == id && entry.status == MemoryStatus::Active)
+            {
+                if let Some(content) = content {
+                    validate_content(&content)?;
+                    entry.content = content.trim().to_string();
+                }
+                if let Some(kind) = kind {
+                    entry.kind = kind;
+                }
+                if let Some(tags) = tags {
+                    entry.tags = normalize_tags(tags);
+                }
+                entry.updated_at = now_secs();
+                let updated = entry.clone();
+                self.save(scope, &file)?;
+                return Ok(updated);
+            }
+        }
+        Err(format!("memory '{id}' was not found"))
+    }
+
+    pub(crate) fn forget(&self, id: &str) -> Result<(), String> {
+        for scope in [MemoryScope::Global, MemoryScope::Project] {
+            let mut file = self.load(scope)?;
+            let original_len = file.entries.len();
+            file.entries.retain(|entry| entry.id != id);
+            if file.entries.len() != original_len {
+                self.save(scope, &file)?;
+                return Ok(());
+            }
+        }
+        Err(format!("memory '{id}' was not found"))
+    }
+
+    pub(crate) fn retrieve(
+        &self,
+        query: &str,
+        config: &MemoryConfig,
+    ) -> Result<Vec<MemoryEntry>, String> {
+        if !config.enabled || query.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let query_tokens = tokens(query);
+        if query_tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut scored = Vec::new();
+        for (scope, limit) in [
+            (MemoryScope::Global, config.max_global_results),
+            (MemoryScope::Project, config.max_project_results),
+        ] {
+            let scope_enabled = match scope {
+                MemoryScope::Global => config.global_enabled,
+                MemoryScope::Project => config.project_enabled,
+            };
+            if !scope_enabled || limit == 0 {
+                continue;
+            }
+            let mut scope_entries = self
+                .load(scope)?
+                .entries
+                .into_iter()
+                .filter(|entry| entry.status == MemoryStatus::Active)
+                .filter_map(|entry| {
+                    let score = relevance(&entry, &query_tokens);
+                    (score > 0.0).then_some((score, entry))
+                })
+                .collect::<Vec<_>>();
+            scope_entries
+                .sort_by(|left, right| right.0.partial_cmp(&left.0).unwrap_or(Ordering::Equal));
+            scored.extend(scope_entries.into_iter().take(limit));
+        }
+        scored.sort_by(|left, right| right.0.partial_cmp(&left.0).unwrap_or(Ordering::Equal));
+        Ok(scored.into_iter().map(|(_, entry)| entry).collect())
+    }
+
+    pub(crate) fn render_list(entries: &[MemoryEntry]) -> String {
+        if entries.is_empty() {
+            return "No active memories.".to_string();
+        }
+        entries
+            .iter()
+            .map(|entry| {
+                format!(
+                    "{}  {:7}  {:12}  {}",
+                    entry.id,
+                    entry.scope.label(),
+                    entry.kind.label(),
+                    entry.content
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn path(&self, scope: MemoryScope) -> &Path {
+        match scope {
+            MemoryScope::Global => &self.global_path,
+            MemoryScope::Project => &self.project_path,
+        }
+    }
+
+    fn load(&self, scope: MemoryScope) -> Result<MemoryFile, String> {
+        let path = self.path(scope);
+        if !path.exists() {
+            return Ok(MemoryFile::empty(self.workspace_path(scope)));
+        }
+        let bytes =
+            std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+        let file: MemoryFile = serde_json::from_slice(&bytes)
+            .map_err(|error| format!("parse {}: {error}", path.display()))?;
+        if file.schema_version > SCHEMA_VERSION {
+            return Err(format!(
+                "memory schema {} is newer than supported schema {SCHEMA_VERSION}",
+                file.schema_version
+            ));
+        }
+        Ok(file)
+    }
+
+    fn save(&self, scope: MemoryScope, file: &MemoryFile) -> Result<(), String> {
+        let path = self.path(scope);
+        let parent = path
+            .parent()
+            .ok_or_else(|| format!("memory path has no parent: {}", path.display()))?;
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("create {}: {error}", parent.display()))?;
+        let json = serde_json::to_string_pretty(file)
+            .map_err(|error| format!("serialize memory: {error}"))?;
+        let temporary = path.with_extension("tmp");
+        std::fs::write(&temporary, json)
+            .map_err(|error| format!("write {}: {error}", temporary.display()))?;
+        std::fs::rename(&temporary, path)
+            .map_err(|error| format!("rename to {}: {error}", path.display()))
+    }
+
+    fn workspace_path(&self, scope: MemoryScope) -> Option<String> {
+        (scope == MemoryScope::Project).then(|| self.workspace_root.display().to_string())
+    }
+}
+
+fn workspace_root(working_dir: &Path) -> PathBuf {
+    let canonical = working_dir
+        .canonicalize()
+        .unwrap_or_else(|_| working_dir.to_path_buf());
+    canonical
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())
+        .unwrap_or(&canonical)
+        .to_path_buf()
+}
+
+fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    tags.into_iter()
+        .map(|tag| tag.trim().to_ascii_lowercase())
+        .filter(|tag| !tag.is_empty() && seen.insert(tag.clone()))
+        .take(16)
+        .collect()
+}
+
+fn validate_content(content: &str) -> Result<(), String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err("memory content must not be empty".to_string());
+    }
+    if trimmed.chars().count() > 2_000 {
+        return Err("memory content exceeds the 2000 character limit".to_string());
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    let sensitive_markers = [
+        "-----begin private key-----",
+        "-----begin rsa private key-----",
+        "authorization: bearer ",
+        "api_key=",
+        "api-key=",
+        "password=",
+        "secret_access_key",
+    ];
+    if sensitive_markers
+        .iter()
+        .any(|marker| lower.contains(marker))
+        || lower.split_whitespace().any(looks_like_secret_token)
+    {
+        return Err("memory content appears to contain a credential or secret".to_string());
+    }
+    Ok(())
+}
+
+fn looks_like_secret_token(token: &str) -> bool {
+    let token = token.trim_matches(|character: char| {
+        !character.is_ascii_alphanumeric() && character != '-' && character != '_'
+    });
+    (token.starts_with("sk-") && token.len() >= 20)
+        || (token.starts_with("ghp_") && token.len() >= 20)
+        || (token.starts_with("github_pat_") && token.len() >= 20)
+}
+
+fn tokens(text: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    for word in text.split(|character: char| {
+        !character.is_alphanumeric()
+            && character != '_'
+            && character != '-'
+            && character != '/'
+            && character != '.'
+    }) {
+        let word = word.trim().to_ascii_lowercase();
+        let characters = word.chars().collect::<Vec<_>>();
+        if characters.len() >= 2 {
+            tokens.insert(word);
+        }
+        if characters.iter().any(|character| !character.is_ascii()) {
+            tokens.extend(
+                characters
+                    .windows(2)
+                    .map(|pair| pair.iter().collect::<String>()),
+            );
+        }
+    }
+    tokens
+}
+
+fn relevance(entry: &MemoryEntry, query_tokens: &HashSet<String>) -> f32 {
+    let content_tokens = tokens(&entry.content);
+    let tag_tokens = entry
+        .tags
+        .iter()
+        .flat_map(|tag| tokens(tag))
+        .collect::<HashSet<_>>();
+    let content_overlap = query_tokens.intersection(&content_tokens).count() as f32;
+    let tag_overlap = query_tokens.intersection(&tag_tokens).count() as f32;
+    if content_overlap == 0.0 && tag_overlap == 0.0 {
+        return 0.0;
+    }
+    content_overlap * 2.0 + tag_overlap * 4.0 + entry.kind.priority() + entry.confidence.score()
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager() -> MemoryManager {
+        let root =
+            std::env::temp_dir().join(format!("programmer-memory-test-{}", uuid::Uuid::new_v4()));
+        MemoryManager::new(root.join("config"), root.join("workspace"))
+    }
+
+    #[test]
+    fn structured_session_memory_parses_compaction_headings() {
+        let memory = SessionMemory::from_summary(
+            "## INTENT\nAdd memory\n## STATE\nStore exists\n## IN FLIGHT\nTesting\n## NEXT\nRun tests",
+        )
+        .unwrap();
+
+        assert_eq!(memory.intent, "Add memory");
+        assert_eq!(memory.state, "Store exists");
+        assert_eq!(memory.in_flight, "Testing");
+        assert_eq!(memory.next, "Run tests");
+    }
+
+    #[test]
+    fn project_and_global_memories_are_isolated() {
+        let manager = manager();
+        manager
+            .remember(
+                MemoryScope::Project,
+                MemoryKind::Decision,
+                "Use JSON storage".into(),
+                vec![],
+            )
+            .unwrap();
+        manager
+            .remember(
+                MemoryScope::Global,
+                MemoryKind::Preference,
+                "Answer concisely".into(),
+                vec![],
+            )
+            .unwrap();
+
+        assert_eq!(manager.list(Some(MemoryScope::Project)).unwrap().len(), 1);
+        assert_eq!(manager.list(Some(MemoryScope::Global)).unwrap().len(), 1);
+        assert_eq!(manager.list(None).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn retrieval_ranks_matching_memory_and_obeys_scope_limits() {
+        let manager = manager();
+        manager
+            .remember(
+                MemoryScope::Project,
+                MemoryKind::Decision,
+                "Store sessions as JSON".into(),
+                vec!["session".into()],
+            )
+            .unwrap();
+        manager
+            .remember(
+                MemoryScope::Project,
+                MemoryKind::Workflow,
+                "Run cargo test".into(),
+                vec!["test".into()],
+            )
+            .unwrap();
+        let config = MemoryConfig {
+            max_project_results: 1,
+            global_enabled: false,
+            ..Default::default()
+        };
+
+        let entries = manager.retrieve("session JSON format", &config).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].content.contains("JSON"));
+        assert!(
+            manager
+                .retrieve("unrelated banana", &config)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn retrieval_supports_cjk_bigrams() {
+        let manager = manager();
+        manager
+            .remember(
+                MemoryScope::Project,
+                MemoryKind::Convention,
+                "测试前先运行格式化检查".into(),
+                vec![],
+            )
+            .unwrap();
+
+        let entries = manager
+            .retrieve("请运行格式化", &MemoryConfig::default())
+            .unwrap();
+
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn update_and_forget_are_persisted() {
+        let manager = manager();
+        let entry = manager
+            .remember(
+                MemoryScope::Project,
+                MemoryKind::ProjectFact,
+                "Old fact".into(),
+                vec![],
+            )
+            .unwrap();
+        manager
+            .update(&entry.id, Some("New fact".into()), None, None)
+            .unwrap();
+        assert_eq!(manager.list(None).unwrap()[0].content, "New fact");
+        manager.forget(&entry.id).unwrap();
+        assert!(manager.list(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn credentials_are_rejected() {
+        assert!(validate_content("api_key=super-secret-value").is_err());
+        assert!(validate_content("sk-abcdefghijklmnopqrstuvwxyz").is_err());
+        assert!(validate_content("Prefer cargo check before tests").is_ok());
+    }
+}

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -79,6 +79,22 @@ responses rendered in a terminal UI, so keep output compact.
   filtered searches over dumping whole files or verbose command output.
 - Never fabricate tool output, file contents, or command results.
 
+# Persistent memory
+
+- When the user explicitly asks to remember something, or explicitly states a
+  stable preference, confirmed decision, reusable constraint, or verified fact,
+  use the `memory` tool when it is available. Do not merely claim it was saved.
+- Before writing, check relevant existing memories. Update an existing entry
+  when it represents the same fact instead of creating a duplicate.
+- Keep each entry atomic and independently updateable. If the material combines
+  unrelated subjects, scopes, or lifecycles, make multiple `remember` calls.
+- Choose the narrowest valid scope. Use `global` only for information reusable
+  across unrelated repositories, such as user preferences or stable machine and
+  access-environment facts. Use `project` for repository-specific paths,
+  services, architecture, deployment procedures, and conventions.
+- Never store credentials, secrets, transient task progress, or unverified
+  inferences. Do not report success until every required memory call succeeds.
+
 # Editing rules
 
 - Preserve surrounding code exactly; do not drop comments or unrelated lines.
@@ -216,7 +232,11 @@ conversation:
 3. IN FLIGHT — the task being worked on right now and its exact status.
 4. NEXT — concrete pending steps or open questions, if any.
 
-Do not invent details. Do not call tools. Output only the summary text.";
+Use exactly these four headings, each on its own line: `## INTENT`, `## STATE`, \
+`## IN FLIGHT`, and `## NEXT`. This format is parsed into the session's \
+structured short-term memory; if parsing fails, the text is still retained as \
+a backward-compatible summary. Do not invent details. Do not call tools. \
+Output only the summary text.";
 
 // ---------------------------------------------------------------------------
 // Post-edit reminders

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -331,6 +331,7 @@ mod tests {
             compact_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
+            memory: Default::default(),
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -236,7 +236,6 @@ impl TurnRunner {
         surface: &dyn AgentSurface,
     ) -> Result<TurnResult, RunnerError> {
         let retrying = &self.stream_retrying;
-
         let mut steps = 0usize;
         loop {
             if cancel.is_cancelled() {

--- a/src/runner/request.rs
+++ b/src/runner/request.rs
@@ -45,15 +45,16 @@ pub(crate) fn build_request(
     model_name: String,
     tools: Vec<Tool>,
 ) -> CreateResponse {
+    let input = conversation.to_input_param_with_vision(
+        ctx.current_model,
+        ctx.skill_prompt,
+        ctx.plan_prompt,
+        ctx.coauthor,
+        ctx.vision_enabled,
+    );
     CreateResponse {
         stream: Some(true),
-        input: conversation.to_input_param_with_vision(
-            ctx.current_model,
-            ctx.skill_prompt,
-            ctx.plan_prompt,
-            ctx.coauthor,
-            ctx.vision_enabled,
-        ),
+        input,
         model: Some(model_name),
         tools: Some(tools),
         reasoning: ctx.thinking_level.reasoning(),
@@ -124,7 +125,7 @@ mod tests {
             dev_text.contains("Ada <ada@example.com>"),
             "coauthor trailer"
         );
-        // The user message follows.
+        // The user message follows the stable developer context directly.
         assert!(matches!(
             &items[1],
             InputItem::Item(Item::Message(ApiMessageItem::Input(m)))

--- a/src/runner/stream.rs
+++ b/src/runner/stream.rs
@@ -58,6 +58,13 @@ pub(crate) fn backoff_delay(attempt: u32) -> std::time::Duration {
     std::time::Duration::from_secs(base) + std::time::Duration::from_millis(jitter_ms)
 }
 
+async fn next_or_cancel<S>(stream: &mut S, cancel: &CancellationToken) -> Option<Option<S::Item>>
+where
+    S: futures::Stream + Unpin,
+{
+    cancel.wait_or(stream.next()).await
+}
+
 /// Open `request` as a streaming response and pump every event into `sink`.
 ///
 /// Retries the initial connection on transient failures (up to
@@ -77,7 +84,14 @@ pub(crate) async fn stream_with_retries(
     retrying.store(false, Ordering::Relaxed);
     let mut attempt: u32 = 0;
     let stream = loop {
-        match client.responses().create_stream(request.clone()).await {
+        let Some(opened) = cancel
+            .wait_or(client.responses().create_stream(request.clone()))
+            .await
+        else {
+            retrying.store(false, Ordering::Relaxed);
+            return;
+        };
+        match opened {
             Ok(stream) => break Ok(stream),
             Err(e) if is_retryable(&e) && attempt < crate::consts::MAX_STREAM_RETRIES => {
                 if cancel.is_cancelled() {
@@ -103,14 +117,15 @@ pub(crate) async fn stream_with_retries(
     };
     retrying.store(false, Ordering::Relaxed);
     match stream {
-        Ok(mut response_stream) => {
-            while let Some(response_stream_event) = response_stream.next().await {
-                if cancel.is_cancelled() {
-                    return;
-                }
-                sink(response_stream_event);
-            }
-        }
+        Ok(mut response_stream) => loop {
+            let Some(next_event) = next_or_cancel(&mut response_stream, cancel).await else {
+                return;
+            };
+            let Some(response_stream_event) = next_event else {
+                break;
+            };
+            sink(response_stream_event);
+        },
         Err(openai_error) => {
             if !cancel.is_cancelled() {
                 sink(Err(openai_error));
@@ -122,6 +137,23 @@ pub(crate) async fn stream_with_retries(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn waiting_for_a_stalled_stream_is_cancelled_promptly() {
+        let cancel = CancellationToken::new();
+        let child = cancel.clone();
+        let mut stream = futures::stream::pending::<Result<ResponseStreamEvent, OpenAIError>>();
+        let waiting = tokio::spawn(async move { next_or_cancel(&mut stream, &child).await });
+
+        tokio::task::yield_now().await;
+        cancel.cancel();
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(100), waiting)
+            .await
+            .expect("stalled stream cancellation timed out")
+            .expect("stream task panicked");
+        assert!(result.is_none());
+    }
 
     #[test]
     fn backoff_grows_exponentially_and_caps() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -24,7 +24,7 @@ use async_openai::types::responses::{
     FunctionCallOutput, FunctionCallOutputItemParam, InputItem, Item, OutputItem,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -185,6 +185,10 @@ pub(crate) struct Session {
     /// Number of messages (derived from items).
     pub(crate) message_count: usize,
     pub(crate) items: Vec<SerializableMessageItem>,
+    /// Parsed structure from the newest compact boundary. Older sessions and
+    /// unparsable summaries leave this empty and continue using summary text.
+    #[serde(default)]
+    pub(crate) session_memory: Option<crate::memory::SessionMemory>,
     /// Input history (most recent last).
     #[serde(default)]
     pub(crate) history: Vec<String>,
@@ -280,6 +284,7 @@ impl SessionManager {
             working_dir,
             message_count: 0,
             items: Vec::new(),
+            session_memory: None,
             history: Vec::new(),
             work_mode: None,
             current_model: None,
@@ -360,6 +365,23 @@ impl SessionManager {
 // Interactive session picker (TUI)
 // ---------------------------------------------------------------------------
 
+fn sessions_for_working_dir(sessions: &[SessionMeta], working_dir: &Path) -> Vec<SessionMeta> {
+    let working_dir = working_dir
+        .canonicalize()
+        .unwrap_or_else(|_| working_dir.to_path_buf());
+    sessions
+        .iter()
+        .filter(|session| {
+            let session_dir = Path::new(&session.working_dir);
+            session_dir
+                .canonicalize()
+                .unwrap_or_else(|_| session_dir.to_path_buf())
+                == working_dir
+        })
+        .cloned()
+        .collect()
+}
+
 /// Show a ratatui TUI list of sessions and let the user pick one with arrow keys.
 /// Runs its own terminal setup/teardown; the main app will re-init the terminal.
 /// Returns the chosen UUID, or `None` if the user chose "new session".
@@ -398,7 +420,10 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend).expect("terminal init");
 
-        let mut sessions = sessions.to_vec();
+        let mut all_sessions = sessions.to_vec();
+        let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let mut filter_working_dir = true;
+        let mut sessions = sessions_for_working_dir(&all_sessions, &working_dir);
         let mut list_state = ListState::default();
         if !sessions.is_empty() {
             list_state.select(Some(0));
@@ -419,18 +444,43 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
                     ])
                     .split(area);
 
-                // -- Title --
+                // -- Title and working-directory filter toggle --
+                let title_chunks = Layout::default()
+                    .direction(ratatui::layout::Direction::Horizontal)
+                    .constraints([Constraint::Min(24), Constraint::Length(24)])
+                    .split(chunks[0]);
                 let title = Paragraph::new(Line::from(vec![
                     Span::styled(
                         "📂  Saved sessions",
                         Style::default().fg(Color::Cyan).bold(),
                     ),
                     Span::styled(
-                        format!("  ({} total, newest first)", sessions.len()),
+                        format!(
+                            "  ({} of {}, newest first)",
+                            sessions.len(),
+                            all_sessions.len()
+                        ),
                         Style::default().fg(Color::Gray).italic(),
                     ),
                 ]));
-                f.render_widget(title, chunks[0]);
+                f.render_widget(title, title_chunks[0]);
+                let filter_label = if filter_working_dir {
+                    "f current dir: ON"
+                } else {
+                    "f current dir: OFF"
+                };
+                let filter = Paragraph::new(Span::styled(
+                    filter_label,
+                    Style::default()
+                        .fg(if filter_working_dir {
+                            Color::Green
+                        } else {
+                            Color::DarkGray
+                        })
+                        .bold(),
+                ))
+                .alignment(ratatui::layout::Alignment::Right);
+                f.render_widget(filter, title_chunks[1]);
 
                 // -- Session list --
                 let highlight_style = Style::default()
@@ -507,6 +557,8 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
                         Span::styled(" new  ", Style::default().fg(Color::Gray)),
                         Span::styled("d", Style::default().fg(Color::Red).bold()),
                         Span::styled(" delete  ", Style::default().fg(Color::Gray)),
+                        Span::styled("f", Style::default().fg(Color::Cyan).bold()),
+                        Span::styled(" current dir  ", Style::default().fg(Color::Gray)),
                         Span::styled("q/Esc", Style::default().fg(Color::Cyan).bold()),
                         Span::styled(" quit", Style::default().fg(Color::Gray)),
                     ]);
@@ -529,15 +581,18 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
                         let _ = mgr.delete(uuid);
                         match mgr.list_all() {
                             Ok(fresh) => {
-                                sessions = fresh;
-                                if sessions.is_empty() {
-                                    break Outcome::NewSession;
-                                }
-                                list_state.select(Some(0));
+                                all_sessions = fresh;
+                                sessions = if filter_working_dir {
+                                    sessions_for_working_dir(&all_sessions, &working_dir)
+                                } else {
+                                    all_sessions.clone()
+                                };
+                                list_state.select((!sessions.is_empty()).then_some(0));
                             }
                             Err(_) => {
+                                all_sessions.clear();
                                 sessions.clear();
-                                break Outcome::NewSession;
+                                list_state.select(None);
                             }
                         }
                         confirm_uuid = None;
@@ -554,6 +609,15 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => break Outcome::Quit,
                 KeyCode::Char('n') => break Outcome::NewSession,
+                KeyCode::Char('f') | KeyCode::Char('F') => {
+                    filter_working_dir = !filter_working_dir;
+                    sessions = if filter_working_dir {
+                        sessions_for_working_dir(&all_sessions, &working_dir)
+                    } else {
+                        all_sessions.clone()
+                    };
+                    list_state.select((!sessions.is_empty()).then_some(0));
+                }
                 KeyCode::Char('d') => {
                     if let Some(i) = list_state.selected()
                         && let Some(s) = sessions.get(i)
@@ -668,6 +732,63 @@ mod tests {
     }
 
     #[test]
+    fn working_directory_filter_keeps_only_matching_sessions() {
+        let current = std::env::temp_dir().join("programmer-project-a");
+        let sessions = vec![
+            SessionMeta {
+                uuid: "matching".to_string(),
+                first_message: String::new(),
+                created_at: 0,
+                updated_at: 2,
+                working_dir: current.display().to_string(),
+                message_count: 0,
+            },
+            SessionMeta {
+                uuid: "other".to_string(),
+                first_message: String::new(),
+                created_at: 0,
+                updated_at: 1,
+                working_dir: std::env::temp_dir()
+                    .join("programmer-project-b")
+                    .display()
+                    .to_string(),
+                message_count: 0,
+            },
+        ];
+
+        let filtered = sessions_for_working_dir(&sessions, &current);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].uuid, "matching");
+    }
+
+    #[test]
+    fn working_directory_filter_preserves_newest_first_order() {
+        let current = std::env::temp_dir().join("programmer-project");
+        let sessions = ["newest", "older"]
+            .into_iter()
+            .map(|uuid| SessionMeta {
+                uuid: uuid.to_string(),
+                first_message: String::new(),
+                created_at: 0,
+                updated_at: 0,
+                working_dir: current.display().to_string(),
+                message_count: 0,
+            })
+            .collect::<Vec<_>>();
+
+        let filtered = sessions_for_working_dir(&sessions, &current);
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|session| session.uuid.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newest", "older"]
+        );
+    }
+
+    #[test]
     fn older_sessions_default_to_auto_thinking() {
         let sessions_dir =
             std::env::temp_dir().join(format!("programmer-session-test-{}", uuid_v4()));
@@ -681,6 +802,22 @@ mod tests {
 
         let loaded: Session = serde_json::from_value(value).unwrap();
         assert_eq!(loaded.thinking_level, crate::thinking::ThinkingLevel::Auto);
+    }
+
+    #[test]
+    fn older_sessions_load_without_structured_memory() {
+        let sessions_dir =
+            std::env::temp_dir().join(format!("programmer-session-test-{}", uuid_v4()));
+        let mgr = SessionManager { sessions_dir };
+        let mut value = serde_json::to_value(mgr.create()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("session_memory")
+            .unwrap();
+
+        let loaded: Session = serde_json::from_value(value).unwrap();
+        assert!(loaded.session_memory.is_none());
     }
 
     #[test]

--- a/src/tools/memory.rs
+++ b/src/tools/memory.rs
@@ -1,0 +1,202 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use async_openai::types::responses::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::function_tool;
+use crate::memory::{MemoryKind, MemoryManager, MemoryScope};
+
+pub const NAME: &str = "memory";
+
+pub fn tool() -> Tool {
+    function_tool(
+        NAME,
+        "Manage durable local memory across sessions. Use `remember` only for explicit, stable user preferences or verified facts/decisions. Store one atomic, independently updateable fact per entry: split mixed subjects and split cross-project environment knowledge (`global`) from repository-specific facts (`project`), using multiple calls when needed. Check existing memories and update rather than duplicating them. Never store credentials, transient progress, or unverified guesses. Actions: `remember`, `recall`, `list`, `update`, and `forget`.",
+        json!({
+            "action": {
+                "type": "string",
+                "enum": ["remember", "recall", "list", "update", "forget"],
+                "description": "The memory operation."
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "project"],
+                "description": "Choose the narrowest valid scope: global is reusable across unrelated repositories (user preferences or stable machine/access environment facts); project is specific to the current repository (its paths, services, architecture, or workflow)."
+            },
+            "kind": {
+                "type": "string",
+                "enum": ["preference", "project_fact", "decision", "convention", "workflow", "constraint", "known_issue"],
+                "description": "Memory category, required for remember and optional for update."
+            },
+            "content": {
+                "type": "string",
+                "description": "One self-contained, atomic fact or preference to remember, or replacement content for update. Do not bundle facts with different scopes or lifecycles."
+            },
+            "tags": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional retrieval tags."
+            },
+            "query": {
+                "type": "string",
+                "description": "Search query required for recall."
+            },
+            "id": {
+                "type": "string",
+                "description": "Memory id required for update and forget."
+            }
+        }),
+        &["action"],
+    )
+}
+
+#[derive(Deserialize)]
+struct Args {
+    action: String,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+}
+
+pub(crate) fn action_is_mutating(arguments: &str) -> bool {
+    serde_json::from_str::<Args>(arguments)
+        .map(|args| matches!(args.action.as_str(), "remember" | "update" | "forget"))
+        .unwrap_or(true)
+}
+
+pub async fn run(arguments: &str) -> Result<String, String> {
+    let args: Args = serde_json::from_str(arguments)
+        .map_err(|error| format!("error: invalid arguments: {error}"))?;
+    let manager = MemoryManager::for_current_dir().map_err(|error| format!("error: {error}"))?;
+
+    match args.action.as_str() {
+        "remember" => {
+            let scope = required_scope(args.scope.as_deref())?;
+            let kind = required_kind(args.kind.as_deref())?;
+            let content = required(args.content, "content")?;
+            let entry = manager
+                .remember(scope, kind, content, args.tags.unwrap_or_default())
+                .map_err(|error| format!("error: {error}"))?;
+            Ok(format!(
+                "Remembered {} memory {}: {}",
+                scope_label(scope),
+                entry.id,
+                entry.content
+            ))
+        }
+        "recall" => {
+            let query = required(args.query, "query")?;
+            let mut config = crate::config::programmer_config::MemoryConfig::default();
+            if let Some(scope) = optional_scope(args.scope.as_deref())? {
+                config.global_enabled = scope == MemoryScope::Global;
+                config.project_enabled = scope == MemoryScope::Project;
+            }
+            let entries = manager
+                .retrieve(&query, &config)
+                .map_err(|error| format!("error: {error}"))?;
+            Ok(MemoryManager::render_list(&entries))
+        }
+        "list" => {
+            let scope = optional_scope(args.scope.as_deref())?;
+            let entries = manager
+                .list(scope)
+                .map_err(|error| format!("error: {error}"))?;
+            Ok(MemoryManager::render_list(&entries))
+        }
+        "update" => {
+            let id = required(args.id, "id")?;
+            let kind = args.kind.as_deref().map(parse_kind).transpose()?;
+            if args.content.is_none() && kind.is_none() && args.tags.is_none() {
+                return Err("error: update requires content, kind, or tags".to_string());
+            }
+            let entry = manager
+                .update(&id, args.content, kind, args.tags)
+                .map_err(|error| format!("error: {error}"))?;
+            Ok(format!("Updated memory {}: {}", entry.id, entry.content))
+        }
+        "forget" => {
+            let id = required(args.id, "id")?;
+            manager
+                .forget(&id)
+                .map_err(|error| format!("error: {error}"))?;
+            Ok(format!("Forgot memory {id}"))
+        }
+        other => Err(format!(
+            "error: unknown action '{other}' — use remember, recall, list, update, or forget"
+        )),
+    }
+}
+
+fn required(value: Option<String>, name: &str) -> Result<String, String> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("error: '{name}' is required"))
+}
+
+fn optional_scope(value: Option<&str>) -> Result<Option<MemoryScope>, String> {
+    value.map(parse_scope).transpose()
+}
+
+fn required_scope(value: Option<&str>) -> Result<MemoryScope, String> {
+    value
+        .ok_or_else(|| "error: 'scope' is required".to_string())
+        .and_then(parse_scope)
+}
+
+fn parse_scope(value: &str) -> Result<MemoryScope, String> {
+    MemoryScope::parse(value)
+        .ok_or_else(|| format!("error: invalid scope '{value}' — use global or project"))
+}
+
+fn required_kind(value: Option<&str>) -> Result<MemoryKind, String> {
+    value
+        .ok_or_else(|| "error: 'kind' is required".to_string())
+        .and_then(parse_kind)
+}
+
+fn parse_kind(value: &str) -> Result<MemoryKind, String> {
+    MemoryKind::parse(value).ok_or_else(|| format!("error: invalid memory kind '{value}'"))
+}
+
+fn scope_label(scope: MemoryScope) -> &'static str {
+    match scope {
+        MemoryScope::Global => "global",
+        MemoryScope::Project => "project",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutation_detection_splits_read_and_write_actions() {
+        assert!(!action_is_mutating(r#"{"action":"list"}"#));
+        assert!(!action_is_mutating(r#"{"action":"recall","query":"rust"}"#));
+        assert!(action_is_mutating(r#"{"action":"remember"}"#));
+        assert!(action_is_mutating("not json"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -24,6 +24,7 @@ pub mod fetch;
 pub mod grep;
 pub mod load_skill;
 pub(crate) mod mcp_bridge;
+pub mod memory;
 pub(crate) mod provider;
 pub mod read_file;
 pub mod read_image;
@@ -261,6 +262,7 @@ pub(crate) async fn run_local_tool(name: &str, arguments: &str) -> Result<String
         fetch::NAME => fetch::run(arguments).await,
         configure_diagnostics::NAME => configure_diagnostics::run(arguments).await,
         diagnostics::NAME => diagnostics::run(arguments).await,
+        memory::NAME => memory::run(arguments).await,
         todo::NAME => Err(
             "error: the todo tool requires a session and is unavailable in standalone MCP mode"
                 .to_string(),

--- a/src/tools/provider.rs
+++ b/src/tools/provider.rs
@@ -25,8 +25,8 @@
 
 use super::{
     agent, ask_user, blob, command, configure_diagnostics, diagnostics, edit_file, fetch, grep,
-    load_skill, mcp_bridge, read_file, read_image, request_permission, run_local_tool, task, todo,
-    write_file,
+    load_skill, mcp_bridge, memory, read_file, read_image, request_permission, run_local_tool,
+    task, todo, write_file,
 };
 use crate::mcp::McpManager;
 use crate::ui::event::Event;
@@ -181,6 +181,7 @@ pub(crate) struct LocalToolProvider {
     security: Arc<crate::security::SecurityHandle>,
     file_scope: u64,
     checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
+    memory_enabled: bool,
 }
 
 impl LocalToolProvider {
@@ -193,6 +194,7 @@ impl LocalToolProvider {
             security,
             file_scope: 0,
             checkpoint: None,
+            memory_enabled: true,
         }
     }
 
@@ -206,6 +208,7 @@ impl LocalToolProvider {
             security,
             file_scope,
             checkpoint: None,
+            memory_enabled: true,
         }
     }
 
@@ -214,6 +217,11 @@ impl LocalToolProvider {
         checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
     ) -> Self {
         self.checkpoint = checkpoint;
+        self
+    }
+
+    pub(crate) fn with_memory_enabled(mut self, enabled: bool) -> Self {
+        self.memory_enabled = enabled;
         self
     }
 }
@@ -236,7 +244,7 @@ impl Default for LocalToolProvider {
 #[async_trait::async_trait]
 impl ToolProvider for LocalToolProvider {
     fn tools(&self) -> Vec<Tool> {
-        vec![
+        let mut tools = vec![
             command::tool(),
             request_permission::tool(),
             read_file::tool(),
@@ -251,7 +259,11 @@ impl ToolProvider for LocalToolProvider {
             diagnostics::tool(),
             todo::tool(),
             task::tool(),
-        ]
+        ];
+        if self.memory_enabled {
+            tools.push(memory::tool());
+        }
+        tools
     }
 
     fn is_read_only(&self, name: &str) -> bool {
@@ -307,6 +319,10 @@ impl ToolProvider for LocalToolProvider {
                 .map(FunctionCallOutput::Text)
         } else if call.name == todo::NAME {
             todo::run(&call.arguments, &self.todos)
+                .await
+                .map(FunctionCallOutput::Text)
+        } else if call.name == memory::NAME {
+            memory::run(&call.arguments)
                 .await
                 .map(FunctionCallOutput::Text)
         } else if call.name == read_image::NAME {

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -67,7 +67,7 @@ const SCROLL_LINES_BASE: usize = 1;
 /// Maximum rows per notch when scrolling fast.
 const SCROLL_LINES_MAX: usize = 5;
 /// Time window (ms) for consecutive scrolls to count as "fast" scrolling.
-const SCROLL_ACCEL_WINDOW_MS: u128 = 150;
+const SCROLL_ACCEL_WINDOW_MS: u128 = 250;
 /// How long (ms) the scrollbar thumb stays visible after the last scroll
 /// interaction. It is an overlay on the last content column, so hiding it
 /// costs no layout space.

--- a/src/ui/components/provider_panel/mod.rs
+++ b/src/ui/components/provider_panel/mod.rs
@@ -1164,6 +1164,7 @@ mod tests {
             compact_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
+            memory: Default::default(),
             allow_yolo: false,
             security: Default::default(),
             security_profiles: Default::default(),


### PR DESCRIPTION
### Programmer v0.2.7

- Add structured L1 session state and inspectable project/global persistent memory.
- Add explicit `memory` tool and `/memory` commands; stored memories are never injected into requests automatically.
- Scope `--resume` session selection to the current workspace.
- Make cancellation interrupt stalled response connection and stream waits promptly.
- Increase the fast-scroll acceleration window for smoother navigation.

### Verification

- `cargo test` — 519 passed, 1 ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo check --locked`
- `git diff --check`