### PR TITLE
v0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.9"
+version = "0.2.10"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -53,10 +53,30 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-/// Keep input bursts from starving terminal redraws. Four events per frame
-/// sustains 120 events/second at the normal 30 FPS tick rate while giving
-/// trackpad scrolling and streamed output a frame boundary every few events.
+/// Bound how many already-queued events are folded into state in one pass.
+/// Bound how many non-streaming events are folded into state in one pass.
 const MAX_EVENTS_PER_FRAME: usize = 4;
+/// Streaming chunks are cheap to merge and must not consume the interaction
+/// event budget, otherwise a fast provider can delay keyboard and mouse input.
+const MAX_CHUNKS_PER_BATCH: usize = 256;
+
+fn event_requests_immediate_redraw(event: &Event) -> bool {
+    !matches!(
+        event,
+        Event::App(crate::ui::event::AppEvent::ChunkReceived(_, _))
+    )
+}
+
+fn scroll_direction(event: &Event) -> Option<crossterm::event::MouseEventKind> {
+    match event {
+        Event::Crossterm(crossterm::event::Event::Mouse(mouse)) => match mouse.kind {
+            crossterm::event::MouseEventKind::ScrollUp
+            | crossterm::event::MouseEventKind::ScrollDown => Some(mouse.kind),
+            _ => None,
+        },
+        _ => None,
+    }
+}
 
 /// A pending tool-call review request from the runner. Manual mode now gets
 /// per-call reviews (no batch), driven by the runner's `review()` callback.
@@ -403,6 +423,8 @@ impl App<'_> {
         let mut saved_input_suggestion = None;
 
         let mut saved_activated_skills: Option<Vec<String>> = None;
+        let mut saved_file_snapshots: Vec<crate::security::policy::PersistedFileSnapshot> =
+            Vec::new();
         if let Some(mgr) = &session_mgr
             && let Some(saved) = mgr.load(&session_uuid)
         {
@@ -416,6 +438,7 @@ impl App<'_> {
             }
             session_title = saved.title;
             saved_input_suggestion = saved.input_suggestion;
+            saved_file_snapshots = saved.file_snapshots;
             vision_enabled = saved.vision_enabled;
             thinking_level = saved.thinking_level;
             classifier_model_override = saved.classifier_model_override;
@@ -450,6 +473,7 @@ impl App<'_> {
                 .expect("security configuration should be validated before starting the app"),
         );
         crate::security::install_active(security_manager.clone());
+        security_manager.restore_snapshots(&saved_file_snapshots);
         let security = Arc::new(crate::security::SecurityHandle::new(security_manager));
         let mcp_server_statuses = config
             .mcp_servers
