### PR TITLE
v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.8"
+version = "0.2.9"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/PROGRAMMER.md
+++ b/PROGRAMMER.md
@@ -6,15 +6,16 @@
 connects to OpenAI-compatible APIs (Responses API), streams responses, and
 gives the model local tools including `command`, `read_file`, `write_file`,
 `edit_file`, `grep`, `blob`, `ask_user`, `configure_diagnostics`, `fetch`,
-`task`, `todo`, `memory`, and `agent`,
+`task`, `todo`, `memory`, `conversation_history`, and `agent`,
 plus MCP-bridged external tools. The TUI is built with Ratatui and crossterm.
 The binary is a single crate at the repo root.
 
 Key features beyond the chat loop:
 - **Multi-provider**: add/edit/delete/switch API backends at runtime.
 - **Multi-session**: UUID-keyed JSON persistence in `~/.config/programmer/sessions/`.
+- **Input suggestions**: after successful turns, a configurable model predicts the next user message as an accept-with-Right placeholder.
 - **Rewind checkpoints**: prompt-level conversation checkpoints plus content-addressed snapshots for built-in file edits.
-- **Context compaction**: manual and provider-usage-triggered background summaries with session overrides and a parsed structured working-state snapshot.
+- **Context compaction**: manual and provider-usage-triggered background summaries with session overrides, immediate safe-boundary persistence for generated summaries, a parsed structured working-state snapshot, and read-only search/paging over exact pre-compaction items.
 - **Persistent memory**: explicit-only bounded lexical recall over inspectable global/project JSON stores, with no automatic request injection, explicit memory management, and credential rejection.
 - **Auto-mode classifier**: per-mode LLM classifier that approves/denies/defers tool calls.
 - **MCP (Model Context Protocol)**: connect to external MCP servers (stdio + HTTP);
@@ -156,6 +157,7 @@ src/
 │   ├── blob.rs               #   File glob (find by name pattern)
 │   ├── ask_user.rs           #   Prompt user for input (yes/no, multi-choice, text)
 │   ├── configure_diagnostics.rs  # Write .programmer/diagnostics.toml
+│   ├── conversation_history.rs   # Search/page exact items hidden by compaction
 │   ├── diagnostics.rs        #   Run diagnostics + return current errors/warnings
 │   ├── fetch.rs              #   HTTP fetch (html2text conversion)
 │   ├── task.rs               #   Background task management (create/list/output/write/wait/kill)
@@ -221,7 +223,7 @@ src/
 - **Error handling:** `color_eyre::Result<T>` throughout; `.wrap_err()` for context; `?` propagation. `thiserror` for library-style error types.
 - **Async:** `#[tokio::main]` on `main()`, `tokio::spawn` for concurrent tasks. All tool execution is async.
 - **Configuration:** `ProgrammerConfig` deserializes from TOML via the `config` crate. Environment variables prefixed with `Programmer` override file values. Config lives at `~/.config/programmer/config.toml`. The optional top-level `soul` value replaces only the identity/mindset section of the developer prompt.
-- **Sessions:** Stored as JSON at `~/.config/programmer/sessions/<uuid>.json`. Each session contains message items, history, todos, and persisted task state.
+- **Sessions:** Stored as JSON at `~/.config/programmer/sessions/<uuid>.json`. Each session contains message items, history, the latest input suggestion, todos, and persisted task state.
 - **Module visibility:** `pub(crate)` for internal visibility; `pub` only where needed externally. UI internals are `mod` (private). Tool modules are `pub` within `tools/`.
 - **Tests:** Inline `#[cfg(test)]` modules at the bottom of source files. No separate `tests/` directory.
 - **Copyright header:** GPL-3.0-or-later header block on every `.rs` file.
@@ -229,6 +231,6 @@ src/
 - **No `unwrap()` in production code:** Prefer `?`, `.unwrap_or_default()`, or explicit `match`.
 - **The diagnostics system** is language-agnostic: it reads `.programmer/diagnostics.toml` for checker definitions. Each checker can be a one-shot command (parsed via `rustc-json`, `tsc`, `gnu`, or regex) or an LSP server (`kind = "lsp"`). The `configure_diagnostics` tool writes this file.
 - **Constants** live in `src/consts.rs` — tunable values like output length limits, concurrency caps, tick rate, and classifier budgets.
