### PR TITLE
v0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.7"
+version = "0.2.8"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/PROGRAMMER.md
+++ b/PROGRAMMER.md
@@ -220,7 +220,7 @@ src/
 
 - **Error handling:** `color_eyre::Result<T>` throughout; `.wrap_err()` for context; `?` propagation. `thiserror` for library-style error types.
 - **Async:** `#[tokio::main]` on `main()`, `tokio::spawn` for concurrent tasks. All tool execution is async.
-- **Configuration:** `ProgrammerConfig` deserializes from TOML via the `config` crate. Environment variables prefixed with `Programmer` override file values. Config lives at `~/.config/programmer/config.toml`.
+- **Configuration:** `ProgrammerConfig` deserializes from TOML via the `config` crate. Environment variables prefixed with `Programmer` override file values. Config lives at `~/.config/programmer/config.toml`. The optional top-level `soul` value replaces only the identity/mindset section of the developer prompt.
 - **Sessions:** Stored as JSON at `~/.config/programmer/sessions/<uuid>.json`. Each session contains message items, history, todos, and persisted task state.
 - **Module visibility:** `pub(crate)` for internal visibility; `pub` only where needed externally. UI internals are `mod` (private). Tool modules are `pub` within `tools/`.
 - **Tests:** Inline `#[cfg(test)]` modules at the bottom of source files. No separate `tests/` directory.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ api_key = "sk-your-key-here"
 ```toml
 default_provider = "openai"
 
+# Optional replacement for Programmer's built-in identity and mindset section.
+# All environment, safety, tool-use, and editing instructions remain in place.
+soul = """
+You are a thoughtful, direct pair programmer.
+"""
+
 # Separate model for the Auto-mode classifier (faster = better).
 # Falls back to the chat model when absent. Must be a non-reasoning model.
 classifier_model = "openai/gpt-4o-mini"
@@ -167,6 +173,10 @@ classifier_top_logprobs = 20
 # Model used for manual and automatic context compaction. Falls back to the
 # current chat model when absent.
 compact_model = "openai/gpt-4o-mini"
+
+# Model used to generate a concise title from a session's first message. Falls
+# back to the current chat model when absent.
+title_model = "openai/gpt-4o-mini"
 
 # Automatically compact after a response reports at least this many input
 # tokens. This uses provider-reported usage (not an estimate); 0 disables it.
@@ -235,9 +245,11 @@ api_key = "sk-your-key-here"
 | Field | Default | Description |
 |---|---|---|
 | `default_provider` | `"openai"` | Active provider at startup. |
+| `soul` | (built-in identity) | Replaces only Programmer's identity and mindset section in the developer prompt; operational and safety instructions remain active. Supports TOML multiline strings. |
 | `classifier_model` | (chat model) | `provider/model` for the Auto-mode classifier. Must be a **non-reasoning** model (see [Auto mode](#work-modes)). |
 | `classifier_top_logprobs` | `20` | Alternative-token count for the fast classifier probe (`0`–`20`). Lower this for providers with a smaller limit; Qwen accepts at most `5`. |
 | `compact_model` | (chat model) | `provider/model` used for manual and automatic context compaction. |
+| `title_model` | (chat model) | `provider/model` used to generate a concise title for each new session. |
 | `auto_compact_tokens` | `100000` | Provider-reported input-token threshold for seamless background compaction. `0` disables it. Providers that do not report usage do not trigger it. |
 | `compact_keep_recent_turns` | `2` | Number of recent complete turns kept verbatim when context is compacted. |
 | `memory.enabled` | `true` | Advertise the persistent-memory tool. Memory is recalled explicitly and is never injected automatically. |
@@ -504,8 +516,10 @@ recovery checkpoint so its file changes can be undone from the same panel.
 Automatic compaction observes the real `input_tokens` returned after every API
 response. For tool-using responses it waits until all call outputs are recorded,
 then summarizes a stable prefix in the background. Input stays usable and new
-messages remain outside that prefix. A stale summary is discarded after
-`/clear`, `/new`, or `/rewind`.
+messages remain outside that prefix. The input title announces that the next
+turn will use compacted context; when that turn starts, a marker is inserted
+immediately before its messages. A stale summary is discarded after `/clear`,
+`/new`, or `/rewind`.
 
 **In model browser (`m`):**
 
@@ -644,8 +658,10 @@ classifier, while `manual` waits for you at the console.
 ### Session management
 
 Sessions are saved to `~/.config/programmer/sessions/<uuid>.json`. Conversation
-history, model/work mode, the `/vision` switch, and todos are restored
-independently for each session.
+history, model/work mode, the `/vision` switch, generated title, and todos are
+restored independently for each session. A background request using
+`title_model` (or the current chat model) names a new session from its first
+message; the resume picker and `/session` show that title.
 
 With `/vision on`, referencing a local PNG, JPEG, WEBP, or non-animated GIF as
 `@path` attaches it as an image input. `/vision off` stops sending both new and

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -366,6 +366,7 @@ pub(crate) struct AgentRuntime {
     pub(crate) security: Arc<crate::security::SecurityHandle>,
     pub(crate) mcp_manager: Option<Arc<crate::mcp::McpManager>>,
     pub(crate) policy: AgentPolicyFactory,
+    pub(crate) soul: Option<String>,
     pub(crate) coauthor: Option<String>,
     pub(crate) vision_enabled: bool,
     pub(crate) thinking_level: crate::thinking::ThinkingLevel,
@@ -430,6 +431,7 @@ impl AgentRuntime {
             model_str: self.model_str.clone(),
             tools: Arc::new(ToolRegistry::new(providers)),
             policy: self.policy.build(),
+            soul: self.soul.clone(),
             coauthor: self.coauthor.clone(),
             vision_enabled: self.vision_enabled,
             thinking_level: self.thinking_level,
@@ -534,7 +536,7 @@ mod tests {
             first.id,
             Ok(crate::runner::TurnResult {
                 final_text: "done".into(),
-                usage: (1, 2),
+                usage: (1, 2, 0),
             }),
         );
         let snapshot = manager.snapshot(first.id).unwrap();

--- a/src/app/command_handlers/session.rs
+++ b/src/app/command_handlers/session.rs
@@ -63,9 +63,14 @@ fn show_session(app: &mut App<'_>) -> CommandOutcome {
     let message = match &app.session.mgr {
         Some(manager) => {
             let path = manager.session_path(&app.session.uuid);
-            format_session_info(item_count, &app.session.uuid, Some((&path, path.exists())))
+            format_session_info(
+                item_count,
+                &app.session.uuid,
+                &app.session.title,
+                Some((&path, path.exists())),
+            )
         }
-        None => format_session_info(item_count, &app.session.uuid, None),
+        None => format_session_info(item_count, &app.session.uuid, &app.session.title, None),
     };
     app.conversation_panel.add_info_string(message);
     CommandOutcome::handled(true)
@@ -74,8 +79,14 @@ fn show_session(app: &mut App<'_>) -> CommandOutcome {
 fn format_session_info(
     item_count: usize,
     uuid: &str,
+    title: &str,
     session_file: Option<(&std::path::Path, bool)>,
 ) -> String {
+    let title_line = if title.is_empty() {
+        String::new()
+    } else {
+        format!("\n  title: {title}")
+    };
     match session_file {
         Some((path, exists)) => {
             let status = if exists {
@@ -84,11 +95,13 @@ fn format_session_info(
                 "not yet saved"
             };
             format!(
-                "Session: {item_count} messages, {status}\n  uuid: {uuid}\n  path: {}",
+                "Session: {item_count} messages, {status}{title_line}\n  uuid: {uuid}\n  path: {}",
                 path.display()
             )
         }
-        None => format!("Session: {item_count} messages (no session manager)\n  uuid: {uuid}"),
+        None => format!(
+            "Session: {item_count} messages (no session manager){title_line}\n  uuid: {uuid}"
+        ),
     }
 }
 
@@ -99,20 +112,32 @@ fn usage(app: &mut App<'_>) -> CommandOutcome {
     CommandOutcome::handled(true)
 }
 
+fn cache_percent(cached_tokens: u64, input_tokens: u64) -> u64 {
+    cached_tokens
+        .saturating_mul(100)
+        .checked_div(input_tokens)
+        .unwrap_or(0)
+}
+
 fn format_usage(summary: crate::conversation::UsageSummary) -> String {
     match summary.last_turn {
-        Some((last_input, last_output)) => format!(
+        Some((last_input, last_output, last_cached)) => format!(
             "Token usage for this session:\n\
              \u{20} input: {} tokens\n\
+             \u{20} cached input: {} tokens ({}%)\n\
              \u{20} output: {} tokens\n\
              \u{20} total: {} tokens\n\
              \u{20} recorded turns: {}\n\
-             Last turn: {} input + {} output = {} tokens",
+             Last turn: {} input ({} cached, {}%) + {} output = {} tokens",
             summary.input_tokens,
+            summary.cached_input_tokens,
+            cache_percent(summary.cached_input_tokens, summary.input_tokens),
             summary.output_tokens,
             summary.total_tokens(),
             summary.turns,
             last_input,
+            last_cached,
+            cache_percent(u64::from(last_cached), u64::from(last_input)),
             last_output,
             u64::from(last_input) + u64::from(last_output),
         ),
@@ -149,6 +174,8 @@ fn new(app: &mut App<'_>) -> CommandOutcome {
     app.checkpoint_store = crate::checkpoint::CheckpointStore::for_session(&app.session.uuid)
         .map(|store| std::sync::Arc::new(std::sync::Mutex::new(store)));
     app.current_checkpoint_id = None;
+    app.session.title.clear();
+    app.session.title_generation_started = false;
     app.todo_list = crate::todos::TodoList::default();
     app.sync_todos_to_store();
     app.vision_enabled = false;
@@ -186,19 +213,20 @@ mod tests {
         let message = format_session_info(
             7,
             "session-uuid",
+            "Fix login retries",
             Some((Path::new("/tmp/session-uuid.json"), true)),
         );
 
         assert_eq!(
             message,
-            "Session: 7 messages, saved on disk\n  uuid: session-uuid\n  path: /tmp/session-uuid.json"
+            "Session: 7 messages, saved on disk\n  title: Fix login retries\n  uuid: session-uuid\n  path: /tmp/session-uuid.json"
         );
     }
 
     #[test]
     fn session_info_handles_unavailable_session_manager() {
         assert_eq!(
-            format_session_info(0, "session-uuid", None),
+            format_session_info(0, "session-uuid", "", None),
             "Session: 0 messages (no session manager)\n  uuid: session-uuid"
         );
     }
@@ -208,15 +236,17 @@ mod tests {
         let message = format_usage(UsageSummary {
             input_tokens: 13,
             output_tokens: 7,
+            cached_input_tokens: 5,
             turns: 2,
-            last_turn: Some((3, 2)),
+            last_turn: Some((3, 2, 2)),
         });
 
         assert!(message.contains("input: 13 tokens"));
+        assert!(message.contains("cached input: 5 tokens (38%)"));
         assert!(message.contains("output: 7 tokens"));
         assert!(message.contains("total: 20 tokens"));
         assert!(message.contains("recorded turns: 2"));
-        assert!(message.contains("Last turn: 3 input + 2 output = 5 tokens"));
+        assert!(message.contains("Last turn: 3 input (2 cached, 66%) + 2 output = 5 tokens"));
     }
 
     #[test]

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -207,6 +207,9 @@ async fn start_ready_request(
 ) {
     debug_assert!(app.cancel.active_id.is_none());
     let conversation_cutoff = app.conversation_panel.items_snapshot().len();
+    let title_source = (app.session.title.is_empty() && !app.session.title_generation_started)
+        .then(|| inputs.first().map(|(text, _, _)| text.clone()))
+        .flatten();
     let user_prompt = inputs
         .iter()
         .find(|(_, role, _)| matches!(role, InputRole::User))
@@ -233,6 +236,9 @@ async fn start_ready_request(
                 role,
                 status: Some(OutputStatus::Completed),
             }));
+    }
+    if let Some(source) = title_source {
+        maybe_start_session_title(app, source);
     }
     app.conversation_panel.reset_accumulated_usage();
     diagnostics::maybe_seed_diagnostics_baseline(app);
@@ -261,6 +267,15 @@ async fn start_ready_request(
             .add_error_string(format!("unknown provider/model: {}", app.current_model));
         return;
     };
+    if let Some(details) = app.input_panel.take_next_turn_compaction() {
+        app.conversation_panel.insert_info_string(
+            conversation_cutoff,
+            format!(
+                "Automatic context compaction — {details} summarized. The model turn below is \
+                 the first to use the compacted context; older history remains visible above."
+            ),
+        );
+    }
     let surface = TuiSurface {
         tx: app.events.sender.clone(),
         skill_prompt: app.skill_registry.catalog_prompt(),
@@ -455,6 +470,54 @@ pub(crate) fn run_bang_command(app: &mut App<'_>, input: &str) {
     }
 }
 
+fn maybe_start_session_title(app: &mut App<'_>, first_message: String) {
+    use crate::ui::event::{AppEvent, Event};
+
+    app.session.title_generation_started = true;
+    let target_model = app.effective_title_model();
+    let Some((client, model_name)) = app.provider_manager.resolve(&target_model) else {
+        app.conversation_panel.add_warning_string(format!(
+            "session title generation skipped: unknown provider/model {target_model}"
+        ));
+        return;
+    };
+    let client = client.clone();
+    let session_uuid = app.session.uuid.clone();
+    let prompt = format!("{}{first_message}", crate::prompts::SESSION_TITLE_PROMPT);
+    let request = async_openai::types::responses::CreateResponse {
+        input: async_openai::types::responses::InputParam::Text(prompt),
+        model: Some(model_name),
+        max_output_tokens: Some(80),
+        ..Default::default()
+    };
+    let sender = app.events.sender.clone();
+    tokio::spawn(async move {
+        let result =
+            stream_compact_response(&client, request, crate::cancel::CancellationToken::new())
+                .await
+                .and_then(|response| normalize_session_title(&response.summary));
+        let _ = sender.send(Event::App(AppEvent::SessionTitleGenerated {
+            session_uuid,
+            result,
+        }));
+    });
+}
+
+fn normalize_session_title(response: &str) -> Result<String, String> {
+    let title = response
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or_default()
+        .trim()
+        .trim_matches(['"', '\'', '“', '”'])
+        .trim();
+    if title.is_empty() {
+        Err("the model returned an empty title".to_string())
+    } else {
+        Ok(title.chars().take(80).collect())
+    }
+}
+
 /// Build the no-tools request shared by foreground and background compaction.
 fn build_compact_request(
     input_items: Vec<async_openai::types::responses::InputItem>,
@@ -528,7 +591,7 @@ async fn stream_compact_response(
     client: &async_openai::Client<async_openai::config::OpenAIConfig>,
     request: async_openai::types::responses::CreateResponse,
     cancel: crate::cancel::CancellationToken,
-) -> Result<String, String> {
+) -> Result<crate::ui::event::CompactionResult, String> {
     let mut partial = crate::response::partial_response::PartialResponse::new(cancel.clone());
     let mut stream_error = None;
     let retrying = std::sync::atomic::AtomicBool::new(false);
@@ -548,10 +611,16 @@ async fn stream_compact_response(
         return Err(error_chain(&error));
     }
 
-    partial
+    let usage = partial.usage;
+    let summary = partial
         .finalize()
         .map_err(|error| error_chain(&error))
-        .and_then(compact_response_text)
+        .and_then(compact_response_text)?;
+    Ok(crate::ui::event::CompactionResult {
+        summary,
+        input_tokens: usage.map(|(input, _, _)| input),
+        output_tokens: usage.map(|(_, output, _)| output),
+    })
 }
 
 /// Include nested transport causes hidden by reqwest's top-level Display text.
@@ -601,6 +670,7 @@ pub(crate) fn start_compact(app: &mut App<'_>) {
     let input_items = compact_input_items(app.conversation_panel.input_param_for_prefix(
         cutoff,
         &target_model,
+        app.config.soul.as_deref(),
         app.vision_enabled,
     ));
 
@@ -662,6 +732,7 @@ pub(crate) fn maybe_start_auto_compact(app: &mut App<'_>, input_tokens: u32) {
     let input_items = compact_input_items(app.conversation_panel.input_param_for_prefix(
         cutoff,
         &target_model,
+        app.config.soul.as_deref(),
         app.vision_enabled,
     ));
     app.auto_compact.next_id = app.auto_compact.next_id.wrapping_add(1);
@@ -689,6 +760,7 @@ pub(crate) fn invalidate_auto_compaction(app: &mut App<'_>) {
     app.auto_compact.history_epoch = app.auto_compact.history_epoch.wrapping_add(1);
     app.auto_compact.active_id = None;
     app.auto_compact.last_cutoff = None;
+    app.input_panel.clear_next_turn_compaction();
 }
 
 /// Open the full-screen task panel. Interactive tasks can grab input; pipe
@@ -854,7 +926,8 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
 mod tests {
     use super::{
         ConversationPanel, build_compact_request, execute_command, format_agent_updates,
-        format_task_updates, ordered_message_content, queue_pending_request,
+        format_task_updates, normalize_session_title, ordered_message_content,
+        queue_pending_request,
     };
     use async_openai::types::responses::{ImageDetail, InputContent, InputImageContent};
     use std::sync::Arc;
@@ -1017,6 +1090,25 @@ mod tests {
             crate::thinking::ThinkingLevel::Auto,
         );
         assert!(auto.reasoning.is_none());
+    }
+
+    #[test]
+    fn generated_session_title_is_cleaned_and_bounded() {
+        assert_eq!(
+            normalize_session_title("  “修复登录重试”  \nextra").unwrap(),
+            "修复登录重试"
+        );
+        assert_eq!(
+            normalize_session_title("   \n"),
+            Err("the model returned an empty title".to_string())
+        );
+        assert_eq!(
+            normalize_session_title(&"x".repeat(100))
+                .unwrap()
+                .chars()
+                .count(),
+            80
+        );
     }
 
     #[tokio::test]

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -295,8 +295,13 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                 return;
             }
             match result {
-                Ok(summary) => {
-                    if app.conversation_panel.apply_compaction_at(cutoff, summary) {
+                Ok(compaction) => {
+                    let turns = app.conversation_panel.compaction_turn_count(cutoff);
+                    let details = compaction_details(turns, &compaction);
+                    if app
+                        .conversation_panel
+                        .apply_compaction_at(cutoff, compaction.summary)
+                    {
                         if let Some(store) = &app.checkpoint_store
                             && let Err(error) =
                                 store.lock().unwrap().record_conversation_insertion(cutoff)
@@ -305,12 +310,30 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                                 "could not update rewind checkpoints after compaction: {error}"
                             ));
                         }
+                        app.input_panel.show_next_turn_compaction(details);
                         session::mark_dirty(app);
                     }
                 }
                 Err(error) => app
                     .conversation_panel
                     .add_warning_string(format!("automatic context compaction failed: {error}")),
+            }
+        }
+        AppEvent::SessionTitleGenerated {
+            session_uuid,
+            result,
+        } => {
+            if app.session.uuid != session_uuid {
+                return;
+            }
+            match result {
+                Ok(title) => {
+                    app.session.title = title;
+                    session::mark_dirty(app);
+                }
+                Err(error) => app
+                    .conversation_panel
+                    .add_warning_string(format!("session title generation failed: {error}")),
             }
         }
         AppEvent::Quit => handle_quit_request(app),
@@ -675,13 +698,23 @@ fn handle_start_init(app: &mut App<'_>, prompt: String) {
     });
 }
 
+fn compaction_details(turns: usize, compaction: &crate::ui::event::CompactionResult) -> String {
+    let turn_label = if turns == 1 { "turn" } else { "turns" };
+    match (compaction.input_tokens, compaction.output_tokens) {
+        (Some(input), Some(output)) => {
+            format!("{turns} {turn_label}, {input}→{output} tokens")
+        }
+        _ => format!("{turns} {turn_label}"),
+    }
+}
+
 /// `/compact` finished: install the summary as the new context boundary, or
 /// surface the error. Always clears the active operation id and phase so a
 /// cancelled compaction doesn't leave the UI stuck in Cancelling.
 fn handle_compact_finished(
     app: &mut App<'_>,
     cutoff: usize,
-    result: Result<String, String>,
+    result: Result<crate::ui::event::CompactionResult, String>,
     cancel_token: CancellationToken,
 ) {
     app.cancel.active_id = None;
@@ -691,8 +724,10 @@ fn handle_compact_finished(
         return;
     }
     match result {
-        Ok(summary) => {
-            if app.conversation_panel.apply_compaction_at(cutoff, summary)
+        Ok(compaction) => {
+            if app
+                .conversation_panel
+                .apply_compaction_at(cutoff, compaction.summary)
                 && let Some(store) = &app.checkpoint_store
                 && let Err(error) = store.lock().unwrap().record_conversation_insertion(cutoff)
             {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -135,6 +135,10 @@ pub(crate) struct SessionState {
     /// so a burst of changes within a turn collapses into a single save at turn
     /// end instead of writing after every event.
     pub(crate) dirty: bool,
+    /// Model-generated title persisted with the session.
+    pub(crate) title: String,
+    /// Prevent duplicate title requests while the first one is in flight.
+    pub(crate) title_generation_started: bool,
     pub(crate) classifier_model_override: ModelOverride,
     pub(crate) compact_model_override: ModelOverride,
     pub(crate) auto_compact_override: AutoCompactOverride,
@@ -389,6 +393,7 @@ impl App<'_> {
         let mut compact_model_override = ModelOverride::Inherit;
         let mut auto_compact_override = AutoCompactOverride::Inherit;
         let mut compact_keep_recent_turns_override = None;
+        let mut session_title = String::new();
 
         let mut saved_activated_skills: Option<Vec<String>> = None;
         if let Some(mgr) = &session_mgr
@@ -402,6 +407,7 @@ impl App<'_> {
             {
                 current_model = model;
             }
+            session_title = saved.title;
             vision_enabled = saved.vision_enabled;
             thinking_level = saved.thinking_level;
             classifier_model_override = saved.classifier_model_override;
@@ -503,6 +509,8 @@ impl App<'_> {
                 mgr: session_mgr,
                 dirty: false,
                 did_save: false,
+                title_generation_started: !session_title.is_empty(),
+                title: session_title,
                 classifier_model_override,
                 compact_model_override,
                 auto_compact_override,
@@ -595,6 +603,13 @@ impl App<'_> {
             &self.session.compact_model_override,
             self.config.compact_model.as_deref(),
         )
+    }
+
+    pub(crate) fn effective_title_model(&self) -> String {
+        self.config
+            .title_model
+            .clone()
+            .unwrap_or_else(|| self.current_model.clone())
     }
 
     pub(crate) fn effective_auto_compact_tokens(&self) -> Option<u32> {
@@ -694,6 +709,7 @@ impl App<'_> {
             security: self.security.clone(),
             mcp_manager: self.mcp_manager.clone(),
             policy: child_policy,
+            soul: self.config.soul.clone(),
             coauthor: self.config.git_coauthor.clone(),
             vision_enabled: self.vision_enabled,
             thinking_level: self.thinking_level,
@@ -719,6 +735,7 @@ impl App<'_> {
             model_str,
             tools,
             policy,
+            soul: self.config.soul.clone(),
             coauthor: self.config.git_coauthor.clone(),
             vision_enabled: self.vision_enabled,
             thinking_level: self.thinking_level,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -80,6 +80,7 @@ fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
         s.uuid = app.session.uuid.clone();
         s
     });
+    session.title = app.session.title.clone();
     // Capture first user message for the picker preview.
     if session.first_message.is_empty()
         && let Some(text) = helpers::first_user_text(&items)
@@ -138,6 +139,8 @@ pub(crate) fn persist_config(app: &mut App<'_>) {
 
 /// Delete the session file and start a fresh session with a new UUID.
 pub(crate) fn delete_session(app: &mut App<'_>) {
+    app.session.title.clear();
+    app.session.title_generation_started = false;
     if let Some(store) = &app.checkpoint_store {
         let _ = store.lock().unwrap().delete_all();
     }

--- a/src/config/programmer_config.rs
+++ b/src/config/programmer_config.rs
@@ -62,6 +62,10 @@ impl Default for MemoryConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ProgrammerConfig {
+    /// Replaces Programmer's built-in identity and mindset section in the
+    /// developer prompt. When absent, the built-in identity is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub soul: Option<String>,
     /// The provider to use when none is specified in the model string.
     pub default_provider: String,
     /// All configured providers, keyed by name.
@@ -82,6 +86,10 @@ pub struct ProgrammerConfig {
     /// the current chat model is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_model: Option<String>,
+    /// Model used to generate concise session titles. When absent, the current
+    /// chat model is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_model: Option<String>,
     /// Start a background context compaction after an API response reports at
     /// least this many input tokens. Zero disables automatic compaction.
     #[serde(default = "default_auto_compact_tokens")]
@@ -205,11 +213,13 @@ impl Default for ProgrammerConfig {
         );
         let security = crate::security::SecurityConfig::default();
         ProgrammerConfig {
+            soul: None,
             default_provider: "openai".to_string(),
             providers,
             classifier_model: None,
             classifier_top_logprobs: default_classifier_top_logprobs(),
             compact_model: None,
+            title_model: None,
             auto_compact_tokens: default_auto_compact_tokens(),
             compact_keep_recent_turns: default_compact_keep_recent_turns(),
             memory: MemoryConfig::default(),
@@ -363,6 +373,25 @@ mod tests {
         let config = ProgrammerConfig::default();
         let serialized = toml::to_string(&config).expect("serialize");
         assert!(!serialized.contains("mcp_servers"));
+    }
+
+    #[test]
+    fn soul_is_optional_and_round_trips() {
+        let defaulted: ProgrammerConfig = toml::from_str("").expect("deserialize defaults");
+        assert_eq!(defaulted.soul, None);
+
+        let configured: ProgrammerConfig =
+            toml::from_str("soul = 'You are a careful pair programmer.'")
+                .expect("deserialize configured soul");
+        assert_eq!(
+            configured.soul.as_deref(),
+            Some("You are a careful pair programmer.")
+        );
+        assert!(
+            toml::to_string(&configured)
+                .expect("serialize")
+                .contains("soul")
+        );
     }
 
     #[test]

--- a/src/conversation.rs
+++ b/src/conversation.rs
@@ -26,7 +26,7 @@
 //!
 //! [`ConversationPanel`]: crate::ui::components::conversation_panel::conversation_panel::ConversationPanel
 
-use crate::prompts::SYSTEM_PROMPT;
+use crate::prompts::{DEFAULT_SOUL, SYSTEM_PROMPT};
 use crate::response::message_item::MessageItem;
 use async_openai::error::OpenAIError;
 use async_openai::types::responses::MessageItem as ApiMessageItem;
@@ -42,10 +42,10 @@ pub struct Conversation {
     /// Every message in the conversation, in order. Rendered by the panel and
     /// mapped to API input items by [`Conversation::to_input_param`].
     pub(crate) items: Vec<MessageItem>,
-    /// Accumulated token usage `(input, output)` across all responses in the
-    /// current turn (a turn may span multiple responses when tool calls are
-    /// involved). Flushed to a [`MessageItem::Usage`] at turn end.
-    pub accumulated_usage: (u32, u32),
+    /// Accumulated token usage `(input, output, cached input)` across all
+    /// responses in the current turn (a turn may span multiple responses when
+    /// tool calls are involved). Flushed to a [`MessageItem::Usage`] at turn end.
+    pub accumulated_usage: (u32, u32, u32),
     /// Bumped whenever an *existing* item is mutated in place (or the list is
     /// replaced wholesale), as opposed to appended to. The renderer's cache is
     /// keyed by item index, so appends are naturally cache-coherent — this
@@ -59,8 +59,9 @@ pub struct Conversation {
 pub struct UsageSummary {
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub cached_input_tokens: u64,
     pub turns: usize,
-    pub last_turn: Option<(u32, u32)>,
+    pub last_turn: Option<(u32, u32, u32)>,
 }
 
 impl UsageSummary {
@@ -156,6 +157,15 @@ impl Conversation {
 
     pub fn add_info_string(&mut self, message: impl Into<String>) {
         self.items.push(MessageItem::Info(message.into()));
+    }
+
+    /// Insert UI-only information at a stable conversation boundary.
+    pub fn insert_info_string(&mut self, index: usize, message: impl Into<String>) {
+        self.items.insert(
+            index.min(self.items.len()),
+            MessageItem::Info(message.into()),
+        );
+        self.mutation_version = self.mutation_version.wrapping_add(1);
     }
 
     pub fn add_meta(&mut self, label: impl Into<String>, text: impl Into<String>) {
@@ -254,19 +264,43 @@ impl Conversation {
             .then_some(cutoff)
     }
 
+    /// Count the complete request turns replaced by a compaction boundary at
+    /// `cutoff`. Adjacent user/developer inputs belong to the same turn.
+    pub fn compaction_turn_count(&self, cutoff: usize) -> usize {
+        let cutoff = cutoff.min(self.items.len());
+        let start = self.items[..cutoff]
+            .iter()
+            .rposition(|item| matches!(item, MessageItem::Compacted { .. }))
+            .map_or(0, |index| index + 1);
+        let mut turns = 0;
+        let mut in_input_group = false;
+        for item in &self.items[start..cutoff] {
+            let is_request_input = matches!(
+                item,
+                MessageItem::Input(InputItem::Item(Item::Message(ApiMessageItem::Input(_))))
+            );
+            if is_request_input && !in_input_group {
+                turns += 1;
+            }
+            in_input_group = is_request_input;
+        }
+        turns
+    }
+
     /// Build the model input for the stable prefix ending at `cutoff`.
     pub fn input_param_for_prefix(
         &self,
         cutoff: usize,
         current_model: &str,
+        soul: Option<&str>,
         vision_enabled: bool,
     ) -> InputParam {
         let prefix = Conversation {
             items: self.items[..cutoff.min(self.items.len())].to_vec(),
-            accumulated_usage: (0, 0),
+            accumulated_usage: (0, 0, 0),
             mutation_version: 0,
         };
-        prefix.to_input_param_with_vision(current_model, None, None, None, vision_enabled)
+        prefix.to_input_param_with_soul(current_model, soul, None, None, None, vision_enabled)
     }
 
     /// Install a compaction boundary at a snapshotted historical cutoff. New
@@ -281,28 +315,31 @@ impl Conversation {
         true
     }
 
-    pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32) {
+    pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32, cached_input_tokens: u32) {
         self.accumulated_usage.0 += input_tokens;
         self.accumulated_usage.1 += output_tokens;
+        self.accumulated_usage.2 += cached_input_tokens;
     }
 
     pub fn usage_summary(&self) -> UsageSummary {
         let mut summary = UsageSummary::default();
         for item in &self.items {
-            if let MessageItem::Usage(input, output) = item {
+            if let MessageItem::Usage(input, output, cached) = item {
                 summary.input_tokens += u64::from(*input);
                 summary.output_tokens += u64::from(*output);
+                summary.cached_input_tokens += u64::from(*cached);
                 summary.turns += 1;
-                summary.last_turn = Some((*input, *output));
+                summary.last_turn = Some((*input, *output, *cached));
             }
         }
 
-        let (input, output) = self.accumulated_usage;
+        let (input, output, cached) = self.accumulated_usage;
         if input > 0 || output > 0 {
             summary.input_tokens += u64::from(input);
             summary.output_tokens += u64::from(output);
+            summary.cached_input_tokens += u64::from(cached);
             summary.turns += 1;
-            summary.last_turn = Some((input, output));
+            summary.last_turn = Some((input, output, cached));
         }
         summary
     }
@@ -311,10 +348,10 @@ impl Conversation {
     /// counter. Returns whether anything was pushed (so a caller can update its
     /// own view state).
     pub fn flush_usage(&mut self) -> bool {
-        let (input, output) = self.accumulated_usage;
+        let (input, output, cached) = self.accumulated_usage;
         if input > 0 || output > 0 {
-            self.items.push(MessageItem::Usage(input, output));
-            self.accumulated_usage = (0, 0);
+            self.items.push(MessageItem::Usage(input, output, cached));
+            self.accumulated_usage = (0, 0, 0);
             true
         } else {
             false
@@ -323,13 +360,13 @@ impl Conversation {
 
     /// Reset the accumulated usage counter (on /clear, new session, etc.).
     pub fn reset_accumulated_usage(&mut self) {
-        self.accumulated_usage = (0, 0);
+        self.accumulated_usage = (0, 0, 0);
     }
 
     /// Clear all conversation history and usage.
     pub fn clear(&mut self) {
         self.items.clear();
-        self.accumulated_usage = (0, 0);
+        self.accumulated_usage = (0, 0, 0);
         self.mutation_version += 1;
     }
 
@@ -341,7 +378,7 @@ impl Conversation {
 
     pub fn truncate(&mut self, cutoff: usize) {
         self.items.truncate(cutoff);
-        self.accumulated_usage = (0, 0);
+        self.accumulated_usage = (0, 0, 0);
         self.mutation_version = self.mutation_version.wrapping_add(1);
     }
 
@@ -375,8 +412,30 @@ impl Conversation {
         coauthor: Option<&str>,
         vision_enabled: bool,
     ) -> InputParam {
+        self.to_input_param_with_soul(
+            current_model,
+            None,
+            skill_prompt,
+            plan_prompt,
+            coauthor,
+            vision_enabled,
+        )
+    }
+
+    /// Build API input with an optional replacement for Programmer's default
+    /// identity and mindset section.
+    pub fn to_input_param_with_soul(
+        &self,
+        current_model: &str,
+        soul: Option<&str>,
+        skill_prompt: Option<&str>,
+        plan_prompt: Option<&str>,
+        coauthor: Option<&str>,
+        vision_enabled: bool,
+    ) -> InputParam {
+        let soul = soul.map(str::trim).unwrap_or(DEFAULT_SOUL);
         let mut system_prompt = format!(
-            "{SYSTEM_PROMPT}\n\nYou are running as model: {current_model}\n\n{}",
+            "{soul}\n\n{SYSTEM_PROMPT}\n\nYou are running as model: {current_model}\n\n{}",
             crate::tools::environment_info()
         );
         if let Some(coauthor) = coauthor.map(str::trim).filter(|c| !c.is_empty()) {
@@ -687,12 +746,32 @@ mod tests {
     }
 
     #[test]
+    fn info_can_be_inserted_at_the_next_turn_boundary() {
+        let mut conv = Conversation::new();
+        conv.add_info_string("older history");
+        let boundary = conv.items.len();
+        conv.add_input_message(user_message("next prompt"));
+
+        conv.insert_info_string(boundary, "compacted context starts here");
+
+        assert!(matches!(
+            &conv.items[boundary],
+            MessageItem::Info(text) if text == "compacted context starts here"
+        ));
+        assert!(matches!(
+            &conv.items[boundary + 1],
+            MessageItem::Input(InputItem::Item(Item::Message(_)))
+        ));
+        assert_eq!(conv.mutation_version, 1);
+    }
+
+    #[test]
     fn compaction_cutoff_keeps_recent_complete_and_active_turns() {
         let mut conv = Conversation::new();
         for turn in 1..=3 {
             conv.add_input_message(user_message(&format!("turn {turn}")));
             conv.add_output(assistant_text(&format!("answer {turn}")));
-            conv.add_usage(10, 2);
+            conv.add_usage(10, 2, 4);
             conv.flush_usage();
         }
         let stable_end = conv.items.len();
@@ -701,7 +780,10 @@ mod tests {
         let cutoff = conv
             .compaction_cutoff_before(1, stable_end)
             .expect("old prefix");
-        assert!(matches!(conv.items[cutoff - 1], MessageItem::Usage(_, _)));
+        assert!(matches!(
+            conv.items[cutoff - 1],
+            MessageItem::Usage(_, _, _)
+        ));
         assert!(
             conv.items[cutoff..]
                 .iter()
@@ -720,6 +802,19 @@ mod tests {
     }
 
     #[test]
+    fn compaction_turn_count_only_includes_the_replaced_prefix() {
+        let mut conv = Conversation::new();
+        for turn in 1..=3 {
+            conv.add_input_message(user_message(&format!("turn {turn}")));
+            conv.add_output(assistant_text(&format!("answer {turn}")));
+        }
+
+        let cutoff = conv.compaction_cutoff(1).expect("old prefix");
+
+        assert_eq!(conv.compaction_turn_count(cutoff), 2);
+    }
+
+    #[test]
     fn compaction_cutoff_does_not_require_provider_usage() {
         let mut conv = Conversation::new();
         for turn in 1..=3 {
@@ -730,7 +825,7 @@ mod tests {
         let cutoff = conv.compaction_cutoff(1).expect("old prefix");
         let prefix = format!(
             "{:?}",
-            conv.input_param_for_prefix(cutoff, "test/model", false)
+            conv.input_param_for_prefix(cutoff, "test/model", None, false)
         );
         assert!(prefix.contains("turn 1"));
         assert!(prefix.contains("turn 2"));
@@ -960,12 +1055,15 @@ mod tests {
     #[test]
     fn usage_accumulates_and_flushes_once() {
         let mut conv = Conversation::new();
-        conv.add_usage(10, 5);
-        conv.add_usage(3, 2);
-        assert_eq!(conv.accumulated_usage, (13, 7));
+        conv.add_usage(10, 5, 4);
+        conv.add_usage(3, 2, 2);
+        assert_eq!(conv.accumulated_usage, (13, 7, 6));
         assert!(conv.flush_usage());
-        assert_eq!(conv.accumulated_usage, (0, 0));
-        assert!(matches!(conv.items.last(), Some(MessageItem::Usage(13, 7))));
+        assert_eq!(conv.accumulated_usage, (0, 0, 0));
+        assert!(matches!(
+            conv.items.last(),
+            Some(MessageItem::Usage(13, 7, 6))
+        ));
         // A second flush with nothing accumulated pushes nothing.
         assert!(!conv.flush_usage());
     }
@@ -973,17 +1071,18 @@ mod tests {
     #[test]
     fn usage_summary_includes_finished_and_current_turns() {
         let mut conv = Conversation::new();
-        conv.add_usage(10, 5);
+        conv.add_usage(10, 5, 4);
         assert!(conv.flush_usage());
-        conv.add_usage(3, 2);
+        conv.add_usage(3, 2, 2);
 
         assert_eq!(
             conv.usage_summary(),
             UsageSummary {
                 input_tokens: 13,
                 output_tokens: 7,
+                cached_input_tokens: 6,
                 turns: 2,
-                last_turn: Some((3, 2)),
+                last_turn: Some((3, 2, 2)),
             }
         );
         assert_eq!(conv.usage_summary().total_tokens(), 20);

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -238,6 +238,7 @@ impl HeadlessAgent {
             security,
             mcp_manager: None,
             policy: child_policy,
+            soul: config.soul.clone(),
             coauthor: config.git_coauthor.clone(),
             vision_enabled: false,
             thinking_level: args.thinking,
@@ -270,6 +271,7 @@ impl HeadlessAgent {
             model_str: model.clone(),
             tools,
             policy,
+            soul: config.soul,
             coauthor: config.git_coauthor,
             vision_enabled: false,
             thinking_level: args.thinking,
@@ -500,6 +502,7 @@ struct AgentResult<'a> {
 struct Usage {
     input_tokens: u32,
     output_tokens: u32,
+    cached_input_tokens: u32,
 }
 
 fn emit_agent_result(
@@ -515,6 +518,7 @@ fn emit_agent_result(
         usage: Usage {
             input_tokens: result.usage.0,
             output_tokens: result.usage.1,
+            cached_input_tokens: result.usage.2,
         },
         check,
         passed: check.is_none_or(|report| report.passed),

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -15,7 +15,8 @@
 
 //! Centralised prompt texts shared across the codebase.
 //!
-//! * [`SYSTEM_PROMPT`] — the main developer message sent to the agent on every turn.
+//! * [`DEFAULT_SOUL`] — Programmer's default identity and mindset.
+//! * [`SYSTEM_PROMPT`] — the identity-independent developer instructions sent on every turn.
 //! * [`CLASSIFIER_INSTRUCTIONS`] — instructions for the Auto-mode classifier LLM.
 //! * [`PLAN_PLANNING_PROMPT`] — injected during Plan → Planning phase.
 
@@ -23,7 +24,7 @@
 // Main system prompt
 // ---------------------------------------------------------------------------
 
-pub(crate) const SYSTEM_PROMPT: &str = r#"You are "programmer", a coding agent written in Rust, operating in the user's
+pub(crate) const DEFAULT_SOUL: &str = r#"You are "programmer", a coding agent written in Rust, operating in the user's
 terminal. You help with software engineering tasks: writing code, fixing bugs,
 refactoring, explaining code, and running commands.
 
@@ -39,9 +40,9 @@ refactoring, explaining code, and running commands.
   first, so the user has a chance to steer.
 - When you disagree with a request (it is dangerous, it will break something, it
   goes against the project's conventions), say so politely, explain why, and
-  offer an alternative.
+  offer an alternative."#;
 
-# Environment
+pub(crate) const SYSTEM_PROMPT: &str = r#"# Environment
 
 You operate inside the user's project directory. You can read files, edit files,
 and execute shell commands through the tools provided to you. The user sees your
@@ -213,6 +214,16 @@ You are in **Plan Mode**. You must NOT make any changes yet.
    choose how to execute the plan.
 
 Your response should end with a complete plan — not with a tool call.";
+
+// ---------------------------------------------------------------------------
+// Session titles
+// ---------------------------------------------------------------------------
+
+pub(crate) const SESSION_TITLE_PROMPT: &str = "\
+Write a concise title for this programming conversation based on its first \
+message. Use the same language as the message when practical. Keep it under \
+50 characters, do not end with punctuation, and output only the title with no \
+quotes or explanation.\n\nFirst message:\n";
 
 // ---------------------------------------------------------------------------
 // /compact — context compaction

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -324,11 +324,13 @@ mod tests {
             },
         );
         let config = ProgrammerConfig {
+            soul: None,
             default_provider: "offline".to_string(),
             providers,
             classifier_model: None,
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             compact_model: None,
+            title_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
             memory: Default::default(),

--- a/src/response/message_item.rs
+++ b/src/response/message_item.rs
@@ -41,7 +41,7 @@ pub enum MessageItem {
         label: String,
         text: String,
     },
-    Usage(u32, u32), // (input_tokens, output_tokens)
+    Usage(u32, u32, u32), // (input_tokens, output_tokens, cached_input_tokens)
     /// A `/compact` boundary: everything before this item was summarized into
     /// `summary`, which is sent to the model in place of that history. The
     /// older items stay in the list for the UI scrollback but are no longer
@@ -73,7 +73,7 @@ impl Clone for MessageItem {
                 label: label.clone(),
                 text: text.clone(),
             },
-            MessageItem::Usage(i, o) => MessageItem::Usage(*i, *o),
+            MessageItem::Usage(i, o, cached) => MessageItem::Usage(*i, *o, *cached),
             MessageItem::Compacted { summary } => MessageItem::Compacted {
                 summary: summary.clone(),
             },

--- a/src/response/partial_response.rs
+++ b/src/response/partial_response.rs
@@ -71,8 +71,9 @@ pub struct PartialResponse {
     finish_reason: Option<ResponseFinishReason>,
     /// Cancelled when the user presses Escape to stop the current request.
     pub cancelled: CancellationToken,
-    /// Token usage from the completed response: (input_tokens, output_tokens).
-    pub usage: Option<(u32, u32)>,
+    /// Token usage from the completed response:
+    /// (input_tokens, output_tokens, cached_input_tokens).
+    pub usage: Option<(u32, u32, u32)>,
     /// Monotonically changes whenever another stream event is folded into this
     /// response. The TUI uses it to reuse an unchanged live tool-group layout
     /// across animation/timer frames without hashing or cloning the full text.
@@ -569,7 +570,11 @@ impl PartialResponse {
             ResponseCompleted(response_completed_event) => {
                 self.mark_all_finished();
                 if let Some(ref u) = response_completed_event.response.usage {
-                    self.usage = Some((u.input_tokens, u.output_tokens));
+                    self.usage = Some((
+                        u.input_tokens,
+                        u.output_tokens,
+                        u.input_tokens_details.cached_tokens,
+                    ));
                 }
                 self.finish_reason = Some(ResponseFinishReason::Completed(
                     response_completed_event.response,
@@ -578,7 +583,11 @@ impl PartialResponse {
             ResponseFailed(response_failed_event) => {
                 self.mark_all_finished();
                 if let Some(ref u) = response_failed_event.response.usage {
-                    self.usage = Some((u.input_tokens, u.output_tokens));
+                    self.usage = Some((
+                        u.input_tokens,
+                        u.output_tokens,
+                        u.input_tokens_details.cached_tokens,
+                    ));
                 }
                 self.finish_reason =
                     Some(ResponseFinishReason::Failed(response_failed_event.response));
@@ -586,7 +595,11 @@ impl PartialResponse {
             ResponseIncomplete(response_incomplete_event) => {
                 self.mark_all_finished();
                 if let Some(ref u) = response_incomplete_event.response.usage {
-                    self.usage = Some((u.input_tokens, u.output_tokens));
+                    self.usage = Some((
+                        u.input_tokens,
+                        u.output_tokens,
+                        u.input_tokens_details.cached_tokens,
+                    ));
                 }
                 self.finish_reason = Some(ResponseFinishReason::Incomplete(
                     response_incomplete_event.response,
@@ -862,13 +875,21 @@ mod tests {
                         "model": "test",
                         "object": "response",
                         "output": [],
-                        "status": "completed"
+                        "status": "completed",
+                        "usage": {
+                            "input_tokens": 100,
+                            "input_tokens_details": { "cached_tokens": 64 },
+                            "output_tokens": 20,
+                            "output_tokens_details": { "reasoning_tokens": 0 },
+                            "total_tokens": 120
+                        }
                     }))
                     .unwrap(),
                 },
             ),
         );
         assert!(!p.get_message_items()[0].1);
+        assert_eq!(p.usage, Some((100, 20, 64)));
         assert!(p.item_render_revision() > before);
     }
 }

--- a/src/runner/classify.rs
+++ b/src/runner/classify.rs
@@ -347,7 +347,7 @@ pub(crate) fn build_classifier_context(items: &[&MessageItem]) -> (String, Strin
             MessageItem::Meta { label, text } => {
                 full_ctx.push(format!("\n[{label}]\n{text}"));
             }
-            MessageItem::Usage(_, _) => {
+            MessageItem::Usage(_, _, _) => {
                 // Token usage counters — not useful for classification.
             }
             MessageItem::Compacted { summary } => {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -85,6 +85,7 @@ pub(crate) struct TurnRunner {
     /// read-only / interaction metadata, and call routing.
     pub tools: Arc<crate::tools::provider::ToolRegistry>,
     pub policy: RunnerPolicy,
+    pub soul: Option<String>,
     pub coauthor: Option<String>,
     /// Include stored image parts in API requests. When false, the conversation
     /// preserves them but sends textual placeholders instead.
@@ -121,7 +122,7 @@ pub(crate) struct DiagnosticsState {
 pub struct TurnResult {
     pub final_text: String,
     #[allow(dead_code)]
-    pub usage: (u32, u32),
+    pub usage: (u32, u32, u32),
 }
 
 /// Why a turn could not complete.
@@ -260,6 +261,7 @@ impl TurnRunner {
             let req = {
                 let ctx = request::SystemContext {
                     current_model: &self.model_str,
+                    soul: self.soul.as_deref(),
                     skill_prompt: skill_prompt.as_deref(),
                     plan_prompt: surface.plan_prompt(),
                     coauthor: self.coauthor.as_deref(),
@@ -321,8 +323,8 @@ impl TurnRunner {
                 for item in items {
                     conv.add_output(item);
                 }
-                if let Some((input, output)) = usage {
-                    conv.add_usage(input, output);
+                if let Some((input, output, cached)) = usage {
+                    conv.add_usage(input, output, cached);
                 }
             }
             // Committed to the shared conversation: tell a live renderer to drop
@@ -335,7 +337,7 @@ impl TurnRunner {
 
             // ---- no tool calls → the turn is done ----
             if calls.is_empty() {
-                if let Some((input_tokens, _)) = usage {
+                if let Some((input_tokens, _, _)) = usage {
                     surface.on_event(RunnerEvent::UsageSafePoint { input_tokens });
                 }
                 let usage = conversation.lock().unwrap().accumulated_usage;
@@ -412,7 +414,7 @@ impl TurnRunner {
                         )
                         .await;
                     }
-                    if let Some((input_tokens, _)) = usage {
+                    if let Some((input_tokens, _, _)) = usage {
                         surface.on_event(RunnerEvent::UsageSafePoint { input_tokens });
                     }
                 }
@@ -753,6 +755,7 @@ mod tests {
                 std::sync::Arc::new(crate::tools::provider::LocalToolProvider::default()),
             ])),
             policy: RunnerPolicy::Yolo,
+            soul: None,
             coauthor: None,
             vision_enabled: true,
             thinking_level: crate::thinking::ThinkingLevel::Auto,
@@ -1024,6 +1027,7 @@ mod tests {
                 std::sync::Arc::new(crate::tools::provider::LocalToolProvider::default()),
             ])),
             policy: RunnerPolicy::Sync(policy_mode.classifier()),
+            soul: None,
             coauthor: None,
             vision_enabled: true,
             thinking_level: crate::thinking::ThinkingLevel::Auto,

--- a/src/runner/request.rs
+++ b/src/runner/request.rs
@@ -25,6 +25,8 @@ use async_openai::types::responses::{CreateResponse, Tool};
 pub(crate) struct SystemContext<'a> {
     /// The active `provider/model`, named in the system prompt banner.
     pub current_model: &'a str,
+    /// Optional replacement for Programmer's built-in identity and mindset.
+    pub soul: Option<&'a str>,
     /// Combined instructions from active skills, if any.
     pub skill_prompt: Option<&'a str>,
     /// Plan-mode instructions, computed by the TUI; the runner passes `None`.
@@ -45,8 +47,9 @@ pub(crate) fn build_request(
     model_name: String,
     tools: Vec<Tool>,
 ) -> CreateResponse {
-    let input = conversation.to_input_param_with_vision(
+    let input = conversation.to_input_param_with_soul(
         ctx.current_model,
+        ctx.soul,
         ctx.skill_prompt,
         ctx.plan_prompt,
         ctx.coauthor,
@@ -81,6 +84,7 @@ mod tests {
 
         let ctx = SystemContext {
             current_model: "prov/model-x",
+            soul: Some("CUSTOM-SOUL-MARKER"),
             skill_prompt: Some("SKILL-PROMPT-MARKER"),
             plan_prompt: None,
             coauthor: Some("Ada <ada@example.com>"),
@@ -117,6 +121,11 @@ mod tests {
             _ => panic!("developer message should be text"),
         };
         assert!(dev_text.contains("prov/model-x"), "model banner");
+        assert!(dev_text.contains("CUSTOM-SOUL-MARKER"), "custom soul");
+        assert!(
+            !dev_text.contains("You are a collaborator"),
+            "default soul replaced"
+        );
         assert!(
             dev_text.contains("SKILL-PROMPT-MARKER"),
             "skill prompt appended"

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -73,6 +73,8 @@ pub(crate) enum SerializableMessageItem {
     Usage {
         input_tokens: u32,
         output_tokens: u32,
+        #[serde(default)]
+        cached_input_tokens: u32,
     },
     /// A `/compact` boundary carrying the summary of everything before it.
     Compacted {
@@ -101,9 +103,10 @@ impl From<MessageItem> for SerializableMessageItem {
             MessageItem::Warning(s) => SerializableMessageItem::Warning(s),
             MessageItem::Info(s) => SerializableMessageItem::Info(s),
             MessageItem::Meta { label, text } => SerializableMessageItem::Meta { label, text },
-            MessageItem::Usage(i, o) => SerializableMessageItem::Usage {
+            MessageItem::Usage(i, o, cached) => SerializableMessageItem::Usage {
                 input_tokens: i,
                 output_tokens: o,
+                cached_input_tokens: cached,
             },
             MessageItem::Compacted { summary } => SerializableMessageItem::Compacted { summary },
         }
@@ -151,7 +154,8 @@ impl From<SerializableMessageItem> for MessageItem {
             SerializableMessageItem::Usage {
                 input_tokens,
                 output_tokens,
-            } => MessageItem::Usage(input_tokens, output_tokens),
+                cached_input_tokens,
+            } => MessageItem::Usage(input_tokens, output_tokens, cached_input_tokens),
             SerializableMessageItem::Compacted { summary } => MessageItem::Compacted { summary },
         }
     }
@@ -165,6 +169,9 @@ impl From<SerializableMessageItem> for MessageItem {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct SessionMeta {
     pub(crate) uuid: String,
+    /// Model-generated title. Empty for legacy or not-yet-titled sessions.
+    #[serde(default)]
+    pub(crate) title: String,
     /// Truncated first user message for preview.
     pub(crate) first_message: String,
     pub(crate) created_at: u64,
@@ -178,6 +185,8 @@ pub(crate) struct SessionMeta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Session {
     pub(crate) uuid: String,
+    #[serde(default)]
+    pub(crate) title: String,
     pub(crate) first_message: String,
     pub(crate) created_at: u64,
     pub(crate) updated_at: u64,
@@ -278,6 +287,7 @@ impl SessionManager {
             std::env::current_dir().map_or_else(|_| ".".to_string(), |p| p.display().to_string());
         Session {
             uuid,
+            title: String::new(),
             first_message: String::new(),
             created_at: now,
             updated_at: now,
@@ -382,13 +392,19 @@ fn sessions_for_working_dir(sessions: &[SessionMeta], working_dir: &Path) -> Vec
         .collect()
 }
 
+const PICKER_QUIT_CONFIRM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+fn picker_quit_is_confirmed(previous: Option<std::time::Instant>, now: std::time::Instant) -> bool {
+    previous.is_some_and(|pressed_at| now.duration_since(pressed_at) <= PICKER_QUIT_CONFIRM_TIMEOUT)
+}
+
 /// Show a ratatui TUI list of sessions and let the user pick one with arrow keys.
 /// Runs its own terminal setup/teardown; the main app will re-init the terminal.
 /// Returns the chosen UUID, or `None` if the user chose "new session".
 /// On quit (q / Esc) the process exits after cleanup.
 /// Press `d` on a session to delete it after confirmation.
 pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Option<String> {
-    use crossterm::event::{self, Event as CEvent, KeyCode, KeyEventKind};
+    use crossterm::event::{self, Event as CEvent, KeyCode, KeyEventKind, KeyModifiers};
     use crossterm::execute;
     use crossterm::terminal::{
         EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -431,6 +447,7 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
 
         // Confirmation state: when set, shows a confirmation overlay.
         let mut confirm_uuid: Option<String> = None;
+        let mut quit_requested_at: Option<std::time::Instant> = None;
 
         let result = loop {
             let _ = terminal.draw(|f: &mut Frame| {
@@ -491,10 +508,12 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
                 let items: Vec<ListItem> = sessions
                     .iter()
                     .map(|s| {
-                        let preview = if s.first_message.is_empty() {
-                            "(empty)".to_string()
-                        } else {
+                        let preview = if !s.title.is_empty() {
+                            truncate_first_line(&s.title, 60)
+                        } else if !s.first_message.is_empty() {
                             truncate_first_line(&s.first_message, 60)
+                        } else {
+                            "(empty)".to_string()
                         };
                         let time_str = unix_to_local(s.updated_at);
                         let short_uuid = &s.uuid[..8.min(s.uuid.len())];
@@ -534,7 +553,13 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
                 f.render_stateful_widget(list, chunks[1], &mut list_state);
 
                 // -- Help bar (or confirmation prompt) --
-                if let Some(ref uuid) = confirm_uuid {
+                if quit_requested_at.is_some() {
+                    let warning = Span::styled(
+                        " Press Ctrl+C again within 2 seconds to exit.",
+                        Style::default().fg(Color::Yellow).bold(),
+                    );
+                    f.render_widget(Paragraph::new(warning), chunks[2]);
+                } else if let Some(ref uuid) = confirm_uuid {
                     let short = &uuid[..8.min(uuid.len())];
                     let confirm = Line::from(vec![
                         Span::styled(
@@ -571,6 +596,21 @@ pub(crate) fn pick_session(sessions: &[SessionMeta], mgr: &SessionManager) -> Op
             };
             if key.kind != KeyEventKind::Press {
                 continue;
+            }
+
+            let now = std::time::Instant::now();
+            if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                if picker_quit_is_confirmed(quit_requested_at, now) {
+                    break Outcome::Quit;
+                }
+                quit_requested_at = Some(now);
+                confirm_uuid = None;
+                continue;
+            }
+            if quit_requested_at.is_some_and(|pressed_at| {
+                now.duration_since(pressed_at) > PICKER_QUIT_CONFIRM_TIMEOUT
+            }) {
+                quit_requested_at = None;
             }
 
             // ---- confirmation mode ----
@@ -737,6 +777,7 @@ mod tests {
         let sessions = vec![
             SessionMeta {
                 uuid: "matching".to_string(),
+                title: String::new(),
                 first_message: String::new(),
                 created_at: 0,
                 updated_at: 2,
@@ -745,6 +786,7 @@ mod tests {
             },
             SessionMeta {
                 uuid: "other".to_string(),
+                title: String::new(),
                 first_message: String::new(),
                 created_at: 0,
                 updated_at: 1,
@@ -763,12 +805,27 @@ mod tests {
     }
 
     #[test]
+    fn picker_requires_two_ctrl_c_presses_within_timeout() {
+        let now = std::time::Instant::now();
+        assert!(!picker_quit_is_confirmed(None, now));
+        assert!(picker_quit_is_confirmed(
+            Some(now - std::time::Duration::from_secs(1)),
+            now
+        ));
+        assert!(!picker_quit_is_confirmed(
+            Some(now - std::time::Duration::from_secs(3)),
+            now
+        ));
+    }
+
+    #[test]
     fn working_directory_filter_preserves_newest_first_order() {
         let current = std::env::temp_dir().join("programmer-project");
         let sessions = ["newest", "older"]
             .into_iter()
             .map(|uuid| SessionMeta {
                 uuid: uuid.to_string(),
+                title: String::new(),
                 first_message: String::new(),
                 created_at: 0,
                 updated_at: 0,
@@ -802,6 +859,23 @@ mod tests {
 
         let loaded: Session = serde_json::from_value(value).unwrap();
         assert_eq!(loaded.thinking_level, crate::thinking::ThinkingLevel::Auto);
+    }
+
+    #[test]
+    fn older_usage_items_default_cached_tokens_to_zero() {
+        let item: SerializableMessageItem = serde_json::from_value(serde_json::json!({
+            "variant": "Usage",
+            "payload": {
+                "input_tokens": 10,
+                "output_tokens": 2
+            }
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            MessageItem::from(item),
+            MessageItem::Usage(10, 2, 0)
+        ));
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -991,6 +991,14 @@ impl ConversationPanel {
         self.stick_to_bottom = true;
     }
 
+    pub fn insert_info_string(&mut self, index: usize, message: impl Into<String>) {
+        self.conversation
+            .lock()
+            .unwrap()
+            .insert_info_string(index, message);
+        self.stick_to_bottom = true;
+    }
+
     pub fn add_meta(&mut self, label: impl Into<String>, text: impl Into<String>) {
         self.conversation.lock().unwrap().add_meta(label, text);
         self.stick_to_bottom = true;
@@ -1058,15 +1066,24 @@ impl ConversationPanel {
             .compaction_cutoff_before(keep_recent_turns, stable_end)
     }
 
+    pub fn compaction_turn_count(&self, cutoff: usize) -> usize {
+        self.conversation
+            .lock()
+            .unwrap()
+            .compaction_turn_count(cutoff)
+    }
+
     pub fn input_param_for_prefix(
         &self,
         cutoff: usize,
         current_model: &str,
+        soul: Option<&str>,
         vision_enabled: bool,
     ) -> InputParam {
         self.conversation.lock().unwrap().input_param_for_prefix(
             cutoff,
             current_model,
+            soul,
             vision_enabled,
         )
     }
@@ -1088,11 +1105,12 @@ impl ConversationPanel {
         applied
     }
 
-    pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32) {
-        self.conversation
-            .lock()
-            .unwrap()
-            .add_usage(input_tokens, output_tokens);
+    pub fn add_usage(&mut self, input_tokens: u32, output_tokens: u32, cached_input_tokens: u32) {
+        self.conversation.lock().unwrap().add_usage(
+            input_tokens,
+            output_tokens,
+            cached_input_tokens,
+        );
     }
 
     /// Flush the accumulated usage as a message and reset the counter.
@@ -1797,7 +1815,7 @@ mod tests {
         (&mut panel).render(area, &mut Buffer::empty(area));
         let before = panel.scroll_view_state.offset().y;
 
-        panel.add_usage(13, 7);
+        panel.add_usage(13, 7, 5);
         panel.flush_usage();
         (&mut panel).render(area, &mut Buffer::empty(area));
 

--- a/src/ui/components/conversation_panel/tool_group.rs
+++ b/src/ui/components/conversation_panel/tool_group.rs
@@ -31,7 +31,9 @@
 //! [`MIN_TOOL_GROUP_SIZE`] threshold so short, finished sequences stay easy to
 //! scan as ordinary calls.
 
-use async_openai::types::responses::{FunctionCallOutputItemParam, FunctionToolCall, OutputItem};
+use async_openai::types::responses::{
+    FunctionCallOutput, FunctionCallOutputItemParam, FunctionToolCall, OutputItem,
+};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::Wrap;
@@ -396,18 +398,78 @@ impl ToolGroup {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn title(&self, completed: usize, failed: usize) -> String {
+        self.title_with_members(&[], completed, failed)
+    }
+
+    fn title_with_members(
+        &self,
+        members: &[ToolGroupMember<'_>],
+        completed: usize,
+        failed: usize,
+    ) -> String {
         let total = self.member_indices.len();
+        let purpose = todo_purpose(members);
         let mut title = if completed < total {
-            format!("{}… · {completed}/{total}", self.kind.active_title())
+            format!("{}…", self.kind.active_title())
         } else {
-            self.kind.completed_title().to_string()
+            self.kind.completed_title()
         };
+        if let Some(purpose) = purpose {
+            title.push_str(" · ");
+            title.push_str(&purpose);
+        }
+        if completed < total {
+            title.push_str(&format!(" · {completed}/{total}"));
+        }
         if failed > 0 {
             title.push_str(&format!(" · {failed} failed"));
         }
         title
     }
+}
+
+/// A todo mutation names the task that the surrounding run of tools is serving.
+/// Prefer the title supplied in call arguments, then recover it from the update
+/// result (updates commonly carry only an id and status).
+fn todo_purpose(members: &[ToolGroupMember<'_>]) -> Option<String> {
+    members.iter().rev().find_map(|member| {
+        if member.call.name != crate::tools::todo::NAME {
+            return None;
+        }
+        let arguments: serde_json::Value = serde_json::from_str(&member.call.arguments).ok()?;
+        match arguments.get("action")?.as_str()? {
+            "add" | "update" => {}
+            _ => return None,
+        }
+        if let Some(title) = arguments.get("title").and_then(|value| value.as_str()) {
+            return clean_todo_purpose(title);
+        }
+        let (output, failed, _) = member.output?;
+        if failed {
+            return None;
+        }
+        let FunctionCallOutput::Text(text) = &output.output else {
+            return None;
+        };
+        let encoded = text.split_once("title=")?.1.split_once(" status=")?.0;
+        serde_json::from_str::<String>(encoded)
+            .ok()
+            .and_then(|title| clean_todo_purpose(&title))
+    })
+}
+
+fn clean_todo_purpose(title: &str) -> Option<String> {
+    let title = title.trim();
+    if title.is_empty() {
+        return None;
+    }
+    let mut shortened = title.chars().take(60).collect::<String>();
+    if title.chars().count() > 60 {
+        shortened.push('…');
+    }
+    Some(shortened)
 }
 
 impl ToolGroupKind {
@@ -508,7 +570,10 @@ pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
     let mut lines = vec![Line::from(vec![
         Span::styled(format!("{arrow} "), muted),
         Span::styled(
-            format!("\u{1F6E0} {}", group.title(completed, failed)),
+            format!(
+                "\u{1F6E0} {}",
+                group.title_with_members(members, completed, failed)
+            ),
             Style::new().fg(color).add_modifier(Modifier::BOLD),
         ),
     ])];
@@ -896,6 +961,45 @@ mod tests {
 
         assert_eq!(group.title(1, 0), "Implementing… · 1/3");
         assert_eq!(group.title(3, 1), "Implemented · 1 failed");
+    }
+
+    #[test]
+    fn todo_change_describes_the_surrounding_tool_run() {
+        let call = FunctionToolCall {
+            arguments: r#"{"action":"update","id":"abc","status":"in_progress"}"#.into(),
+            call_id: "todo-call".into(),
+            namespace: None,
+            name: crate::tools::todo::NAME.into(),
+            id: None,
+            status: None,
+        };
+        let output = FunctionCallOutputItemParam {
+            call_id: "todo-call".into(),
+            output: FunctionCallOutput::Text(
+                "updated todo abc: title=\"Add session titles\" status=in progress".into(),
+            ),
+            id: None,
+            status: None,
+        };
+        let members = [ToolGroupMember {
+            index: 0,
+            call: &call,
+            output: Some((&output, false, None)),
+            live_output: None,
+            expanded: false,
+        }];
+        let group = ToolGroup {
+            key: "todo-call".into(),
+            member_indices: vec![0, 1, 2],
+            absorbed: Vec::new(),
+            open: false,
+            kind: ToolGroupKind::General,
+        };
+
+        assert_eq!(
+            group.title_with_members(&members, 3, 0),
+            "Used tools · Add session titles"
+        );
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -79,7 +79,7 @@ fn estimate_item_height(item: &MessageItem, width: u16) -> u16 {
         | MessageItem::Warning(_)
         | MessageItem::Info(_) => 1,
         MessageItem::Meta { .. } => 1,
-        MessageItem::Usage(_, _) => 1,
+        MessageItem::Usage(_, _, _) => 1,
         // Usually collapsed to its one-line divider (like Reasoning, the
         // estimate ignores the expanded state — the real height comes from the
         // built paragraph).
@@ -531,8 +531,8 @@ fn build_item_paragraph(
             WarningMessage::new(message.clone()).into_paragraph(),
             Vec::new(),
         ),
-        MessageItem::Usage(input, output) => (
-            UsageMessage::new(*input, *output).into_paragraph(),
+        MessageItem::Usage(input, output, cached) => (
+            UsageMessage::new(*input, *output, *cached).into_paragraph(),
             Vec::new(),
         ),
         MessageItem::Compacted { summary } => {

--- a/src/ui/components/input_panel/input_panel.rs
+++ b/src/ui/components/input_panel/input_panel.rs
@@ -33,6 +33,9 @@ pub struct InputPanel<'a> {
     /// Clipboard images associated with placeholders still present in the draft.
     images: Vec<(String, InputImageContent)>,
     next_image_id: usize,
+    /// Details shown in the title until the next model turn consumes a freshly
+    /// compacted context.
+    pub(crate) next_turn_compaction: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,7 +68,20 @@ impl InputPanel<'_> {
             pastes: Vec::new(),
             images: Vec::new(),
             next_image_id: 1,
+            next_turn_compaction: None,
         }
+    }
+
+    pub(crate) fn show_next_turn_compaction(&mut self, details: String) {
+        self.next_turn_compaction = Some(details);
+    }
+
+    pub(crate) fn clear_next_turn_compaction(&mut self) {
+        self.next_turn_compaction = None;
+    }
+
+    pub(crate) fn take_next_turn_compaction(&mut self) -> Option<String> {
+        self.next_turn_compaction.take()
     }
 
     pub fn get_content(&self) -> String {

--- a/src/ui/components/input_panel/ui.rs
+++ b/src/ui/components/input_panel/ui.rs
@@ -32,12 +32,16 @@ impl Widget for &InputPanel<'_> {
         let bang = self.get_content().starts_with('!');
         let (title, accent, prompt) = if bang {
             (
-                " ! Shell — runs in the interactive terminal ",
+                " ! Shell — runs in the interactive terminal ".to_string(),
                 BANG_ACCENT,
                 "$ ",
             )
         } else {
-            (" Input ", ACCENT, "❯ ")
+            let title = self.next_turn_compaction.as_ref().map_or_else(
+                || " Input ".to_string(),
+                |details| format!(" Input — next turn uses compacted context · {details} "),
+            );
+            (title, ACCENT, "❯ ")
         };
 
         let block = Block::default()
@@ -93,7 +97,7 @@ mod tests {
     use super::*;
 
     fn render_to_text(panel: &InputPanel<'_>) -> String {
-        let area = Rect::new(0, 0, 60, 5);
+        let area = Rect::new(0, 0, 100, 5);
         let mut buf = Buffer::empty(area);
         panel.render(area, &mut buf);
         (0..area.height)
@@ -122,6 +126,20 @@ mod tests {
         panel.set_content("cargo test");
         let back = render_to_text(&panel);
         assert!(back.contains(" Input "), "back to normal: {back}");
+    }
+
+    #[test]
+    fn compacted_context_is_announced_for_the_next_turn() {
+        let mut panel = InputPanel::new();
+        panel.show_next_turn_compaction("3 turns, 120000→4000 tokens".to_string());
+
+        let rendered = render_to_text(&panel);
+
+        assert!(
+            rendered
+                .contains("Input — next turn uses compacted context · 3 turns, 120000→4000 tokens"),
+            "compaction title: {rendered}"
+        );
     }
 
     #[test]

--- a/src/ui/components/logo/mod.rs
+++ b/src/ui/components/logo/mod.rs
@@ -20,18 +20,20 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::Paragraph;
 
-pub struct Logo {}
+pub struct Logo<'a> {
+    title: &'a str,
+}
 
-impl Logo {
-    pub fn new() -> Self {
-        Logo {}
+impl<'a> Logo<'a> {
+    pub fn new(title: &'a str) -> Self {
+        Logo { title }
     }
 }
 
-impl Widget for Logo {
+impl Widget for Logo<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let title = Line::styled(
-            "Programmer",
+            self.title,
             Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
@@ -43,5 +45,24 @@ impl Widget for Logo {
         Paragraph::new(vec![title, separator])
             .centered()
             .render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_the_supplied_session_title() {
+        let area = Rect::new(0, 0, 30, 2);
+        let mut buffer = Buffer::empty(area);
+
+        Logo::new("Fix session header").render(area, &mut buffer);
+
+        let first_line = (0..area.width)
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect::<String>();
+        assert!(first_line.contains("Fix session header"));
+        assert!(!first_line.contains("Programmer"));
     }
 }

--- a/src/ui/components/messages/assistant/tool_call.rs
+++ b/src/ui/components/messages/assistant/tool_call.rs
@@ -241,17 +241,21 @@ fn background_hint() -> Line<'static> {
 /// Lines of live command output shown while a running call is collapsed.
 const LIVE_TAIL_LINES: usize = 8;
 
-/// Append a running command's output to `lines`, each row dimmed and marked
-/// with the result gutter. Collapsed calls pass a line limit and get a leading
-/// `⋯` when earlier rows are hidden; expanded calls pass `None` to show all
-/// output retained by the task.
+/// Append a running command's output to `lines`, marked with the result gutter.
+/// Collapsed calls pass a line limit and render a dim tail (with a leading `⋯`
+/// when earlier rows are hidden); expanded calls pass `None` and use the normal
+/// detail style so the full output remains readable.
 fn push_live_output(
     lines: &mut Vec<Line<'static>>,
     live: &str,
     muted: Style,
     tail_lines: Option<usize>,
 ) {
-    let dim = muted.add_modifier(Modifier::DIM);
+    let output_style = if tail_lines.is_some() {
+        muted.add_modifier(Modifier::DIM)
+    } else {
+        detail_style()
+    };
     let all: Vec<&str> = live.lines().collect();
     // A trailing newline yields no final empty entry from `.lines()`, so this is
     // simply every non-terminated line the command has produced so far.
@@ -263,10 +267,16 @@ fn push_live_output(
         .map(|limit| all.len().saturating_sub(limit))
         .unwrap_or(0);
     if start > 0 {
-        lines.push(Line::from(Span::styled("  \u{23BF} \u{22EF}", dim)));
+        lines.push(Line::from(Span::styled(
+            "  \u{23BF} \u{22EF}",
+            output_style,
+        )));
     }
     for line in &all[start..] {
-        lines.push(Line::from(Span::styled(format!("  \u{23BF} {line}"), dim)));
+        lines.push(Line::from(Span::styled(
+            format!("  \u{23BF} {line}"),
+            output_style,
+        )));
     }
 }
 
@@ -483,6 +493,21 @@ mod tests {
     fn command_background_hint_shows_the_shortcut() {
         let hint = plain(&[background_hint()]);
         assert_eq!(hint, ["  Ctrl+Z move to background"]);
+    }
+
+    #[test]
+    fn expanded_live_command_output_uses_readable_detail_style() {
+        let mut lines = Vec::new();
+        push_live_output(
+            &mut lines,
+            "visible output",
+            Style::new().fg(palette::MUTED),
+            None,
+        );
+
+        let style = lines[0].spans[0].style;
+        assert_eq!(style.fg, detail_style().fg);
+        assert!(!style.add_modifier.contains(Modifier::DIM));
     }
 
     #[test]

--- a/src/ui/components/messages/usage_message.rs
+++ b/src/ui/components/messages/usage_message.rs
@@ -23,18 +23,24 @@ use crate::ui::markdown_theme::palette;
 pub struct UsageMessage {
     input_tokens: u32,
     output_tokens: u32,
+    cached_input_tokens: u32,
 }
 
 impl UsageMessage {
-    pub fn new(input_tokens: u32, output_tokens: u32) -> Self {
+    pub fn new(input_tokens: u32, output_tokens: u32, cached_input_tokens: u32) -> Self {
         Self {
             input_tokens,
             output_tokens,
+            cached_input_tokens,
         }
     }
 
     pub fn into_paragraph(self) -> Paragraph<'static> {
         let total = self.input_tokens + self.output_tokens;
+        let cached_percent = u64::from(self.cached_input_tokens)
+            .saturating_mul(100)
+            .checked_div(u64::from(self.input_tokens))
+            .unwrap_or(0);
 
         Paragraph::new(Line::from(vec![
             Span::styled("↳  ", Style::new().fg(palette::FAINT)),
@@ -43,6 +49,15 @@ impl UsageMessage {
                 Style::new().fg(palette::CYAN),
             ),
             Span::styled(" input", Style::new().fg(palette::MUTED)),
+            Span::styled("  ·  ", Style::new().fg(palette::FAINT)),
+            Span::styled(
+                self.cached_input_tokens.to_string(),
+                Style::new().fg(palette::CYAN),
+            ),
+            Span::styled(
+                format!(" cached ({cached_percent}%)"),
+                Style::new().fg(palette::MUTED),
+            ),
             Span::styled("  ·  ", Style::new().fg(palette::FAINT)),
             Span::styled(
                 self.output_tokens.to_string(),
@@ -66,9 +81,9 @@ mod tests {
 
     #[test]
     fn usage_is_a_compact_borderless_summary() {
-        let area = Rect::new(0, 0, 60, 1);
+        let area = Rect::new(0, 0, 80, 1);
         let mut buffer = Buffer::empty(area);
-        UsageMessage::new(13, 7)
+        UsageMessage::new(13, 7, 5)
             .into_paragraph()
             .render(area, &mut buffer);
 
@@ -77,7 +92,9 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
 
-        assert!(rendered.starts_with("↳  13 input  ·  7 output  ·  20 total tokens"));
+        assert!(
+            rendered.starts_with("↳  13 input  ·  5 cached (38%)  ·  7 output  ·  20 total tokens")
+        );
         assert!(!rendered.contains('│'));
     }
 }

--- a/src/ui/components/provider_panel/mod.rs
+++ b/src/ui/components/provider_panel/mod.rs
@@ -273,6 +273,13 @@ impl ProviderPanel {
                 {
                     config.compact_model = None;
                 }
+                if config
+                    .title_model
+                    .as_deref()
+                    .is_some_and(|model| model.starts_with(&format!("{name}/")))
+                {
+                    config.title_model = None;
+                }
                 // Keep default_provider pointing at something that exists.
                 if config.default_provider == name {
                     config.default_provider = Self::sorted_names(config)
@@ -440,6 +447,7 @@ impl ProviderPanel {
                     }
                     rename_global_model_provider(&mut config.classifier_model, original, &name);
                     rename_global_model_provider(&mut config.compact_model, original, &name);
+                    rename_global_model_provider(&mut config.title_model, original, &name);
                 }
                 config.providers.insert(
                     name.clone(),
@@ -579,7 +587,7 @@ impl ProviderPanel {
                 PanelAction::None
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                *selected = (*selected + 1).min(4);
+                *selected = (*selected + 1).min(6);
                 PanelAction::None
             }
             KeyCode::Enter => {
@@ -592,8 +600,10 @@ impl ProviderPanel {
                     }
                     1 => config.classifier_model = Some(qualified),
                     2 => config.compact_model = Some(qualified),
-                    3 => config.classifier_model = None,
-                    4 => config.compact_model = None,
+                    3 => config.title_model = Some(qualified),
+                    4 => config.classifier_model = None,
+                    5 => config.compact_model = None,
+                    6 => config.title_model = None,
                     _ => unreachable!(),
                 }
                 self.mode = Mode::List;
@@ -946,6 +956,7 @@ impl ProviderPanel {
                             config.classifier_model.as_deref() == Some(qualified.as_str());
                         let is_compact =
                             config.compact_model.as_deref() == Some(qualified.as_str());
+                        let is_title = config.title_model.as_deref() == Some(qualified.as_str());
                         let mut spans = if f.is_empty() {
                             vec![Span::styled((*m).to_string(), style)]
                         } else {
@@ -984,6 +995,12 @@ impl ProviderPanel {
                             spans.push(Span::styled(
                                 "  compact",
                                 Style::default().fg(palette::CYAN),
+                            ));
+                        }
+                        if is_title {
+                            spans.push(Span::styled(
+                                "  title",
+                                Style::default().fg(palette::YELLOW),
                             ));
                         }
                         ListItem::new(Line::from(spans))
@@ -1055,8 +1072,10 @@ impl ProviderPanel {
                     "Set as provider chat default",
                     "Set as global classifier model",
                     "Set as global compact model",
+                    "Set as global title model",
                     "Clear global classifier model",
                     "Clear global compact model",
+                    "Clear global title model",
                 ];
                 let items = choices.iter().enumerate().map(|(index, choice)| {
                     let style = if index == *selected {
@@ -1157,11 +1176,13 @@ mod tests {
             );
         }
         ProgrammerConfig {
+            soul: None,
             default_provider: names.first().unwrap_or(&"").to_string(),
             providers,
             classifier_model: None,
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             compact_model: None,
+            title_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
             memory: Default::default(),

--- a/src/ui/event.rs
+++ b/src/ui/event.rs
@@ -44,6 +44,14 @@ pub enum Event {
     App(AppEvent),
 }
 
+/// A completed context-compaction request and its provider-reported token
+/// usage.
+pub struct CompactionResult {
+    pub(crate) summary: String,
+    pub(crate) input_tokens: Option<u32>,
+    pub(crate) output_tokens: Option<u32>,
+}
+
 /// Application events.
 ///
 /// You can extend this enum with your own custom events.
@@ -86,13 +94,23 @@ pub enum AppEvent {
     /// context boundary, `Err` the error to surface. The token identifies the
     /// run so a summary from a cancelled compaction is dropped. Tagged with
     /// the operation id.
-    CompactFinished(u64, usize, Result<String, String>, CancellationToken),
+    CompactFinished(
+        u64,
+        usize,
+        Result<CompactionResult, String>,
+        CancellationToken,
+    ),
     /// A seamless background compaction finished. The job id and history
     /// epoch make stale summaries harmless after clear/rewind/session changes.
     AutoCompactFinished {
         job_id: u64,
         history_epoch: u64,
         cutoff: usize,
+        result: Result<CompactionResult, String>,
+    },
+    /// Background generation of the current session's display title finished.
+    SessionTitleGenerated {
+        session_uuid: String,
         result: Result<String, String>,
     },
     /// A background process entered a terminal state.
@@ -225,6 +243,14 @@ impl std::fmt::Debug for AppEvent {
             Self::AutoCompactFinished { job_id, result, .. } => f
                 .debug_struct("AutoCompactFinished")
                 .field("job_id", job_id)
+                .field("result", &result.as_ref().map(|_| ".."))
+                .finish(),
+            Self::SessionTitleGenerated {
+                session_uuid,
+                result,
+            } => f
+                .debug_struct("SessionTitleGenerated")
+                .field("session_uuid", session_uuid)
                 .field("result", &result.as_ref().map(|_| ".."))
                 .finish(),
             Self::TaskStateChanged(event) => f

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -404,8 +404,12 @@ impl Widget for &mut App<'_> {
                 Constraint::Min(1),    // content area
             ])
             .split(area);
-        let logo = Logo::new();
-        logo.render(vert[0], buf);
+        let title = if self.session.title.is_empty() {
+            "Programmer"
+        } else {
+            &self.session.title
+        };
+        Logo::new(title).render(vert[0], buf);
         let content_area = vert[1];
 
         // ---- sidebar: conditionally split the content area horizontally ----


### PR DESCRIPTION
### Programmer v0.2.8

- Add configurable `soul` instructions while retaining Programmer's operational and safety guidance.
- Generate and persist concise session titles with a configurable `title_model`; show them in the header, session picker, and `/session` output.
- Track cached input tokens across the TUI, `/usage`, saved sessions, and headless JSON output, including cache-hit percentages.
- Make automatic compaction visible with next-turn status details, summarized turn/token counts, and a marker immediately before the first turn using compacted context.
- Label grouped tool runs with their todo purpose and improve the readability of expanded live command output.
- Require a second `Ctrl+C` within two seconds before exiting the session picker.

### Verification

- `cargo test` — 528 passed, 1 ignored; CLI diagnostics test passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `git diff --check`