@@ -777,21 +801,64 @@ impl App<'_> {
         crate::app::diagnostics::maybe_seed_diagnostics_baseline(&mut self);
 
         let result = async {
+            // Paint startup state immediately. After this, raw stream chunks only
+            // mutate the in-flight response; Tick presents their accumulated state
+            // at the configured frame rate. User input and lifecycle events still
+            // request an immediate frame.
+            terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
             while self.running {
-                terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
-
                 let mut event = Some(self.events.next().await?);
-                for index in 0..MAX_EVENTS_PER_FRAME {
+                let mut redraw = false;
+                let mut regular_events = 0;
+                let mut chunks = 0;
+                loop {
                     let Some(current) = event.take() else {
                         break;
                     };
+                    let chunk_received = matches!(
+                        &current,
+                        Event::App(crate::ui::event::AppEvent::ChunkReceived(_, _))
+                    );
+                    let current_scroll_direction = scroll_direction(&current);
+                    redraw |= matches!(&current, Event::Tick)
+                        || event_requests_immediate_redraw(&current);
                     self.handle_event(current).await?;
-                    if !self.running {
+                    if chunk_received {
+                        chunks += 1;
+                    } else {
+                        regular_events += 1;
+                    }
+                    // Busy status labels contain a live elapsed timer. Keep
+                    // that timer moving only while a busy phase is active;
+                    // idle sessions still produce no synthetic Tick events.
+                    if self.footer.status.status.is_busy() {
+                        self.events.schedule_redraw();
+                    }
+                    // Mouse wheel events are often delivered in a burst. Consume
+                    // only the contiguous events with the same direction, so a
+                    // reverse scroll or any keyboard/input event remains next.
+                    if let Some(direction) = current_scroll_direction {
+                        while let Some(next) = self.events.try_next() {
+                            if scroll_direction(&next) != Some(direction) {
+                                event = Some(next);
+                                break;
+                            }
+                            redraw |= event_requests_immediate_redraw(&next);
+                            self.handle_event(next).await?;
+                        }
+                    }
+                    if !self.running || redraw {
                         break;
                     }
-                    if index + 1 < MAX_EVENTS_PER_FRAME {
+                    if regular_events >= MAX_EVENTS_PER_FRAME || chunks >= MAX_CHUNKS_PER_BATCH {
+                        break;
+                    }
+                    if event.is_none() {
                         event = self.events.try_next();
                     }
+                }
+                if self.running && redraw {
+                    terminal.draw(|frame| frame.render_widget(&mut self, frame.area()))?;
                 }
             }
             Ok(())
@@ -831,10 +898,17 @@ impl App<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::TaskNotificationState;
+    use super::{TaskNotificationState, event_requests_immediate_redraw};
+    use crate::ui::event::{AppEvent, Event};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
+
+    #[test]
+    fn redraw_policy_keeps_ticks_and_interaction_immediate_but_throttles_chunks() {
+        assert!(event_requests_immediate_redraw(&Event::Tick));
+        assert!(event_requests_immediate_redraw(&Event::App(AppEvent::Quit)));
+    }
 
     fn event(sequence: u64) -> crate::tasks::TaskLifecycleEvent {
         crate::tasks::TaskLifecycleEvent {

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -106,6 +106,7 @@ fn persist_session(app: &mut App<'_>) -> Result<bool, String> {
     session.activated_skills = app.skill_registry.activated_names().to_vec();
     session.skill_selection_saved = true;
     session.tasks = crate::tasks::persist_all();
+    session.file_snapshots = app.security.snapshot().persisted_snapshots();
     mgr.save(&mut session)?;
     app.session.did_save = true;
     Ok(true)

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -39,9 +39,6 @@ pub(crate) const MAX_CONCURRENT_READ_TOOLS: usize = 8;
 /// connection error before giving up.
 pub(crate) const MAX_STREAM_RETRIES: u32 = 10;
 
-/// The frequency at which tick events are emitted.
-pub(crate) const TICK_FPS: f64 = 30.0;
-
 /// How many file-editing turns pass between reminders to refresh PROGRAMMER.md.
 pub(crate) const OVERVIEW_REMINDER_EVERY: usize = 5;
 

--- a/src/response/partial_response.rs
+++ b/src/response/partial_response.rs
@@ -183,31 +183,30 @@ impl PartialResponse {
     /// Iterate over Markdown-bearing assistant items without cloning them.
     /// The UI uses the item revision to clone only a changed item before
     /// handing it to the background renderer.
-    pub fn markdown_items(&self) -> Vec<(usize, &OutputItem, bool, u64)> {
+    pub fn markdown_items(&self) -> impl Iterator<Item = (usize, &OutputItem, bool, u64)> + '_ {
         let mut live_index = 0;
-        let mut items = Vec::new();
-        for (protocol_index, slot) in self.items.iter().enumerate() {
-            let Some(item) = slot.as_ref() else {
-                continue;
-            };
-            let current_live_index = live_index;
-            live_index += 1;
-            if !matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_)) {
-                continue;
-            }
-            let in_progress = !self
-                .finished_items
-                .get(protocol_index)
-                .copied()
-                .unwrap_or(false);
-            let revision = self
-                .item_revisions
-                .get(protocol_index)
-                .copied()
-                .unwrap_or_default();
-            items.push((current_live_index, item, in_progress, revision));
-        }
-        items
+        self.items
+            .iter()
+            .enumerate()
+            .filter_map(move |(protocol_index, slot)| {
+                let item = slot.as_ref()?;
+                let current_live_index = live_index;
+                live_index += 1;
+                if !matches!(item, OutputItem::Message(_) | OutputItem::Reasoning(_)) {
+                    return None;
+                }
+                let in_progress = !self
+                    .finished_items
+                    .get(protocol_index)
+                    .copied()
+                    .unwrap_or(false);
+                let revision = self
+                    .item_revisions
+                    .get(protocol_index)
+                    .copied()
+                    .unwrap_or_default();
+                Some((current_live_index, item, in_progress, revision))
+            })
     }
 
     pub fn handle_response_stream_event(&mut self, response_stream_event: ResponseStreamEvent) {
@@ -825,7 +824,7 @@ mod tests {
         p.set_item(msg_item(), 2);
         p.set_item(fc_item(), 4);
 
-        let items = p.markdown_items();
+        let items: Vec<_> = p.markdown_items().collect();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].0, 0, "live UI indices skip protocol gaps");
         assert_eq!(items[0].3, 0);

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -192,6 +192,12 @@ struct CompiledRule {
     matcher: GlobMatcher,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct PersistedFileSnapshot {
+    pub(crate) path: PathBuf,
+    pub(crate) hash: [u8; 32],
+}
+
 pub(crate) struct SecurityManager {
     workspace: PathBuf,
     config: SecurityConfig,
@@ -411,6 +417,34 @@ impl SecurityManager {
             .and_then(serde_json::Value::as_str)
             .ok_or_else(|| "missing path for security check".to_string())?;
         self.authorize_path(operation, path).map(|_| ())
+    }
+
+    pub(crate) fn persisted_snapshots(&self) -> Vec<PersistedFileSnapshot> {
+        self.snapshots
+            .lock()
+            .map(|snapshots| {
+                snapshots
+                    .iter()
+                    .filter_map(|((scope, path), hash)| {
+                        (*scope == 0).then_some(PersistedFileSnapshot {
+                            path: path.clone(),
+                            hash: *hash.as_bytes(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn restore_snapshots(&self, snapshots: &[PersistedFileSnapshot]) {
+        if let Ok(mut current) = self.snapshots.lock() {
+            for snapshot in snapshots {
+                current.insert(
+                    (0, snapshot.path.clone()),
+                    blake3::Hash::from_bytes(snapshot.hash),
+                );
+            }
+        }
     }
 
     pub(crate) fn record_read(&self, path: &Path, contents: &[u8]) {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -241,6 +241,9 @@ pub(crate) struct Session {
     /// are restored as killed — their processes died with the old instance.
     #[serde(default)]
     pub(crate) tasks: Vec<crate::tasks::PersistedTask>,
+    /// File content fingerprints read in this session, used by file protection after resume.
+    #[serde(default)]
+    pub(crate) file_snapshots: Vec<crate::security::policy::PersistedFileSnapshot>,
 }
 
 pub(crate) struct SessionManager {
@@ -312,6 +315,7 @@ impl SessionManager {
             activated_skills: Vec::new(),
             skill_selection_saved: false,
             tasks: Vec::new(),
+            file_snapshots: Vec::new(),
         }
     }
 

--- a/src/ui/components/conversation_panel/ui.rs
+++ b/src/ui/components/conversation_panel/ui.rs
@@ -261,6 +261,12 @@ fn render_virtual_welcome(
     }
 }
 
+fn restore_bottom_follow(panel: &mut ConversationPanel) {
+    if !panel.stick_to_bottom && panel.scroll_view_state.is_at_bottom() {
+        panel.stick_to_bottom = true;
+    }
+}
+
 fn live_cache_matches(
     cache: &LiveRenderCache,
     response_revision: u64,
@@ -576,6 +582,12 @@ impl Widget for &mut ConversationPanel {
         // before calculating live layout. No Markdown parser is run on this
         // render thread.
         self.prepare_live_markdown(content_width);
+        // Keep the semantic follow flag consistent with the actual scroll
+        // position. A response can finish between frames and increase the
+        // virtual height; if the previous frame was already at the bottom,
+        // continue following the new bottom even if an intermediate event did
+        // not update the flag.
+        restore_bottom_follow(self);
         let stick_to_bottom = self.stick_to_bottom;
         let welcome_message = WelcomeMessage;
         let welcome_height = welcome_message.line_count(content_width);
@@ -1556,7 +1568,10 @@ impl Widget for &mut ConversationPanel {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_hidden_developer_input, render_virtual_paragraph};
+    use super::{
+        is_hidden_developer_input, live_cache_matches, render_virtual_paragraph,
+        restore_bottom_follow,
+    };
     use async_openai::types::responses::{
         FunctionCallOutput, FunctionCallOutputItemParam, FunctionToolCall, InputContent,
         InputMessage, InputRole, InputTextContent, Item, MessageItem as ApiMessageItem, OutputItem,
@@ -1570,8 +1585,85 @@ mod tests {
 
     use crate::tools::ToolOutput;
     use crate::ui::components::conversation_panel::conversation_panel::{
-        ActivePhase, ConversationPanel, ViewportParagraphCache,
+        ActivePhase, ConversationPanel, LiveRenderCache, ViewportParagraphCache,
     };
+    use std::collections::HashSet;
+
+    #[test]
+    fn streaming_output_growth_keeps_a_previous_bottom_view_at_the_bottom() {
+        let mut panel = ConversationPanel::new();
+        panel.stick_to_bottom = false;
+        panel.scroll_view_state.update(20, 10);
+        panel.scroll_view_state.scroll_to_bottom();
+
+        // The flag may be stale when the response finishes, but the view was
+        // still at the old bottom before the virtual content grew.
+        restore_bottom_follow(&mut panel);
+        assert!(panel.stick_to_bottom);
+
+        panel.scroll_view_state.update(40, 10);
+        if panel.stick_to_bottom {
+            panel.scroll_view_state.scroll_to_bottom();
+        }
+        assert_eq!(panel.scroll_view_state.offset().y, 30);
+        assert!(panel.scroll_view_state.is_at_bottom());
+    }
+
+    #[test]
+    fn live_layout_cache_key_invalidates_revision_width_and_fold_state() {
+        let cache = LiveRenderCache {
+            response_revision: 7,
+            content_width: 80,
+            conversation_len: 12,
+            conversation_mutation_version: 3,
+            expanded_items: HashSet::from([2]),
+            live_expanded_items: HashSet::from([0]),
+            bridged_committed_items: HashSet::from([4]),
+            slots: Vec::new(),
+        };
+        let expanded_items = HashSet::from([2]);
+        let live_expanded_items = HashSet::from([0]);
+
+        assert!(live_cache_matches(
+            &cache,
+            7,
+            80,
+            12,
+            3,
+            &expanded_items,
+            &live_expanded_items
+        ));
+        assert!(!live_cache_matches(
+            &cache,
+            8,
+            80,
+            12,
+            3,
+            &expanded_items,
+            &live_expanded_items
+        ));
+        assert!(!live_cache_matches(
+            &cache,
+            7,
+            81,
+            12,
+            3,
+            &expanded_items,
+            &live_expanded_items
+        ));
+
+        let mut changed_folds = expanded_items.clone();
+        changed_folds.insert(5);
+        assert!(!live_cache_matches(
+            &cache,
+            7,
+            80,
+            12,
+            3,
+            &changed_folds,
+            &live_expanded_items,
+        ));
+    }
 
     #[test]
     fn developer_runtime_inputs_are_hidden_from_chat_rendering() {

--- a/src/ui/components/messages/pending_message.rs
+++ b/src/ui/components/messages/pending_message.rs
@@ -13,14 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::Borders;
-use ratatui_widgets::block::Block;
-use ratatui_widgets::paragraph::{Paragraph, Wrap};
+use ratatui_widgets::paragraph::Paragraph;
 
+use super::notice_message::notice;
 use crate::ui::markdown_theme::palette;
 
+/// Renders a queued user message as a lightweight status notice.
 pub struct PendingMessage<'a> {
     text: &'a str,
 }
@@ -30,50 +28,13 @@ impl<'a> PendingMessage<'a> {
         Self { text }
     }
 
-    pub fn into_paragraph(self) -> Paragraph<'a> {
-        let header = Line::from(vec![
-            Span::styled(
-                "  QUEUED",
-                Style::default()
-                    .fg(palette::YELLOW)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("  ·  ", Style::default().fg(palette::FAINT)),
-            Span::styled(
-                " Esc ",
-                Style::default()
-                    .fg(palette::CODE_BG)
-                    .bg(palette::YELLOW)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" interrupt  ·  ", Style::default().fg(palette::MUTED)),
-            Span::styled(
-                " ↑ ",
-                Style::default()
-                    .fg(palette::TEXT)
-                    .bg(palette::SURFACE)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" edit", Style::default().fg(palette::MUTED)),
-        ]);
-        let mut lines = vec![header];
-        for (index, line) in self.text.lines().enumerate() {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    if index == 0 { "  ↳  " } else { "     " },
-                    Style::default().fg(palette::YELLOW),
-                ),
-                Span::styled(line, Style::default().fg(palette::TEXT)),
-            ]));
-        }
-        let block = Block::default()
-            .borders(Borders::TOP | Borders::BOTTOM)
-            .border_style(Style::default().fg(palette::BORDER))
-            .style(Style::default().bg(palette::CODE_BG));
-
-        Paragraph::new(Text::from(lines))
-            .block(block)
-            .wrap(Wrap { trim: false })
+    pub fn into_paragraph(self) -> Paragraph<'static> {
+        notice(
+            "↳",
+            palette::YELLOW,
+            palette::MUTED,
+            format!("Queued  {}  ·  ↑ edit", self.text),
+        )
     }
 }
 
@@ -85,26 +46,22 @@ mod tests {
     use ratatui::widgets::Widget;
 
     #[test]
-    fn queued_strip_shows_interrupt_hint_and_message() {
-        let area = Rect::new(0, 0, 60, 4);
+    fn queued_notice_shows_status_and_message() {
+        let area = Rect::new(0, 0, 60, 1);
         let mut buffer = Buffer::empty(area);
-        let paragraph = PendingMessage::new("continue with the tests").into_paragraph();
+        PendingMessage::new("continue with the tests")
+            .into_paragraph()
+            .render(area, &mut buffer);
 
-        assert_eq!(paragraph.line_count(area.width), area.height as usize);
-        paragraph.render(area, &mut buffer);
-
-        let rendered = (0..area.height)
-            .map(|y| {
-                (0..area.width)
-                    .map(|x| buffer[(x, y)].symbol())
-                    .collect::<String>()
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(rendered.contains("QUEUED"), "{rendered}");
-        assert!(rendered.contains("Esc"), "{rendered}");
-        assert!(rendered.contains("interrupt"), "{rendered}");
-        assert!(rendered.contains("↑  edit"), "{rendered}");
+        let rendered = (0..area.width)
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect::<String>();
+        assert!(rendered.contains("Queued"), "{rendered}");
         assert!(rendered.contains("continue with the tests"), "{rendered}");
+        assert!(!rendered.contains("Esc"), "{rendered}");
+        assert!(
+            rendered.contains("↑") && rendered.contains("edit"),
+            "{rendered}"
+        );
     }
 }

--- a/src/ui/event.rs
+++ b/src/ui/event.rs
@@ -21,7 +21,6 @@ use crossterm::event::Event as CrosstermEvent;
 use futures::{FutureExt, StreamExt};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 use tokio::sync::mpsc;
 
 /// Representation of all possible events.
@@ -353,23 +352,16 @@ pub struct EventHandler {
 impl EventHandler {
     /// Constructs a new instance of [`EventHandler`].
     pub fn new() -> Self {
-        let tick_rate = tick_interval();
         let (sender, receiver) = mpsc::unbounded_channel();
         let _sender = sender.clone();
         let tick_queued = Arc::new(AtomicBool::new(false));
-        let producer_tick_queued = tick_queued.clone();
         let _task = tokio::spawn(async move {
             let mut reader = crossterm::event::EventStream::new();
-            let mut tick = tokio::time::interval(tick_rate);
             loop {
-                let tick_delay = tick.tick();
                 let crossterm_event = reader.next().fuse();
                 tokio::select! {
                   _ = _sender.closed() => {
                     break;
-                  }
-                  _ = tick_delay => {
-                    queue_tick(&_sender, &producer_tick_queued);
                   }
                   Some(Ok(evt)) = crossterm_event => {
                     let _ = _sender.send(Event::Crossterm(evt));
@@ -414,61 +406,32 @@ impl EventHandler {
     /// This is useful for sending events to the event handler which will be processed by the next
     /// iteration of the application's event loop.
     pub fn send(&mut self, app_event: AppEvent) {
-        // Ignore the result as the reciever cannot be dropped while this struct still has a
-        // reference to it
         let _ = self.sender.send(Event::App(app_event));
+    }
+
+    /// Schedule one coalesced redraw at the maximum refresh rate. Unlike a
+    /// periodic ticker this creates no events while the UI is idle.
+    pub fn schedule_redraw(&self) {
+        if self
+            .tick_queued
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        let sender = self.sender.clone();
+        let queued = self.tick_queued.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(16)).await;
+            if sender.send(Event::Tick).is_err() {
+                queued.store(false, Ordering::Release);
+            }
+        });
     }
 
     fn mark_received(&self, event: &Event) {
         if matches!(event, Event::Tick) {
             self.tick_queued.store(false, Ordering::Release);
         }
-    }
-}
-
-fn queue_tick(sender: &mpsc::UnboundedSender<Event>, queued: &AtomicBool) {
-    if queued
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_ok()
-        && sender.send(Event::Tick).is_err()
-    {
-        queued.store(false, Ordering::Release);
-    }
-}
-
-fn tick_interval() -> Duration {
-    Duration::from_secs_f64(1.0 / crate::consts::TICK_FPS)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Event, queue_tick, tick_interval};
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use tokio::sync::mpsc;
-
-    #[test]
-    fn tick_interval_is_one_over_tick_fps() {
-        // EventHandler::new() uses this exact helper, so the production call
-        // site cannot accidentally pass FPS as a duration again.
-        let ms = tick_interval().as_millis();
-        assert!(
-            (30..=35).contains(&ms),
-            "expected ~33ms per tick, got {ms}ms — is the formula 1.0 / TICK_FPS?"
-        );
-    }
-
-    #[test]
-    fn queued_ticks_are_coalesced_until_consumed() {
-        let (sender, mut receiver) = mpsc::unbounded_channel();
-        let queued = AtomicBool::new(false);
-
-        queue_tick(&sender, &queued);
-        queue_tick(&sender, &queued);
-        assert!(matches!(receiver.try_recv(), Ok(Event::Tick)));
-        assert!(receiver.try_recv().is_err());
-
-        queued.store(false, Ordering::Release);
-        queue_tick(&sender, &queued);
-        assert!(matches!(receiver.try_recv(), Ok(Event::Tick)));
     }
 }


### PR DESCRIPTION
### programmer v0.2.10

- Make TUI redraws event-driven with a 60 FPS burst cap and no idle ticks.
- Coalesce same-direction mouse wheel events so scrolling does not block keyboard input.
- Keep busy-state elapsed timers updating while idle sessions remain at 0 FPS.
- Persist file-protection read snapshots across session resume.
- Simplify queued-message UI while retaining the `↑ edit` hint.
- Add streaming redraw, scrolling, cache, and persistence regression coverage.