### PR TITLE
v0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "programmer"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "arboard",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "programmer"
-version = "0.2.10"
+version = "0.2.11"
 description = "A coding agent written in rust"
 authors = ["huangdihd <hd20100104@163.com>"]
 license = "GPL-3.0-or-later"

--- a/src/app/events/keys.rs
+++ b/src/app/events/keys.rs
@@ -716,6 +716,14 @@ fn handle_terminal_key(app: &mut App<'_>, key_event: KeyEvent) {
         return;
     }
 
+    // Esc always closes the panel, even while input is grabbed. Previously it
+    // was forwarded to the PTY, making short-lived commands such as `!pwd`
+    // appear impossible to exit from.
+    if key_event.code == KeyCode::Esc {
+        app.terminal_pane = None;
+        return;
+    }
+
     // Ctrl+O is the escape hatch — never forwarded.
     if key_event.code == KeyCode::Char('o') && key_event.modifiers.contains(KeyModifiers::CONTROL) {
         pane.grabbed = !pane.grabbed;

--- a/src/ui/components/conversation_panel/conversation_panel.rs
+++ b/src/ui/components/conversation_panel/conversation_panel.rs
@@ -1388,10 +1388,15 @@ impl ConversationPanel {
         // Keep the single worker focused on the response currently arriving.
         // Historical reflows can wait until the turn boundary; otherwise a
         // large resize backlog could delay the live reasoning snapshot.
-        if width == 0
-            || self.live_markdown_history_keys.is_empty()
-            || self.receiving_response.is_some()
-        {
+        // Historical reasoning still needs to reflow when a request is only
+        // connecting. In that state there are no live output items competing
+        // for the worker, and skipping these jobs makes an expand/collapse
+        // click leave the item stuck on the old front snapshot.
+        let live_output_started = self
+            .receiving_response
+            .as_ref()
+            .is_some_and(|response| !response.message_item_refs().is_empty());
+        if width == 0 || self.live_markdown_history_keys.is_empty() || live_output_started {
             return;
         }
         let generation = self.live_markdown_generation;
@@ -1763,7 +1768,9 @@ impl ConversationPanel {
 mod tests {
     use super::*;
     use crate::cancel::CancellationToken;
-    use async_openai::types::responses::{InputContent, InputMessage, InputRole, OutputStatus};
+    use async_openai::types::responses::{
+        InputContent, InputMessage, InputRole, OutputStatus, ReasoningItem,
+    };
     use ratatui::buffer::Buffer;
     use ratatui::widgets::Widget;
 
@@ -1897,6 +1904,29 @@ mod tests {
         let second = cache.scrolled(&source, 9_900);
 
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn connecting_does_not_block_committed_reasoning_reflow() {
+        let mut panel = ConversationPanel::new();
+        panel
+            .live_markdown_history_keys
+            .insert(0, "generation:1:reasoning:done".into());
+        panel.receiving_response = Some(PartialResponse::new(CancellationToken::new()));
+        let items = vec![MessageItem::Output(OutputItem::Reasoning(ReasoningItem {
+            id: Some("done".into()),
+            summary: Vec::new(),
+            content: None,
+            encrypted_content: None,
+            status: None,
+        }))];
+
+        panel.queue_committed_markdown_jobs(&items, 80);
+
+        assert_eq!(
+            panel.live_markdown_history_last_job.get(&0),
+            Some(&(80, false))
+        );
     }
 
     #[test]

--- a/src/ui/components/conversation_panel/tool_group.rs
+++ b/src/ui/components/conversation_panel/tool_group.rs
@@ -36,7 +36,6 @@ use async_openai::types::responses::{
 };
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::Wrap;
 use ratatui_widgets::block::{Block, Padding};
 use ratatui_widgets::paragraph::Paragraph;
 use std::collections::{HashMap, HashSet};
@@ -586,10 +585,8 @@ pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
         )));
     }
     let mut headers = Vec::new();
-    let wrap = members.iter().any(|member| member.expanded)
-        || absorbed.iter().any(|(_, _, expanded)| *expanded);
     let inner_width = width.saturating_sub(2).max(1);
-    let mut rendered_rows = text_height(&Text::from(lines.clone()), inner_width, wrap);
+    let mut rendered_rows = lines.len() as u16;
 
     if expanded {
         // Calls and reasoning interleave in the transcript; render them in
@@ -613,7 +610,12 @@ pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
                     .live_output(member.live_output)
                     .expanded(member.expanded)
                     .into_text();
-                let height = text_height(&text, inner_width, wrap);
+                let text = if member.expanded {
+                    wrap_text(text, inner_width)
+                } else {
+                    text
+                };
+                let height = text.lines.len() as u16;
                 headers.push(MemberHeader {
                     index: member.index,
                     top: rendered_rows,
@@ -639,7 +641,12 @@ pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
                         .into_parts()
                         .0
                 };
-                let height = text_height(&text, inner_width, wrap);
+                let text = if thought_expanded {
+                    wrap_text(text, inner_width)
+                } else {
+                    text
+                };
+                let height = text.lines.len() as u16;
                 headers.push(MemberHeader {
                     index,
                     top: rendered_rows,
@@ -658,21 +665,45 @@ pub(crate) fn build_tool_group_paragraph_with_reasoning_cache<'a>(
         } else {
             Style::new()
         });
-    let mut paragraph = Paragraph::new(Text::from(lines)).block(block);
-    if wrap {
-        paragraph = paragraph.wrap(Wrap { trim: false });
-    }
+    let paragraph = Paragraph::new(Text::from(lines)).block(block);
     (paragraph, headers)
 }
 
-fn text_height(text: &Text<'static>, width: u16, wrap: bool) -> u16 {
-    let paragraph = Paragraph::new(text.clone());
-    let paragraph = if wrap {
-        paragraph.wrap(Wrap { trim: false })
-    } else {
-        paragraph
-    };
-    paragraph.line_count(width) as u16
+/// Wrap only expanded member bodies. Applying a Paragraph-wide wrap would also
+/// wrap every collapsed sibling in the group, making their one-line summaries
+/// look expanded and leaving them in the muted summary style.
+fn wrap_text(text: Text<'static>, width: u16) -> Text<'static> {
+    let width = width.max(1) as usize;
+    let mut wrapped = Vec::new();
+
+    for line in text.lines {
+        let mut current = Vec::new();
+        let mut current_width = 0usize;
+        for span in &line.spans {
+            let mut chunk = String::new();
+            for character in span.content.chars() {
+                let character_width =
+                    unicode_width::UnicodeWidthChar::width(character).unwrap_or(0);
+                if current_width > 0 && current_width + character_width > width {
+                    current.push(Span::styled(std::mem::take(&mut chunk), span.style));
+                    wrapped.push(Line::from(std::mem::take(&mut current)));
+                    current_width = 0;
+                }
+                chunk.push(character);
+                current_width = current_width.saturating_add(character_width);
+            }
+            if !chunk.is_empty() {
+                current.push(Span::styled(chunk, span.style));
+            }
+        }
+        if current.is_empty() {
+            wrapped.push(Line::default());
+        } else {
+            wrapped.push(Line::from(current));
+        }
+    }
+
+    Text::from(wrapped)
 }
 
 /// The muted detail line under a collapsed group header: the tool names, the
@@ -743,6 +774,71 @@ mod tests {
             id: None,
             status: None,
         }))
+    }
+
+    #[test]
+    fn expanding_one_member_does_not_wrap_collapsed_siblings() {
+        let first = FunctionToolCall {
+            arguments: r#"{"path":"src/main.rs","old_string":"old","new_string":"new"}"#.into(),
+            call_id: "call-0".into(),
+            namespace: None,
+            name: "edit_file".into(),
+            id: None,
+            status: None,
+        };
+        let second = FunctionToolCall {
+            arguments: r#"{"command":"this is a deliberately long collapsed summary"}"#.into(),
+            call_id: "call-1".into(),
+            namespace: None,
+            name: "command".into(),
+            id: None,
+            status: None,
+        };
+        let third = FunctionToolCall {
+            arguments: r#"{"command":"another deliberately long collapsed summary"}"#.into(),
+            call_id: "call-2".into(),
+            namespace: None,
+            name: "command".into(),
+            id: None,
+            status: None,
+        };
+        let items = vec![
+            MessageItem::Output(OutputItem::FunctionCall(first.clone())),
+            MessageItem::Output(OutputItem::FunctionCall(second.clone())),
+            MessageItem::Output(OutputItem::FunctionCall(third.clone())),
+        ];
+        let group = discover_tool_groups(&items).pop().unwrap();
+        let members = vec![
+            ToolGroupMember {
+                index: 0,
+                call: &first,
+                output: None,
+                live_output: None,
+                expanded: true,
+            },
+            ToolGroupMember {
+                index: 1,
+                call: &second,
+                output: None,
+                live_output: None,
+                expanded: false,
+            },
+            ToolGroupMember {
+                index: 2,
+                call: &third,
+                output: None,
+                live_output: None,
+                expanded: false,
+            },
+        ];
+
+        let (_, headers) = build_tool_group_paragraph(&group, &members, &[], 24, true, false);
+
+        assert_eq!(headers.len(), 3);
+        // A collapsed command has its summary, waiting line, and hint. Its
+        // long summary must remain one physical row; only the expanded first
+        // member is wrapped.
+        assert_eq!(headers[2].top - headers[1].top, 3);
     }
 
     #[test]

--- a/src/ui/components/status_bar/status_bar.rs
+++ b/src/ui/components/status_bar/status_bar.rs
@@ -44,6 +44,8 @@ pub enum StatusState {
     WaitingAnswer,
     /// Tool calls are queued for approval in Manual mode.
     WaitingApproval,
+    /// The parent agent is waiting for one or more sub-agents to finish.
+    WaitingSubagents,
 }
 
 impl StatusState {
@@ -60,6 +62,7 @@ impl StatusState {
                 | StatusState::Classifying
                 | StatusState::Compacting
                 | StatusState::Cancelling
+                | StatusState::WaitingSubagents
         )
     }
 
@@ -79,6 +82,7 @@ impl StatusState {
             StatusState::Cancelling => "\u{2716} Cancelling",
             StatusState::WaitingAnswer => "? Waiting for answer",
             StatusState::WaitingApproval => "\u{1f6e1} Waiting for approval",
+            StatusState::WaitingSubagents => "⏳ Waiting subagents",
         }
     }
 }