-- **Prompts** are centralised in `src/prompts.rs`: system prompt, classifier instructions, and plan-mode injection.
+- **Prompts** are centralised in `src/prompts.rs`: system prompt, classifier instructions, plan-mode injection, and post-edit reminders. Project initialization state is kept out of the system prompt for cache stability; periodic runner hooks surface `/init` guidance after edits when its artifacts are missing.
 - **MCP integration** supports both stdio and HTTP transports. Tools are prefixed `mcp__<server>__<tool>` and merged into the advertised tool list.
 - **Skills** are compiled from `src/skills/builtin/<name>/SKILL.md` or discovered from `~/.agents/skills/<name>/SKILL.md` (shared), the platform config directory's `programmer/skills/<name>/SKILL.md` (global), and `.programmer/skills/<name>/SKILL.md` (project). Precedence is project > global > shared > built-in.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Use `--version v0.2.4` with `install.sh`, or `-Version v0.2.4` with
    ```
 
    Use `/init` if you want Programmer to create project guidance and configure
-   diagnostics before making changes. The default Auto mode asks a classifier
-   model to review mutating tool calls; use a non-reasoning model for that role.
+   diagnostics before making changes. If several edits are made before those
+   project artifacts exist, post-edit feedback may remind the agent to suggest
+   `/init` to you. The default Auto mode asks a classifier model to review
+   mutating tool calls; use a non-reasoning model for that role.
 
 If the provider works but the model list is empty, configure `models` and
 `default_model` explicitly in `config.toml`; see
@@ -178,6 +180,10 @@ compact_model = "openai/gpt-4o-mini"
 # back to the current chat model when absent.
 title_model = "openai/gpt-4o-mini"
 
+# Model used after each completed turn to predict the user's next message for
+# the input placeholder. Falls back to the current chat model when absent.
+suggestion_model = "openai/gpt-4o-mini"
+
 # Automatically compact after a response reports at least this many input
 # tokens. This uses provider-reported usage (not an estimate); 0 disables it.
 auto_compact_tokens = 100000
@@ -250,6 +256,7 @@ api_key = "sk-your-key-here"
 | `classifier_top_logprobs` | `20` | Alternative-token count for the fast classifier probe (`0`–`20`). Lower this for providers with a smaller limit; Qwen accepts at most `5`. |
 | `compact_model` | (chat model) | `provider/model` used for manual and automatic context compaction. |
 | `title_model` | (chat model) | `provider/model` used to generate a concise title for each new session. |
+| `suggestion_model` | (chat model) | `provider/model` used after successful turns to predict the next user message shown in the input placeholder. |
 | `auto_compact_tokens` | `100000` | Provider-reported input-token threshold for seamless background compaction. `0` disables it. Providers that do not report usage do not trigger it. |
 | `compact_keep_recent_turns` | `2` | Number of recent complete turns kept verbatim when context is compacted. |
 | `memory.enabled` | `true` | Advertise the persistent-memory tool. Memory is recalled explicitly and is never injected automatically. |
@@ -419,6 +426,8 @@ programmer
 | Key | Action |
 |---|---|
 | `Enter` | Send message |
+| `Right` | Accept the model-generated next-message suggestion when the input is empty; typing hides it, and deleting the draft reveals it again |
+| `Up` | Move a queued message back into the empty input for editing |
 | `Esc` | Cancel the active request; before any model output, restore the original draft to the input |
 | `Ctrl+T` | Cycle work mode (Manual → Auto → Plan → optional YOLO) |
 | `Ctrl+C` / `Ctrl+Q` twice | Quit |
@@ -468,6 +477,7 @@ programmer
 | `/usage` | Show token usage for the session and latest turn |
 | `/new` `/n` | Start a new session (auto-saves current) |
 | `/session` `/s` | Show current session UUID and info |
+| `/title [text]` | Regenerate the current session title, or set it manually when text is provided |
 | `/providers show` | List all configured providers and models |
 | `/providers manage` | Open the provider management panel |
 | `/providers refresh [provider]` | Refetch auto-discovered model lists (optionally for one provider) |
@@ -516,10 +526,15 @@ recovery checkpoint so its file changes can be undone from the same panel.
 Automatic compaction observes the real `input_tokens` returned after every API
 response. For tool-using responses it waits until all call outputs are recorded,
 then summarizes a stable prefix in the background. Input stays usable and new
-messages remain outside that prefix. The input title announces that the next
-turn will use compacted context; when that turn starts, a marker is inserted
-immediately before its messages. A stale summary is discarded after `/clear`,
-`/new`, or `/rewind`.
+messages remain outside that prefix. Once the summary is installed, the session
+is saved immediately when idle (or at the next safe turn boundary), so reopening
+the conversation reuses the generated summary. The input title announces that
+the next turn will use compacted context; when that turn starts, a marker is
+inserted immediately before its messages. The read-only `conversation_history` tool is
+then exposed to the main agent and its sub-agents, allowing them to search the
+exact pre-compaction items and page through a matching message or tool result
+when the summary omits a needed detail. A stale summary is discarded after
+`/clear`, `/new`, or `/rewind`.
 
 **In model browser (`m`):**
 
@@ -658,10 +673,14 @@ classifier, while `manual` waits for you at the console.
 ### Session management
 
 Sessions are saved to `~/.config/programmer/sessions/<uuid>.json`. Conversation
-history, model/work mode, the `/vision` switch, generated title, and todos are
-restored independently for each session. A background request using
+history, model/work mode, the `/vision` switch, generated title, latest input
+suggestion, and todos are restored independently for each session. Completed
+suggestions are saved immediately when idle, so the gray hint is available after
+`--resume` without another model request. A background request using
 `title_model` (or the current chat model) names a new session from its first
-message; the resume picker and `/session` show that title.
+message; the resume picker and `/session` show that title. Once available, the
+generated title also replaces the project directory name in the terminal window
+title; untitled sessions continue to show the directory name.
 
 With `/vision on`, referencing a local PNG, JPEG, WEBP, or non-animated GIF as
 `@path` attaches it as an image input. `/vision off` stops sending both new and
@@ -687,6 +706,7 @@ Terminal emulators generally reserve `Cmd+V` for text paste, so image paste uses
 | `programmer --resume <uuid>` | Resume a specific session |
 | `/new` `/n` | Save current session and start fresh |
 | `/session` `/s` | Show current session UUID |
+| `/title [text]` | Regenerate the current session title, or set it manually |
 | `/usage` | Show session and most recent turn token usage |
 
 ## Project structure

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -375,6 +375,7 @@ pub(crate) struct AgentRuntime {
     pub(crate) skill_prompt: Option<String>,
     pub(crate) approval_label: String,
     pub(crate) checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
+    pub(crate) conversation_history: Option<Arc<Mutex<crate::conversation::Conversation>>>,
 }
 
 impl AgentRuntime {
@@ -418,7 +419,8 @@ impl AgentRuntime {
                     file_scope,
                 )
                 .with_checkpoint(self.checkpoint.clone())
-                .with_memory_enabled(self.memory_config.enabled),
+                .with_memory_enabled(self.memory_config.enabled)
+                .with_conversation_history(self.conversation_history.clone()),
             ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];

--- a/src/app/command_handlers/session.rs
+++ b/src/app/command_handlers/session.rs
@@ -20,6 +20,10 @@ pub(in crate::app) fn execute(app: &mut App<'_>, command: Command) -> CommandOut
         Command::Clear => clear(app),
         Command::New => new(app),
         Command::Session => show_session(app),
+        Command::Title(title) => {
+            commands::set_or_regenerate_session_title(app, &title);
+            CommandOutcome::handled(true)
+        }
         Command::Usage => usage(app),
         Command::Rewind => rewind(app),
         Command::Todo => {
@@ -158,6 +162,11 @@ fn clear(app: &mut App<'_>) -> CommandOutcome {
 
 fn new(app: &mut App<'_>) -> CommandOutcome {
     commands::invalidate_auto_compaction(app);
+    app.active_suggestion_operation_id = None;
+    if let Some(cancel) = app.input_suggestion_cancel.take() {
+        cancel.cancel();
+    }
+    app.input_panel.clear_suggestion();
     session::save_session(app);
     app.conversation_panel.clear_messages();
     diagnostics::reset_diagnostics_state(app);
@@ -176,6 +185,7 @@ fn new(app: &mut App<'_>) -> CommandOutcome {
     app.current_checkpoint_id = None;
     app.session.title.clear();
     app.session.title_generation_started = false;
+    app.session.title_generation_id = app.session.title_generation_id.wrapping_add(1);
     app.todo_list = crate::todos::TodoList::default();
     app.sync_todos_to_store();
     app.vision_enabled = false;

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -206,6 +206,11 @@ async fn start_ready_request(
     )>,
 ) {
     debug_assert!(app.cancel.active_id.is_none());
+    app.active_suggestion_operation_id = None;
+    if let Some(cancel) = app.input_suggestion_cancel.take() {
+        cancel.cancel();
+    }
+    app.input_panel.clear_suggestion();
     let conversation_cutoff = app.conversation_panel.items_snapshot().len();
     let title_source = (app.session.title.is_empty() && !app.session.title_generation_started)
         .then(|| inputs.first().map(|(text, _, _)| text.clone()))
@@ -470,7 +475,7 @@ pub(crate) fn run_bang_command(app: &mut App<'_>, input: &str) {
     }
 }
 
-fn maybe_start_session_title(app: &mut App<'_>, first_message: String) {
+fn maybe_start_session_title(app: &mut App<'_>, first_message: String) -> bool {
     use crate::ui::event::{AppEvent, Event};
 
     app.session.title_generation_started = true;
@@ -479,9 +484,11 @@ fn maybe_start_session_title(app: &mut App<'_>, first_message: String) {
         app.conversation_panel.add_warning_string(format!(
             "session title generation skipped: unknown provider/model {target_model}"
         ));
-        return;
+        return false;
     };
     let client = client.clone();
+    app.session.title_generation_id = app.session.title_generation_id.wrapping_add(1);
+    let generation_id = app.session.title_generation_id;
     let session_uuid = app.session.uuid.clone();
     let prompt = format!("{}{first_message}", crate::prompts::SESSION_TITLE_PROMPT);
     let request = async_openai::types::responses::CreateResponse {
@@ -498,9 +505,39 @@ fn maybe_start_session_title(app: &mut App<'_>, first_message: String) {
                 .and_then(|response| normalize_session_title(&response.summary));
         let _ = sender.send(Event::App(AppEvent::SessionTitleGenerated {
             session_uuid,
+            generation_id,
             result,
         }));
     });
+    true
+}
+
+pub(in crate::app) fn set_or_regenerate_session_title(app: &mut App<'_>, requested: &str) {
+    if !requested.trim().is_empty() {
+        let Ok(title) = normalize_session_title(requested) else {
+            app.conversation_panel
+                .add_warning_string("session title cannot be empty");
+            return;
+        };
+        app.session.title_generation_id = app.session.title_generation_id.wrapping_add(1);
+        app.session.title_generation_started = true;
+        app.session.title = title.clone();
+        session::mark_dirty(app);
+        app.conversation_panel
+            .add_info_string(format!("Session title set to: {title}"));
+        return;
+    }
+
+    let items = app.conversation_panel.items_snapshot();
+    let Some(first_message) = super::helpers::first_user_text(&items) else {
+        app.conversation_panel
+            .add_warning_string("cannot generate a title before the first user message");
+        return;
+    };
+    if maybe_start_session_title(app, first_message) {
+        app.conversation_panel
+            .add_info_string("Regenerating session title…");
+    }
 }
 
 fn normalize_session_title(response: &str) -> Result<String, String> {
@@ -515,6 +552,78 @@ fn normalize_session_title(response: &str) -> Result<String, String> {
         Err("the model returned an empty title".to_string())
     } else {
         Ok(title.chars().take(80).collect())
+    }
+}
+
+pub(super) fn maybe_start_input_suggestion(app: &mut App<'_>, operation_id: u64) {
+    use async_openai::types::responses::{InputItem, InputParam, Item};
+
+    if !app.input_panel.get_content().is_empty() || app.cancel.active_id.is_some() {
+        return;
+    }
+    let target_model = app.effective_suggestion_model();
+    let Some((client, model_name)) = app.provider_manager.resolve(&target_model) else {
+        return;
+    };
+    let mut input =
+        match app
+            .conversation_panel
+            .get_input_param(&target_model, None, None, None, false)
+        {
+            InputParam::Items(items) => items,
+            InputParam::Text(text) => vec![InputItem::from(Item::Message(ApiMessageItem::Input(
+                InputMessage {
+                    content: vec![InputContent::InputText(InputTextContent { text })],
+                    role: InputRole::User,
+                    status: Some(OutputStatus::Completed),
+                },
+            )))],
+        };
+    input.push(InputItem::from(Item::Message(ApiMessageItem::Input(
+        InputMessage {
+            content: vec![InputContent::InputText(InputTextContent {
+                text: crate::prompts::INPUT_SUGGESTION_PROMPT.to_string(),
+            })],
+            role: InputRole::User,
+            status: Some(OutputStatus::Completed),
+        },
+    ))));
+
+    app.active_suggestion_operation_id = Some(operation_id);
+    let cancel = crate::cancel::CancellationToken::new();
+    app.input_suggestion_cancel = Some(cancel.clone());
+    let request = async_openai::types::responses::CreateResponse {
+        input: InputParam::Items(input),
+        model: Some(model_name),
+        max_output_tokens: Some(120),
+        ..Default::default()
+    };
+    let client = client.clone();
+    let session_uuid = app.session.uuid.clone();
+    let sender = app.events.sender.clone();
+    tokio::spawn(async move {
+        let result = stream_compact_response(&client, request, cancel)
+            .await
+            .and_then(|response| normalize_input_suggestion(&response.summary));
+        let _ = sender.send(Event::App(AppEvent::InputSuggestionGenerated {
+            session_uuid,
+            operation_id,
+            result,
+        }));
+    });
+}
+
+fn normalize_input_suggestion(response: &str) -> Result<String, String> {
+    let suggestion = response
+        .trim()
+        .trim_matches(['"', '\'', '“', '”'])
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if suggestion.is_empty() {
+        Err("the model returned an empty input suggestion".to_string())
+    } else {
+        Ok(suggestion.chars().take(240).collect())
     }
 }
 
@@ -892,6 +1001,7 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
         | Command::Clear
         | Command::New
         | Command::Session
+        | Command::Title(_)
         | Command::Usage
         | Command::Rewind
         | Command::Todo
@@ -926,8 +1036,8 @@ pub(crate) async fn execute_command(app: &mut App<'_>, input: &str) {
 mod tests {
     use super::{
         ConversationPanel, build_compact_request, execute_command, format_agent_updates,
-        format_task_updates, normalize_session_title, ordered_message_content,
-        queue_pending_request,
+        format_task_updates, normalize_input_suggestion, normalize_session_title,
+        ordered_message_content, queue_pending_request,
     };
     use async_openai::types::responses::{ImageDetail, InputContent, InputImageContent};
     use std::sync::Arc;
@@ -980,6 +1090,7 @@ mod tests {
                 "/session",
                 ExpectedCommandEffect::AppendedMessage,
             ),
+            ("title", "/title", ExpectedCommandEffect::AppendedMessage),
             ("usage", "/usage", ExpectedCommandEffect::AppendedMessage),
             ("rewind", "/rewind", ExpectedCommandEffect::AppendedMessage),
             ("mode", "/mode auto", ExpectedCommandEffect::AppendedMessage),
@@ -1092,6 +1203,17 @@ mod tests {
         assert!(auto.reasoning.is_none());
     }
 
+    #[tokio::test]
+    async fn title_command_sets_a_manual_title() {
+        let mut app = command_test_app().await;
+
+        execute_command(&mut app, "/title  Fix queued editing  ").await;
+
+        assert_eq!(app.session.title, "Fix queued editing");
+        assert!(app.session.title_generation_started);
+        assert_eq!(app.session.title_generation_id, 1);
+    }
+
     #[test]
     fn generated_session_title_is_cleaned_and_bounded() {
         assert_eq!(
@@ -1108,6 +1230,22 @@ mod tests {
                 .chars()
                 .count(),
             80
+        );
+    }
+
+    #[test]
+    fn generated_input_suggestion_is_cleaned_and_bounded() {
+        assert_eq!(
+            normalize_input_suggestion("  “继续  修复测试”\n  ").unwrap(),
+            "继续 修复测试"
+        );
+        assert!(normalize_input_suggestion("  \n ").is_err());
+        assert_eq!(
+            normalize_input_suggestion(&"x".repeat(300))
+                .unwrap()
+                .chars()
+                .count(),
+            240
         );
     }
 

--- a/src/app/events/keys.rs
+++ b/src/app/events/keys.rs
@@ -373,6 +373,11 @@ pub(crate) async fn handle_key_events(
             }
             update_completions(app);
         }
+        KeyCode::Right
+            if key_event.modifiers == KeyModifiers::NONE && app.input_panel.accept_suggestion() =>
+        {
+            update_completions(app);
+        }
         KeyCode::PageUp => {
             app.conversation_panel.scroll_page_up();
         }

--- a/src/app/events/mod.rs
+++ b/src/app/events/mod.rs
@@ -255,6 +255,9 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
             // current TUI/native-selection choice.
             let _ = crate::terminal::set_mouse_capture(!app.native_selection_mode);
             start_queued_work(app).await;
+            if was_ok && app.cancel.active_id.is_none() {
+                commands::maybe_start_input_suggestion(app, op_id);
+            }
         }
         AppEvent::Start => {
             diagnostics::maybe_seed_diagnostics_baseline(app);
@@ -312,6 +315,12 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                         }
                         app.input_panel.show_next_turn_compaction(details);
                         session::mark_dirty(app);
+                        // Make the generated summary durable immediately when
+                        // the foreground is idle, so reopening the session can
+                        // reuse it instead of compacting the same history again.
+                        // If another turn is active, the normal idle flush saves
+                        // it at the next safe turn boundary.
+                        session::flush_if_dirty(app);
                     }
                 }
                 Err(error) => app
@@ -321,9 +330,11 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
         }
         AppEvent::SessionTitleGenerated {
             session_uuid,
+            generation_id,
             result,
         } => {
-            if app.session.uuid != session_uuid {
+            if app.session.uuid != session_uuid || app.session.title_generation_id != generation_id
+            {
                 return;
             }
             match result {
@@ -334,6 +345,27 @@ async fn handle_app_event(app: &mut App<'_>, app_event: AppEvent) {
                 Err(error) => app
                     .conversation_panel
                     .add_warning_string(format!("session title generation failed: {error}")),
+            }
+        }
+        AppEvent::InputSuggestionGenerated {
+            session_uuid,
+            operation_id,
+            result,
+        } => {
+            if app.session.uuid != session_uuid
+                || app.active_suggestion_operation_id != Some(operation_id)
+            {
+                return;
+            }
+            app.active_suggestion_operation_id = None;
+            app.input_suggestion_cancel = None;
+            if let Ok(suggestion) = result
+                && app.cancel.active_id.is_none()
+                && app.input_panel.get_content().is_empty()
+            {
+                app.input_panel.set_suggestion(suggestion);
+                session::mark_dirty(app);
+                session::flush_if_dirty(app);
             }
         }
         AppEvent::Quit => handle_quit_request(app),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -139,6 +139,8 @@ pub(crate) struct SessionState {
     pub(crate) title: String,
     /// Prevent duplicate title requests while the first one is in flight.
     pub(crate) title_generation_started: bool,
+    /// Monotonic id used to ignore stale title-generation results.
+    pub(crate) title_generation_id: u64,
     pub(crate) classifier_model_override: ModelOverride,
     pub(crate) compact_model_override: ModelOverride,
     pub(crate) auto_compact_override: AutoCompactOverride,
@@ -338,6 +340,10 @@ pub struct App<'a> {
     /// Background automatic compaction bookkeeping. This is deliberately
     /// independent from the foreground turn phase and cancellation token.
     pub(crate) auto_compact: AutoCompactState,
+    /// Operation whose completed turn is currently generating an input hint.
+    pub(crate) active_suggestion_operation_id: Option<u64>,
+    /// Cancels obsolete hint requests when another user turn starts.
+    pub(crate) input_suggestion_cancel: Option<crate::cancel::CancellationToken>,
     pub(crate) checkpoint_store: Option<Arc<Mutex<crate::checkpoint::CheckpointStore>>>,
     pub(crate) current_checkpoint_id: Option<u64>,
     /// Project directory name for the terminal title.
@@ -394,6 +400,7 @@ impl App<'_> {
         let mut auto_compact_override = AutoCompactOverride::Inherit;
         let mut compact_keep_recent_turns_override = None;
         let mut session_title = String::new();
+        let mut saved_input_suggestion = None;
 
         let mut saved_activated_skills: Option<Vec<String>> = None;
         if let Some(mgr) = &session_mgr
@@ -408,6 +415,7 @@ impl App<'_> {
                 current_model = model;
             }
             session_title = saved.title;
+            saved_input_suggestion = saved.input_suggestion;
             vision_enabled = saved.vision_enabled;
             thinking_level = saved.thinking_level;
             classifier_model_override = saved.classifier_model_override;
@@ -432,6 +440,9 @@ impl App<'_> {
         }
         let mut input_panel = InputPanel::new();
         input_panel.history = saved_history;
+        if let Some(suggestion) = saved_input_suggestion {
+            input_panel.set_suggestion(suggestion);
+        }
         let todo_list = crate::todos::TodoList { todos: saved_todos };
         let todo_store = Arc::new(Mutex::new(todo_list.clone()));
         let security_manager = Arc::new(
@@ -510,6 +521,7 @@ impl App<'_> {
                 dirty: false,
                 did_save: false,
                 title_generation_started: !session_title.is_empty(),
+                title_generation_id: 0,
                 title: session_title,
                 classifier_model_override,
                 compact_model_override,
@@ -517,6 +529,8 @@ impl App<'_> {
                 compact_keep_recent_turns_override,
             },
             auto_compact: AutoCompactState::default(),
+            active_suggestion_operation_id: None,
+            input_suggestion_cancel: None,
             checkpoint_store,
             current_checkpoint_id: None,
             skill_registry: crate::skills::SkillRegistry::load(),
@@ -612,6 +626,13 @@ impl App<'_> {
             .unwrap_or_else(|| self.current_model.clone())
     }
 
+    pub(crate) fn effective_suggestion_model(&self) -> String {
+        self.config
+            .suggestion_model
+            .clone()
+            .unwrap_or_else(|| self.current_model.clone())
+    }
+
     pub(crate) fn effective_auto_compact_tokens(&self) -> Option<u32> {
         match self.session.auto_compact_override {
             AutoCompactOverride::Inherit => {
@@ -666,7 +687,8 @@ impl App<'_> {
             Arc::new(
                 LocalToolProvider::new(self.todo_store.clone(), self.security.clone())
                     .with_checkpoint(self.checkpoint_recorder())
-                    .with_memory_enabled(self.config.memory.enabled),
+                    .with_memory_enabled(self.config.memory.enabled)
+                    .with_conversation_history(Some(self.conversation_panel.shared_conversation())),
             ),
             Arc::new(SkillToolProvider::new(self.skill_registry.clone())),
         ];
@@ -722,6 +744,7 @@ impl App<'_> {
                 self.work_mode.label()
             ),
             checkpoint: self.checkpoint_recorder(),
+            conversation_history: Some(self.conversation_panel.shared_conversation()),
         };
         base_providers.push(Arc::new(crate::tools::provider::AgentToolProvider::new(
             self.agents.clone(),

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -93,6 +93,7 @@ fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
     });
     SessionManager::set_items(&mut session, items);
     session.history = app.input_panel.history.clone();
+    session.input_suggestion = app.input_panel.suggestion().map(str::to_owned);
     session.work_mode = Some(app.work_mode);
     session.current_model = Some(app.current_model.clone());
     session.vision_enabled = app.vision_enabled;
@@ -139,8 +140,14 @@ pub(crate) fn persist_config(app: &mut App<'_>) {
 
 /// Delete the session file and start a fresh session with a new UUID.
 pub(crate) fn delete_session(app: &mut App<'_>) {
+    app.active_suggestion_operation_id = None;
+    if let Some(cancel) = app.input_suggestion_cancel.take() {
+        cancel.cancel();
+    }
+    app.input_panel.clear_suggestion();
     app.session.title.clear();
     app.session.title_generation_started = false;
+    app.session.title_generation_id = app.session.title_generation_id.wrapping_add(1);
     if let Some(store) = &app.checkpoint_store {
         let _ = store.lock().unwrap().delete_all();
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -43,6 +43,8 @@ pub enum Command {
     Init,
     Help,
     Session,
+    /// `/title [text]` — regenerate the current session title, or set it manually.
+    Title(String),
     Usage,
     Rewind,
     Todo,
@@ -86,6 +88,7 @@ enum CommandKind {
     Init,
     Help,
     Session,
+    Title,
     Usage,
     Rewind,
     Todo,
@@ -162,6 +165,7 @@ impl CommandKind {
             Self::Init => Command::Init,
             Self::Help => Command::Help,
             Self::Session => Command::Session,
+            Self::Title => Command::Title(args),
             Self::Usage => Command::Usage,
             Self::Rewind => Command::Rewind,
             Self::Todo => Command::Todo,
@@ -244,12 +248,23 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         }],
     },
     CommandSpec {
+        kind: CommandKind::Title,
+        name: "title",
+        aliases: &[],
+        completion: CompletionKind::None,
+        help: &[HelpEntry {
+            order: 27,
+            usage: "/title [text]",
+            description: "Regenerate the session title, or set it manually",
+        }],
+    },
+    CommandSpec {
         kind: CommandKind::Usage,
         name: "usage",
         aliases: &[],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 27,
+            order: 28,
             usage: "/usage",
             description: "Show token usage for the current session",
         }],
@@ -260,7 +275,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 28,
+            order: 29,
             usage: "/rewind",
             description: "Restore conversation and built-in file edits to a user prompt",
         }],
@@ -317,7 +332,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
             "list", "recall", "remember", "update", "forget", "on", "off",
         ]),
         help: &[HelpEntry {
-            order: 32,
+            order: 33,
             usage: "/memory <list|recall|remember|update|forget|on|off>",
             description: "Inspect or manage persistent memory",
         }],
@@ -485,7 +500,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["c"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 29,
+            order: 30,
             usage: "/clear | /c",
             description: "Delete this session; reset chat, todos, images, and diagnostics",
         }],
@@ -496,7 +511,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["q", "exit"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 30,
+            order: 31,
             usage: "/quit | /q",
             description: "Exit the application",
         }],
@@ -507,7 +522,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &["?"],
         completion: CompletionKind::None,
         help: &[HelpEntry {
-            order: 31,
+            order: 32,
             usage: "/help | /?",
             description: "Show this help",
         }],
@@ -1659,6 +1674,7 @@ mod tests {
             "new",
             "providers",
             "session",
+            "title",
             "usage",
             "rewind",
             "mode",
@@ -1786,6 +1802,10 @@ mod tests {
                 "Refetch auto-discovered provider models",
             ),
             ("/session | /s", "Show current session info"),
+            (
+                "/title [text]",
+                "Regenerate the session title, or set it manually",
+            ),
             ("/usage", "Show token usage for the current session"),
             (
                 "/rewind",

--- a/src/config/programmer_config.rs
+++ b/src/config/programmer_config.rs
@@ -90,6 +90,10 @@ pub struct ProgrammerConfig {
     /// chat model is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_model: Option<String>,
+    /// Model used to predict the user's next message for the input placeholder.
+    /// When absent, the current chat model is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggestion_model: Option<String>,
     /// Start a background context compaction after an API response reports at
     /// least this many input tokens. Zero disables automatic compaction.
     #[serde(default = "default_auto_compact_tokens")]
@@ -220,6 +224,7 @@ impl Default for ProgrammerConfig {
             classifier_top_logprobs: default_classifier_top_logprobs(),
             compact_model: None,
             title_model: None,
+            suggestion_model: None,
             auto_compact_tokens: default_auto_compact_tokens(),
             compact_keep_recent_turns: default_compact_keep_recent_turns(),
             memory: MemoryConfig::default(),

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -251,6 +251,7 @@ impl HeadlessAgent {
                 args.work_mode.label()
             ),
             checkpoint: None,
+            conversation_history: None,
         };
         base_providers.push(Arc::new(AgentToolProvider::new(
             agents.clone(),

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -87,6 +87,9 @@ responses rendered in a terminal UI, so keep output compact.
   use the `memory` tool when it is available. Do not merely claim it was saved.
 - Before writing, check relevant existing memories. Update an existing entry
   when it represents the same fact instead of creating a duplicate.
+- If you encounter an error and do not know how to resolve it, recall relevant
+  memory before asking the user. Ask only if memory does not provide a workable
+  answer and user input is still necessary.
 - Keep each entry atomic and independently updateable. If the material combines
   unrelated subjects, scopes, or lifecycles, make multiple `remember` calls.
 - Choose the narrowest valid scope. Use `global` only for information reusable
@@ -225,6 +228,12 @@ message. Use the same language as the message when practical. Keep it under \
 50 characters, do not end with punctuation, and output only the title with no \
 quotes or explanation.\n\nFirst message:\n";
 
+pub(crate) const INPUT_SUGGESTION_PROMPT: &str = "\
+Predict the single most likely next message the user would type in this coding \
+conversation. Write it from the user's perspective, in the language they have \
+been using. Keep it concise and actionable. Output only the suggested message, \
+with no quotes, label, or explanation.";
+
 // ---------------------------------------------------------------------------
 // /compact — context compaction
 // ---------------------------------------------------------------------------
@@ -261,3 +270,19 @@ pub(crate) const OVERVIEW_REMINDER: &str = "Reminder: several edits have \
     build/test commands, directory layout, or conventions have changed, update \
     PROGRAMMER.md now with write_file so it stays an accurate map for future \
     sessions. If nothing meaningful changed, ignore this.";
+
+pub(crate) const INIT_REMINDER: &str = "Reminder: several file edits have been \
+    made, but this project does not appear to have been initialized for \
+    Programmer. Briefly tell the user they can run `/init` to create \
+    PROGRAMMER.md and configure project diagnostics. Do not run `/init` unless \
+    the user explicitly asks.";
+
+#[cfg(test)]
+mod tests {
+    use super::SYSTEM_PROMPT;
+
+    #[test]
+    fn unknown_errors_trigger_memory_recall_before_user_questions() {
+        assert!(SYSTEM_PROMPT.contains("recall relevant\n  memory before asking the user"));
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -331,6 +331,7 @@ mod tests {
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             compact_model: None,
             title_model: None,
+            suggestion_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
             memory: Default::default(),

--- a/src/runner/hooks.rs
+++ b/src/runner/hooks.rs
@@ -171,10 +171,11 @@ impl TurnHook for DiagnosticsHook {
     }
 }
 
-/// Periodic PROGRAMMER.md refresh reminder. Every `every` editing batches — when
-/// the project actually has a `PROGRAMMER.md` — nudge the model to keep the
-/// overview current. Shares the edit-batch counter with the diagnostics baseline
-/// state so both reset together when diagnostics is reconfigured.
+/// Periodic project-maintenance reminder. Every `every` editing batches, nudge
+/// the model either to keep an initialized project's PROGRAMMER.md current or to
+/// tell the user about `/init` when its project artifacts are absent. Shares the
+/// edit-batch counter with the diagnostics baseline state so both reset together
+/// when diagnostics is reconfigured.
 pub(crate) struct OverviewReminderHook {
     pub state: Arc<Mutex<DiagnosticsState>>,
     pub every: usize,
@@ -197,13 +198,62 @@ impl TurnHook for OverviewReminderHook {
             st.mutating_turns += 1;
             st.mutating_turns
         };
-        let due = self.every != 0
-            && count.is_multiple_of(self.every)
-            && std::path::Path::new("PROGRAMMER.md").exists();
-        if due {
-            Some(crate::prompts::OVERVIEW_REMINDER.to_string())
-        } else {
-            None
-        }
+        maintenance_reminder(
+            count,
+            self.every,
+            std::path::Path::new("PROGRAMMER.md").exists(),
+            std::path::Path::new(crate::diagnostics::PROFILE_PATH).exists(),
+        )
+        .map(str::to_string)
+    }
+}
+
+fn maintenance_reminder(
+    edit_batches: usize,
+    every: usize,
+    has_overview: bool,
+    has_diagnostics: bool,
+) -> Option<&'static str> {
+    if every == 0 || !edit_batches.is_multiple_of(every) {
+        return None;
+    }
+    if has_overview && has_diagnostics {
+        Some(crate::prompts::OVERVIEW_REMINDER)
+    } else {
+        Some(crate::prompts::INIT_REMINDER)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::maintenance_reminder;
+
+    #[test]
+    fn maintenance_reminder_preserves_its_edit_cadence() {
+        assert_eq!(maintenance_reminder(4, 5, false, false), None);
+        assert_eq!(maintenance_reminder(5, 0, false, false), None);
+    }
+
+    #[test]
+    fn maintenance_reminder_suggests_init_when_project_artifacts_are_missing() {
+        let reminder = maintenance_reminder(5, 5, false, false).unwrap();
+        assert!(reminder.contains("/init"));
+        assert!(
+            maintenance_reminder(5, 5, true, false)
+                .unwrap()
+                .contains("/init")
+        );
+        assert!(
+            maintenance_reminder(5, 5, false, true)
+                .unwrap()
+                .contains("/init")
+        );
+    }
+
+    #[test]
+    fn maintenance_reminder_refreshes_initialized_project_overview() {
+        let reminder = maintenance_reminder(5, 5, true, true).unwrap();
+        assert!(reminder.contains("update PROGRAMMER.md"));
+        assert!(!reminder.contains("/init"));
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -201,6 +201,9 @@ pub(crate) struct Session {
     /// Input history (most recent last).
     #[serde(default)]
     pub(crate) history: Vec<String>,
+    /// Latest model-predicted next message, restored as the empty-input hint.
+    #[serde(default)]
+    pub(crate) input_suggestion: Option<String>,
     /// Work mode in effect when the session was last saved, restored on resume.
     #[serde(default)]
     pub(crate) work_mode: Option<crate::classifier::WorkMode>,
@@ -296,6 +299,7 @@ impl SessionManager {
             items: Vec::new(),
             session_memory: None,
             history: Vec::new(),
+            input_suggestion: None,
             work_mode: None,
             current_model: None,
             vision_enabled: false,
@@ -895,6 +899,22 @@ mod tests {
     }
 
     #[test]
+    fn older_sessions_load_without_an_input_suggestion() {
+        let sessions_dir =
+            std::env::temp_dir().join(format!("programmer-session-test-{}", uuid_v4()));
+        let mgr = SessionManager { sessions_dir };
+        let mut value = serde_json::to_value(mgr.create()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("input_suggestion")
+            .unwrap();
+
+        let loaded: Session = serde_json::from_value(value).unwrap();
+        assert!(loaded.input_suggestion.is_none());
+    }
+
+    #[test]
     fn legacy_sessions_have_no_explicit_skill_selection() {
         let sessions_dir =
             std::env::temp_dir().join(format!("programmer-session-test-{}", uuid_v4()));
@@ -921,6 +941,7 @@ mod tests {
         let mut first = mgr.create();
         first.vision_enabled = true;
         first.thinking_level = crate::thinking::ThinkingLevel::High;
+        first.input_suggestion = Some("continue first session".to_string());
         let mut first_todos = crate::todos::TodoList::default();
         first_todos.add("first session only".to_string(), None);
         first.todos = first_todos.todos;
@@ -949,6 +970,11 @@ mod tests {
         );
         assert_eq!(loaded_first.todos[0].title, "first session only");
         assert_eq!(loaded_second.todos[0].title, "second session only");
+        assert_eq!(
+            loaded_first.input_suggestion.as_deref(),
+            Some("continue first session")
+        );
+        assert!(loaded_second.input_suggestion.is_none());
 
         std::fs::remove_dir_all(sessions_dir).unwrap();
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -37,6 +37,9 @@ static LAST_TITLE_HASH: AtomicU64 = AtomicU64::new(0);
 /// Write an OSC 0 terminal title sequence to stdout.  No-ops when `title` is
 /// the same as the last call (fast hash compare — no allocation).
 pub(crate) fn set_terminal_title(title: &str) {
+    // Session titles come from a model and restored JSON, so never allow them
+    // to inject control sequences into OSC 0.
+    let title = sanitize_terminal_title(title);
     let mut hasher = DefaultHasher::new();
     title.hash(&mut hasher);
     let h = hasher.finish();
@@ -46,6 +49,13 @@ pub(crate) fn set_terminal_title(title: &str) {
     use std::io::Write;
     print!("\x1b]0;{}\x07", title);
     let _ = io::stdout().flush();
+}
+
+fn sanitize_terminal_title(title: &str) -> String {
+    title
+        .chars()
+        .filter(|character| !character.is_control())
+        .collect()
 }
 
 /// Initialises the fullscreen TUI, returning the terminal handle and a guard
@@ -117,5 +127,18 @@ impl Drop for TerminalGuard {
         let _ = disable_raw_mode();
         // Invalidate the title cache so a future run starts fresh.
         LAST_TITLE_HASH.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_terminal_title;
+
+    #[test]
+    fn terminal_titles_cannot_inject_control_sequences() {
+        assert_eq!(
+            sanitize_terminal_title("session\n\x1b]0;spoofed\x07"),
+            "session]0;spoofed"
+        );
     }
 }

--- a/src/tools/conversation_history.rs
+++ b/src/tools/conversation_history.rs
@@ -1,0 +1,424 @@
+// Copyright (C) 2026 huangdihd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Read-only access to exact conversation items hidden by the latest
+//! compaction boundary.
+
+use crate::conversation::Conversation;
+use crate::response::message_item::MessageItem;
+use async_openai::types::responses::Tool;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::sync::{Arc, Mutex};
+
+use super::function_tool;
+
+pub const NAME: &str = "conversation_history";
+const DEFAULT_LIST_LIMIT: usize = 20;
+const MAX_LIST_LIMIT: usize = 50;
+const DEFAULT_SEARCH_RESULTS: usize = 10;
+const MAX_SEARCH_RESULTS: usize = 20;
+const DEFAULT_READ_CHARS: usize = 6_000;
+const MAX_READ_CHARS: usize = 7_000;
+const PREVIEW_CHARS: usize = 140;
+const SEARCH_SNIPPET_CHARS: usize = 240;
+
+pub fn tool() -> Tool {
+    function_tool(
+        NAME,
+        "Search or read exact original conversation items hidden behind the latest context-\
+         compaction boundary. Use search to locate details omitted or possibly distorted by the \
+         summary, then read the matching item by index. Read supports character-offset paging for \
+         long messages and tool outputs. This tool is available only when this session contains \
+         compacted history.",
+        json!({
+            "action": {
+                "type": "string",
+                "enum": ["list", "search", "read"],
+                "description": "list archived item previews, search archived content, or read one exact archived item."
+            },
+            "query": {
+                "type": "string",
+                "description": "search only: case-insensitive literal text to find."
+            },
+            "index": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "read only: archived conversation item index returned by list/search."
+            },
+            "start_index": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "list only: first archived conversation item index to consider. Default 0."
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "read only: character offset within the serialized item. Default 0."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "list: maximum entries (default 20, max 50); read: maximum characters (default 6000, max 7000)."
+            },
+            "max_results": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 20,
+                "description": "search only: maximum matching items. Default 10."
+            }
+        }),
+        &["action"],
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Action {
+    List,
+    Search,
+    Read,
+}
+
+#[derive(Debug, Deserialize)]
+struct Args {
+    action: Action,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    start_index: Option<usize>,
+    #[serde(default)]
+    offset: Option<usize>,
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    max_results: Option<usize>,
+}
+
+pub fn available(conversation: &Arc<Mutex<Conversation>>) -> bool {
+    conversation
+        .lock()
+        .unwrap()
+        .items()
+        .any(|item| matches!(item, MessageItem::Compacted { .. }))
+}
+
+pub async fn run(
+    arguments: &str,
+    conversation: &Arc<Mutex<Conversation>>,
+) -> Result<String, String> {
+    let args: Args = serde_json::from_str(arguments)
+        .map_err(|error| format!("error: invalid arguments: {error}"))?;
+    let conversation = conversation.lock().unwrap();
+    let items = conversation.items().collect::<Vec<_>>();
+    let boundary = items
+        .iter()
+        .rposition(|item| matches!(item, MessageItem::Compacted { .. }))
+        .ok_or_else(|| "error: this session has no compacted conversation history".to_string())?;
+    let archived = &items[..boundary];
+
+    match args.action {
+        Action::List => list(archived, &args),
+        Action::Search => search(archived, &args),
+        Action::Read => read(archived, &args),
+    }
+}
+
+fn list(items: &[&MessageItem], args: &Args) -> Result<String, String> {
+    let start = args.start_index.unwrap_or(0);
+    let limit = args.limit.unwrap_or(DEFAULT_LIST_LIMIT).min(MAX_LIST_LIMIT);
+    if limit == 0 {
+        return Err("error: limit must be at least 1".to_string());
+    }
+    if start >= items.len() {
+        return Ok(format!(
+            "no archived items at or after index {start}; archived item count={}",
+            items.len()
+        ));
+    }
+
+    let mut lines = vec![format!(
+        "archived conversation items: {} (latest compaction boundary index: {})",
+        items.len(),
+        items.len()
+    )];
+    for (index, item) in items.iter().enumerate().skip(start).take(limit) {
+        let rendered = render_item(index, item, false)?;
+        lines.push(format!(
+            "[{index}] {} — {}",
+            item_kind(item),
+            one_line_preview(&rendered, PREVIEW_CHARS)
+        ));
+    }
+    let next = start.saturating_add(limit);
+    if next < items.len() {
+        lines.push(format!(
+            "more items available; continue with start_index={next}"
+        ));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn search(items: &[&MessageItem], args: &Args) -> Result<String, String> {
+    let query = args
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .ok_or_else(|| "error: query is required for search".to_string())?;
+    let needle = query.to_lowercase();
+    let max_results = args
+        .max_results
+        .unwrap_or(DEFAULT_SEARCH_RESULTS)
+        .clamp(1, MAX_SEARCH_RESULTS);
+    let mut matches = Vec::new();
+
+    for (index, item) in items.iter().enumerate() {
+        let rendered = render_item(index, item, false)?;
+        if let Some(line) = rendered
+            .lines()
+            .find(|line| line.to_lowercase().contains(&needle))
+        {
+            matches.push(format!(
+                "[{index}] {} — {}",
+                item_kind(item),
+                one_line_preview(line.trim(), SEARCH_SNIPPET_CHARS)
+            ));
+            if matches.len() == max_results {
+                break;
+            }
+        }
+    }
+
+    if matches.is_empty() {
+        Ok(format!(
+            "no archived conversation items matched literal query {query:?}"
+        ))
+    } else {
+        let count = matches.len();
+        matches.push(format!(
+            "{count} match(es); use action=read with an index for exact content"
+        ));
+        Ok(matches.join("\n"))
+    }
+}
+
+fn read(items: &[&MessageItem], args: &Args) -> Result<String, String> {
+    let index = args
+        .index
+        .ok_or_else(|| "error: index is required for read".to_string())?;
+    let item = items.get(index).ok_or_else(|| {
+        format!(
+            "error: archived item index {index} is out of range (count={})",
+            items.len()
+        )
+    })?;
+    let rendered = render_item(index, item, true)?;
+    let total = rendered.chars().count();
+    let offset = args.offset.unwrap_or(0);
+    if offset > total {
+        return Err(format!(
+            "error: offset {offset} is past the end of archived item {index} ({total} characters)"
+        ));
+    }
+    let limit = args.limit.unwrap_or(DEFAULT_READ_CHARS).min(MAX_READ_CHARS);
+    if limit == 0 {
+        return Err("error: limit must be at least 1".to_string());
+    }
+    let chunk = rendered
+        .chars()
+        .skip(offset)
+        .take(limit)
+        .collect::<String>();
+    let consumed = chunk.chars().count();
+    let next = offset + consumed;
+    let mut output = format!(
+        "archived item {index} ({kind}), characters {offset}..{next} of {total}\n{chunk}",
+        kind = item_kind(item)
+    );
+    if next < total {
+        output.push_str(&format!(
+            "\n[more content available; read index={index} offset={next}]"
+        ));
+    }
+    Ok(output)
+}
+
+fn render_item(index: usize, item: &MessageItem, pretty: bool) -> Result<String, String> {
+    let mut value = match item {
+        MessageItem::Input(input) => json!({ "index": index, "kind": "input", "value": input }),
+        MessageItem::Output(output) => {
+            json!({ "index": index, "kind": "output", "value": output })
+        }
+        MessageItem::ToolOutput {
+            output,
+            failed,
+            approval_label,
+        } => json!({
+            "index": index,
+            "kind": "tool_output",
+            "failed": failed,
+            "approval_label": approval_label,
+            "value": output
+        }),
+        MessageItem::OpenAIError(error) => {
+            json!({ "index": index, "kind": "api_error", "message": error.to_string() })
+        }
+        MessageItem::Error(message) => {
+            json!({ "index": index, "kind": "error", "message": message })
+        }
+        MessageItem::Warning(message) => {
+            json!({ "index": index, "kind": "warning", "message": message })
+        }
+        MessageItem::Info(message) => {
+            json!({ "index": index, "kind": "info", "message": message })
+        }
+        MessageItem::Meta { label, text } => {
+            json!({ "index": index, "kind": "meta", "label": label, "text": text })
+        }
+        MessageItem::Usage(input, output, cached) => json!({
+            "index": index,
+            "kind": "usage",
+            "input_tokens": input,
+            "output_tokens": output,
+            "cached_input_tokens": cached
+        }),
+        MessageItem::Compacted { summary } => {
+            json!({ "index": index, "kind": "earlier_compaction", "summary": summary })
+        }
+    };
+    redact_inline_images(&mut value);
+    if pretty {
+        serde_json::to_string_pretty(&value)
+    } else {
+        serde_json::to_string(&value)
+    }
+    .map_err(|error| format!("error: could not serialize archived item: {error}"))
+}
+
+fn redact_inline_images(value: &mut Value) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                redact_inline_images(value);
+            }
+        }
+        Value::Object(values) => {
+            for (key, value) in values {
+                if key == "image_url" && value.as_str().is_some_and(|url| url.starts_with("data:"))
+                {
+                    *value = Value::String("[inline image data omitted]".to_string());
+                } else {
+                    redact_inline_images(value);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn item_kind(item: &MessageItem) -> &'static str {
+    match item {
+        MessageItem::Input(_) => "input",
+        MessageItem::Output(_) => "output",
+        MessageItem::ToolOutput { .. } => "tool_output",
+        MessageItem::OpenAIError(_) => "api_error",
+        MessageItem::Error(_) => "error",
+        MessageItem::Warning(_) => "warning",
+        MessageItem::Info(_) => "info",
+        MessageItem::Meta { .. } => "meta",
+        MessageItem::Usage(_, _, _) => "usage",
+        MessageItem::Compacted { .. } => "earlier_compaction",
+    }
+}
+
+fn one_line_preview(text: &str, max_chars: usize) -> String {
+    let flattened = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flattened.chars().count() <= max_chars {
+        flattened
+    } else {
+        let mut preview = flattened.chars().take(max_chars).collect::<String>();
+        preview.push('…');
+        preview
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_openai::types::responses::{
+        InputContent, InputMessage, InputRole, MessageItem as ApiMessageItem, OutputStatus,
+    };
+
+    fn compacted_conversation() -> Arc<Mutex<Conversation>> {
+        let mut conversation = Conversation::new();
+        conversation.add_input_message(ApiMessageItem::Input(InputMessage {
+            content: vec![InputContent::InputText(
+                "the exact secret detail is cerulean".into(),
+            )],
+            role: InputRole::User,
+            status: Some(OutputStatus::Completed),
+        }));
+        conversation.add_info_string("another archived entry");
+        conversation.apply_compaction("summary without the detail".to_string());
+        Arc::new(Mutex::new(conversation))
+    }
+
+    #[tokio::test]
+    async fn searches_and_reads_exact_archived_items() {
+        let conversation = compacted_conversation();
+        let found = run(r#"{"action":"search","query":"CERULEAN"}"#, &conversation)
+            .await
+            .unwrap();
+        assert!(found.contains("[0] input"));
+
+        let exact = run(r#"{"action":"read","index":0}"#, &conversation)
+            .await
+            .unwrap();
+        assert!(exact.contains("the exact secret detail is cerulean"));
+        assert!(!exact.contains("summary without the detail"));
+    }
+
+    #[tokio::test]
+    async fn long_items_support_character_offset_paging() {
+        let conversation = compacted_conversation();
+        let first = run(
+            r#"{"action":"read","index":0,"offset":0,"limit":20}"#,
+            &conversation,
+        )
+        .await
+        .unwrap();
+        assert!(first.contains("offset=20"));
+
+        let second = run(
+            r#"{"action":"read","index":0,"offset":20,"limit":20}"#,
+            &conversation,
+        )
+        .await
+        .unwrap();
+        assert!(second.contains("characters 20.."));
+    }
+
+    #[tokio::test]
+    async fn rejects_sessions_without_compacted_history() {
+        let conversation = Arc::new(Mutex::new(Conversation::new()));
+        let error = run(r#"{"action":"list"}"#, &conversation)
+            .await
+            .unwrap_err();
+        assert!(error.contains("no compacted conversation history"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,6 +18,7 @@ pub mod ask_user;
 pub mod blob;
 pub mod command;
 pub mod configure_diagnostics;
+pub mod conversation_history;
 pub mod diagnostics;
 pub mod edit_file;
 pub mod fetch;
@@ -119,7 +120,7 @@ pub fn environment_info() -> String {
         .or_else(|_| std::env::var("LC_ALL"))
         .unwrap_or_else(|_| "unknown".to_string());
 
-    let mut info = format!(
+    format!(
         "# Environment info\n\
          - Operating system: {os} ({arch})\n\
          - Shell for the `command` tool: {shell}\n\
@@ -130,25 +131,7 @@ pub fn environment_info() -> String {
         shell = program,
         cwd = cwd,
         locale = locale,
-    );
-
-    // Point the model at project resources without spending tokens on their
-    // contents — it can read them on demand when relevant.
-    if std::path::Path::new("PROGRAMMER.md").exists() {
-        info.push_str(
-            "\n- A project overview exists at PROGRAMMER.md — read it with \
-             read_file when you need project context.",
-        );
-    }
-    if std::path::Path::new(crate::diagnostics::PROFILE_PATH).exists() {
-        info.push_str(
-            "\n- A diagnostics profile is configured; edits are checked \
-             automatically. Re-run setup any time with the /init flow or by \
-             calling configure_diagnostics.",
-        );
-    }
-
-    info
+    )
 }
 
 // The advertised tool list is now assembled by the `provider` layer: the
@@ -317,7 +300,12 @@ pub(crate) fn mcp_server_tools() -> Vec<Tool> {
 pub(crate) fn is_read_only_builtin(name: &str) -> bool {
     matches!(
         name,
-        read_file::NAME | read_image::NAME | grep::NAME | blob::NAME | fetch::NAME
+        read_file::NAME
+            | read_image::NAME
+            | grep::NAME
+            | blob::NAME
+            | fetch::NAME
+            | conversation_history::NAME
     )
 }
 
@@ -450,6 +438,13 @@ fn function_tool(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn environment_info_does_not_encode_project_initialization_state() {
+        let info = environment_info();
+        assert!(!info.contains("PROGRAMMER.md"));
+        assert!(!info.contains("diagnostics profile"));
+    }
 
     #[tokio::test]
     async fn command_runs_and_captures_output() {

--- a/src/tools/provider.rs
+++ b/src/tools/provider.rs
@@ -24,9 +24,9 @@
 //! never sniffs prefixes.
 
 use super::{
-    agent, ask_user, blob, command, configure_diagnostics, diagnostics, edit_file, fetch, grep,
-    load_skill, mcp_bridge, memory, read_file, read_image, request_permission, run_local_tool,
-    task, todo, write_file,
+    agent, ask_user, blob, command, configure_diagnostics, conversation_history, diagnostics,
+    edit_file, fetch, grep, load_skill, mcp_bridge, memory, read_file, read_image,
+    request_permission, run_local_tool, task, todo, write_file,
 };
 use crate::mcp::McpManager;
 use crate::ui::event::Event;
@@ -182,6 +182,7 @@ pub(crate) struct LocalToolProvider {
     file_scope: u64,
     checkpoint: Option<crate::checkpoint::CheckpointRecorder>,
     memory_enabled: bool,
+    conversation_history: Option<Arc<Mutex<crate::conversation::Conversation>>>,
 }
 
 impl LocalToolProvider {
@@ -195,6 +196,7 @@ impl LocalToolProvider {
             file_scope: 0,
             checkpoint: None,
             memory_enabled: true,
+            conversation_history: None,
         }
     }
 
@@ -209,6 +211,7 @@ impl LocalToolProvider {
             file_scope,
             checkpoint: None,
             memory_enabled: true,
+            conversation_history: None,
         }
     }
 
@@ -222,6 +225,14 @@ impl LocalToolProvider {
 
     pub(crate) fn with_memory_enabled(mut self, enabled: bool) -> Self {
         self.memory_enabled = enabled;
+        self
+    }
+
+    pub(crate) fn with_conversation_history(
+        mut self,
+        conversation: Option<Arc<Mutex<crate::conversation::Conversation>>>,
+    ) -> Self {
+        self.conversation_history = conversation;
         self
     }
 }
@@ -262,6 +273,13 @@ impl ToolProvider for LocalToolProvider {
         ];
         if self.memory_enabled {
             tools.push(memory::tool());
+        }
+        if self
+            .conversation_history
+            .as_ref()
+            .is_some_and(conversation_history::available)
+        {
+            tools.push(conversation_history::tool());
         }
         tools
     }
@@ -323,6 +341,13 @@ impl ToolProvider for LocalToolProvider {
                 .map(FunctionCallOutput::Text)
         } else if call.name == memory::NAME {
             memory::run(&call.arguments)
+                .await
+                .map(FunctionCallOutput::Text)
+        } else if call.name == conversation_history::NAME {
+            let conversation = self.conversation_history.as_ref().ok_or_else(|| {
+                "error: this session has no compacted conversation history".to_string()
+            })?;
+            conversation_history::run(&call.arguments, conversation)
                 .await
                 .map(FunctionCallOutput::Text)
         } else if call.name == read_image::NAME {
@@ -604,6 +629,27 @@ mod tests {
         assert!(p.requires_interaction(ask_user::NAME));
         assert!(p.requires_interaction(request_permission::NAME));
         assert!(!p.requires_interaction(read_file::NAME));
+        assert!(!names.contains(&conversation_history::NAME.to_string()));
+    }
+
+    #[test]
+    fn conversation_history_is_advertised_only_after_compaction() {
+        let conversation = Arc::new(Mutex::new(crate::conversation::Conversation::new()));
+        conversation
+            .lock()
+            .unwrap()
+            .add_info_string("archived detail");
+        conversation
+            .lock()
+            .unwrap()
+            .apply_compaction("summary".to_string());
+        let provider = LocalToolProvider::default().with_conversation_history(Some(conversation));
+
+        assert!(provider.tools().iter().any(|tool| matches!(
+            tool,
+            Tool::Function(function) if function.name == conversation_history::NAME
+        )));
+        assert!(provider.is_read_only(conversation_history::NAME));
     }
 
     #[test]

--- a/src/ui/components/input_panel/input_panel.rs
+++ b/src/ui/components/input_panel/input_panel.rs
@@ -18,6 +18,8 @@ use async_openai::types::responses::InputImageContent;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui_textarea::{CursorMove, Input, TextArea};
 
+const DEFAULT_PLACEHOLDER: &str = "Talk with the programmer…";
+
 #[derive(Debug, Clone)]
 pub struct InputPanel<'a> {
     pub text_area: TextArea<'a>,
@@ -36,6 +38,8 @@ pub struct InputPanel<'a> {
     /// Details shown in the title until the next model turn consumes a freshly
     /// compacted context.
     pub(crate) next_turn_compaction: Option<String>,
+    /// Model-predicted next user message shown as the empty input placeholder.
+    suggestion: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,7 +57,7 @@ impl InputPanel<'_> {
         text_area.set_style(Style::default().fg(Color::White));
         text_area.set_cursor_line_style(Style::default());
         text_area.set_cursor_style(Style::default().add_modifier(Modifier::REVERSED));
-        text_area.set_placeholder_text("Talk with the programmer…");
+        text_area.set_placeholder_text(DEFAULT_PLACEHOLDER);
         text_area.set_placeholder_style(
             Style::default()
                 .fg(Color::DarkGray)
@@ -69,7 +73,34 @@ impl InputPanel<'_> {
             images: Vec::new(),
             next_image_id: 1,
             next_turn_compaction: None,
+            suggestion: None,
         }
+    }
+
+    pub(crate) fn set_suggestion(&mut self, suggestion: String) {
+        self.text_area.set_placeholder_text(suggestion.clone());
+        self.suggestion = Some(suggestion);
+    }
+
+    pub(crate) fn suggestion(&self) -> Option<&str> {
+        self.suggestion.as_deref()
+    }
+
+    pub(crate) fn clear_suggestion(&mut self) {
+        self.text_area.set_placeholder_text(DEFAULT_PLACEHOLDER);
+        self.suggestion = None;
+    }
+
+    pub(crate) fn accept_suggestion(&mut self) -> bool {
+        if !self.get_content().is_empty() {
+            return false;
+        }
+        let Some(suggestion) = self.suggestion.take() else {
+            return false;
+        };
+        self.text_area.set_placeholder_text(DEFAULT_PLACEHOLDER);
+        self.set_content(&suggestion);
+        true
     }
 
     pub(crate) fn show_next_turn_compaction(&mut self, details: String) {
@@ -268,6 +299,7 @@ impl InputPanel<'_> {
     }
 
     pub fn clear(&mut self) -> bool {
+        self.clear_suggestion();
         self.pastes.clear();
         self.images.clear();
         self.next_image_id = 1;
@@ -277,6 +309,7 @@ impl InputPanel<'_> {
 
     /// Replace the entire content of the text area with `text`.
     pub fn set_content(&mut self, text: &str) {
+        self.clear_suggestion();
         self.text_area.clear();
         self.text_area.insert_str(text);
     }
@@ -374,6 +407,32 @@ mod tests {
 
         assert!(panel.get_content().is_empty());
         assert!(panel.completion.is_none());
+    }
+
+    #[test]
+    fn suggestion_is_accepted_only_into_an_empty_input() {
+        let mut panel = InputPanel::new();
+        panel.set_suggestion("继续修复测试".to_string());
+        assert!(panel.accept_suggestion());
+        assert_eq!(panel.get_content(), "继续修复测试");
+        assert!(!panel.accept_suggestion());
+
+        panel.clear();
+        panel.set_suggestion("删除草稿后恢复".to_string());
+        panel.input(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('x'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(!panel.accept_suggestion());
+        panel.input(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Backspace,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(
+            panel.accept_suggestion(),
+            "emptying the draft restores the hint"
+        );
+        assert_eq!(panel.get_content(), "删除草稿后恢复");
     }
 
     #[test]

--- a/src/ui/components/messages/pending_message.rs
+++ b/src/ui/components/messages/pending_message.rs
@@ -13,10 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ratatui::prelude::Color;
-use ratatui::style::Stylize;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::Borders;
 use ratatui_widgets::block::Block;
 use ratatui_widgets::paragraph::{Paragraph, Wrap};
+
+use crate::ui::markdown_theme::palette;
 
 pub struct PendingMessage<'a> {
     text: &'a str,
@@ -28,13 +31,80 @@ impl<'a> PendingMessage<'a> {
     }
 
     pub fn into_paragraph(self) -> Paragraph<'a> {
+        let header = Line::from(vec![
+            Span::styled(
+                "  QUEUED",
+                Style::default()
+                    .fg(palette::YELLOW)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  ·  ", Style::default().fg(palette::FAINT)),
+            Span::styled(
+                " Esc ",
+                Style::default()
+                    .fg(palette::CODE_BG)
+                    .bg(palette::YELLOW)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" interrupt  ·  ", Style::default().fg(palette::MUTED)),
+            Span::styled(
+                " ↑ ",
+                Style::default()
+                    .fg(palette::TEXT)
+                    .bg(palette::SURFACE)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" edit", Style::default().fg(palette::MUTED)),
+        ]);
+        let mut lines = vec![header];
+        for (index, line) in self.text.lines().enumerate() {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    if index == 0 { "  ↳  " } else { "     " },
+                    Style::default().fg(palette::YELLOW),
+                ),
+                Span::styled(line, Style::default().fg(palette::TEXT)),
+            ]));
+        }
         let block = Block::default()
-            .title("Pending Message")
-            .title_style(Color::Green);
-        Paragraph::new(self.text)
+            .borders(Borders::TOP | Borders::BOTTOM)
+            .border_style(Style::default().fg(palette::BORDER))
+            .style(Style::default().bg(palette::CODE_BG));
+
+        Paragraph::new(Text::from(lines))
             .block(block)
-            .fg(Color::LightBlue)
-            .bg(Color::DarkGray)
-            .wrap(Wrap { trim: true })
+            .wrap(Wrap { trim: false })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::widgets::Widget;
+
+    #[test]
+    fn queued_strip_shows_interrupt_hint_and_message() {
+        let area = Rect::new(0, 0, 60, 4);
+        let mut buffer = Buffer::empty(area);
+        let paragraph = PendingMessage::new("continue with the tests").into_paragraph();
+
+        assert_eq!(paragraph.line_count(area.width), area.height as usize);
+        paragraph.render(area, &mut buffer);
+
+        let rendered = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("QUEUED"), "{rendered}");
+        assert!(rendered.contains("Esc"), "{rendered}");
+        assert!(rendered.contains("interrupt"), "{rendered}");
+        assert!(rendered.contains("↑  edit"), "{rendered}");
+        assert!(rendered.contains("continue with the tests"), "{rendered}");
     }
 }

--- a/src/ui/components/provider_panel/mod.rs
+++ b/src/ui/components/provider_panel/mod.rs
@@ -280,6 +280,13 @@ impl ProviderPanel {
                 {
                     config.title_model = None;
                 }
+                if config
+                    .suggestion_model
+                    .as_deref()
+                    .is_some_and(|model| model.starts_with(&format!("{name}/")))
+                {
+                    config.suggestion_model = None;
+                }
                 // Keep default_provider pointing at something that exists.
                 if config.default_provider == name {
                     config.default_provider = Self::sorted_names(config)
@@ -448,6 +455,7 @@ impl ProviderPanel {
                     rename_global_model_provider(&mut config.classifier_model, original, &name);
                     rename_global_model_provider(&mut config.compact_model, original, &name);
                     rename_global_model_provider(&mut config.title_model, original, &name);
+                    rename_global_model_provider(&mut config.suggestion_model, original, &name);
                 }
                 config.providers.insert(
                     name.clone(),
@@ -587,7 +595,7 @@ impl ProviderPanel {
                 PanelAction::None
             }
             KeyCode::Down | KeyCode::Char('j') => {
-                *selected = (*selected + 1).min(6);
+                *selected = (*selected + 1).min(8);
                 PanelAction::None
             }
             KeyCode::Enter => {
@@ -601,9 +609,11 @@ impl ProviderPanel {
                     1 => config.classifier_model = Some(qualified),
                     2 => config.compact_model = Some(qualified),
                     3 => config.title_model = Some(qualified),
-                    4 => config.classifier_model = None,
-                    5 => config.compact_model = None,
-                    6 => config.title_model = None,
+                    4 => config.suggestion_model = Some(qualified),
+                    5 => config.classifier_model = None,
+                    6 => config.compact_model = None,
+                    7 => config.title_model = None,
+                    8 => config.suggestion_model = None,
                     _ => unreachable!(),
                 }
                 self.mode = Mode::List;
@@ -957,6 +967,8 @@ impl ProviderPanel {
                         let is_compact =
                             config.compact_model.as_deref() == Some(qualified.as_str());
                         let is_title = config.title_model.as_deref() == Some(qualified.as_str());
+                        let is_suggestion =
+                            config.suggestion_model.as_deref() == Some(qualified.as_str());
                         let mut spans = if f.is_empty() {
                             vec![Span::styled((*m).to_string(), style)]
                         } else {
@@ -1001,6 +1013,12 @@ impl ProviderPanel {
                             spans.push(Span::styled(
                                 "  title",
                                 Style::default().fg(palette::YELLOW),
+                            ));
+                        }
+                        if is_suggestion {
+                            spans.push(Span::styled(
+                                "  suggestion",
+                                Style::default().fg(palette::BLUE),
                             ));
                         }
                         ListItem::new(Line::from(spans))
@@ -1073,9 +1091,11 @@ impl ProviderPanel {
                     "Set as global classifier model",
                     "Set as global compact model",
                     "Set as global title model",
+                    "Set as global suggestion model",
                     "Clear global classifier model",
                     "Clear global compact model",
                     "Clear global title model",
+                    "Clear global suggestion model",
                 ];
                 let items = choices.iter().enumerate().map(|(index, choice)| {
                     let style = if index == *selected {
@@ -1183,6 +1203,7 @@ mod tests {
             classifier_top_logprobs: crate::consts::DEFAULT_CLASSIFIER_TOP_LOGPROBS,
             compact_model: None,
             title_model: None,
+            suggestion_model: None,
             auto_compact_tokens: 100_000,
             compact_keep_recent_turns: 2,
             memory: Default::default(),
@@ -1321,6 +1342,35 @@ mod tests {
             &panel.mode,
             Mode::Models { filter, .. } if filter == "deepseek"
         ));
+    }
+
+    #[test]
+    fn model_role_menu_sets_and_clears_suggestion_model() {
+        let mut config = config_with(&["alpha"]);
+        let pm = pm_stub();
+        let mut panel = ProviderPanel::new();
+        panel.mode = Mode::RoleMenu {
+            provider: "alpha".to_string(),
+            model: "fast".to_string(),
+            selected: 4,
+        };
+
+        assert_eq!(
+            panel.handle_key(key(KeyCode::Enter), &mut config, &pm),
+            PanelAction::Saved
+        );
+        assert_eq!(config.suggestion_model.as_deref(), Some("alpha/fast"));
+
+        panel.mode = Mode::RoleMenu {
+            provider: "alpha".to_string(),
+            model: "fast".to_string(),
+            selected: 8,
+        };
+        assert_eq!(
+            panel.handle_key(key(KeyCode::Enter), &mut config, &pm),
+            PanelAction::Saved
+        );
+        assert!(config.suggestion_model.is_none());
     }
 
     #[test]

--- a/src/ui/event.rs
+++ b/src/ui/event.rs
@@ -111,6 +111,13 @@ pub enum AppEvent {
     /// Background generation of the current session's display title finished.
     SessionTitleGenerated {
         session_uuid: String,
+        generation_id: u64,
+        result: Result<String, String>,
+    },
+    /// Background prediction of the next user message finished.
+    InputSuggestionGenerated {
+        session_uuid: String,
+        operation_id: u64,
         result: Result<String, String>,
     },
     /// A background process entered a terminal state.
@@ -248,9 +255,20 @@ impl std::fmt::Debug for AppEvent {
             Self::SessionTitleGenerated {
                 session_uuid,
                 result,
+                ..
             } => f
                 .debug_struct("SessionTitleGenerated")
                 .field("session_uuid", session_uuid)
+                .field("result", &result.as_ref().map(|_| ".."))
+                .finish(),
+            Self::InputSuggestionGenerated {
+                session_uuid,
+                operation_id,
+                result,
+            } => f
+                .debug_struct("InputSuggestionGenerated")
+                .field("session_uuid", session_uuid)
+                .field("operation_id", operation_id)
                 .field("result", &result.as_ref().map(|_| ".."))
                 .finish(),
             Self::TaskStateChanged(event) => f

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -25,6 +25,15 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
 
+fn terminal_title_subject<'a>(session_title: &'a str, project_name: &'a str) -> &'a str {
+    let session_title = session_title.trim();
+    if session_title.is_empty() {
+        project_name
+    } else {
+        session_title
+    }
+}
+
 impl App<'_> {
     /// The single status the footer shows, by precedence: user-input waits
     /// first, then the current busy phase, then idle.
@@ -345,11 +354,14 @@ impl Widget for &mut App<'_> {
         // Resolve the single status the footer should show, then let the
         // status bar track its own busy timer.
         self.footer.status.set(self.resolve_status());
-        // Keep the terminal title in sync with the current status.
+        // Keep the terminal title in sync with the current status. Once the
+        // session has a generated title, use it in place of the project
+        // directory so several Programmer windows remain distinguishable.
+        let title_subject = terminal_title_subject(&self.session.title, &self.project_name);
         crate::terminal::set_terminal_title(&format!(
             "{} {} \u{b7} programmer",
             self.footer.status.status.emoji_label(),
-            self.project_name,
+            title_subject,
         ));
         self.footer.status.detail = None;
         self.footer.work_mode = self.work_mode;
@@ -461,5 +473,19 @@ impl Widget for &mut App<'_> {
             self.sidebar_area = None;
             self.render_main(content_area, buf, bottom_height);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::terminal_title_subject;
+
+    #[test]
+    fn session_title_replaces_project_name_in_terminal_title() {
+        assert_eq!(
+            terminal_title_subject("Fix compaction", "programmer"),
+            "Fix compaction"
+        );
+        assert_eq!(terminal_title_subject("   ", "programmer"), "programmer");
     }
 }


### PR DESCRIPTION
### Programmer v0.2.9

## What's changed
- Add model-generated next-message suggestions with Right-arrow acceptance, session persistence, and configurable provider/model selection.
- Add the read-only `conversation_history` tool for listing, searching, and paging through exact items hidden by context compaction.
- Persist generated compaction summaries at safe idle boundaries so resumed sessions do not repeat completed compaction work.
- Add `/title`, use session titles in terminal titles, and sanitize terminal control sequences.
- Improve queued-message presentation and project initialization/overview reminders.
- Update README and PROGRAMMER.md documentation.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (546 passed, 1 ignored)
- `cargo build --release`