@@ -137,6 +141,7 @@ mod tests {
             StatusState::Compacting,
             StatusState::WaitingAnswer,
             StatusState::WaitingApproval,
+            StatusState::WaitingSubagents,
         ];
         for v in variants {
             let label = v.emoji_label();
@@ -162,6 +167,7 @@ mod tests {
             StatusState::Compacting,
             StatusState::WaitingAnswer,
             StatusState::WaitingApproval,
+            StatusState::WaitingSubagents,
         ];
         let labels: HashSet<&str> = variants.iter().map(|v| v.emoji_label()).collect();
         assert_eq!(labels.len(), variants.len(), "duplicate labels detected");

--- a/src/ui/components/status_bar/ui.rs
+++ b/src/ui/components/status_bar/ui.rs
@@ -41,6 +41,7 @@ impl Widget for &StatusBar {
             StatusState::Cancelling => ("✖", "Cancelling", WARN),
             StatusState::WaitingAnswer => ("?", "Waiting for answer", ACCENT),
             StatusState::WaitingApproval => ("🛡", "Waiting for approval", WARN),
+            StatusState::WaitingSubagents => ("⏳", "waiting subagents", ACCENT),
         };
 
         let busy = self.status.is_busy();

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -34,6 +34,16 @@ fn terminal_title_subject<'a>(session_title: &'a str, project_name: &'a str) -> 
     }
 }
 
+fn status_for_pending_turn(active_turn: bool, retrying: bool) -> StatusState {
+    if retrying {
+        StatusState::Retrying
+    } else if active_turn {
+        StatusState::Connecting
+    } else {
+        StatusState::Idle
+    }
+}
+
 impl App<'_> {
     /// The single status the footer shows, by precedence: user-input waits
     /// first, then the current busy phase, then idle.
@@ -43,6 +53,14 @@ impl App<'_> {
         }
         if self.pending_review.is_some() {
             return StatusState::WaitingApproval;
+        }
+        if self
+            .agents
+            .snapshot_all()
+            .iter()
+            .any(|agent| agent.status == crate::agents::AgentStatus::Running)
+        {
+            return StatusState::WaitingSubagents;
         }
         let cp = &self.conversation_panel;
         match cp.phase {
@@ -56,17 +74,12 @@ impl App<'_> {
             ActivePhase::None => match &cp.receiving_response {
                 // Request in flight but nothing has streamed back yet: either
                 // still connecting, or backing off between retries.
-                Some(partial) if !partial.started() => {
-                    if self
-                        .cancel
+                Some(partial) if !partial.started() => status_for_pending_turn(
+                    true,
+                    self.cancel
                         .stream_retrying
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                    {
-                        StatusState::Retrying
-                    } else {
-                        StatusState::Connecting
-                    }
-                }
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                ),
                 // Streaming: derive the state from what the model is emitting
                 // right now — reasoning, visible text, or a tool call.
                 Some(partial) => match partial.streaming_kind() {
@@ -78,7 +91,12 @@ impl App<'_> {
                     }
                     _ => StatusState::Thinking,
                 },
-                None => StatusState::Idle,
+                None => status_for_pending_turn(
+                    self.cancel.active_id.is_some(),
+                    self.cancel
+                        .stream_retrying
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                ),
             },
         }
     }
@@ -478,7 +496,18 @@ impl Widget for &mut App<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::terminal_title_subject;
+    use super::{status_for_pending_turn, terminal_title_subject};
+    use crate::ui::components::status_bar::status_bar::StatusState;
+
+    #[test]
+    fn active_turn_is_connecting_before_streaming_phase_arrives() {
+        assert_eq!(
+            status_for_pending_turn(true, false),
+            StatusState::Connecting
+        );
+        assert_eq!(status_for_pending_turn(true, true), StatusState::Retrying);
+        assert_eq!(status_for_pending_turn(false, false), StatusState::Idle);
+    }
 
     #[test]
     fn session_title_replaces_project_name_in_terminal_title() {


### PR DESCRIPTION
### Programmer v0.2.11

- Keep collapsed tool calls on one line when another absorbed-group member is expanded.
- Add a waiting subagents status while child agents are running.
- Let Esc close a grabbed terminal pane after bang commands such as `!pwd`.
- Allow committed thought blocks to expand and collapse while the next response is connecting.
- Keep the footer in Connecting during the short active-turn window before the streaming phase event arrives.

Verification: `cargo test -q` (549 passed, 1 ignored; integration test passed).